### PR TITLE
ci: add fmt + clippy + test workflow on push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+# Mango CI
+#
+# Three parallel jobs (fmt, clippy, test) run on every push to `main` and
+# every pull request. A red CI run blocks merge.
+#
+# Action refs are SHA-pinned per GitHub's third-party-action hardening
+# guidance; the human-readable tag is in the trailing comment. The Rust
+# toolchain itself floats on `stable` (no MSRV enforcement yet — that's
+# a tracked roadmap follow-up).
+
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+# Cancel superseded PR runs but never cancel a `main` run mid-flight; if
+# two PRs merge back-to-back, both `main` runs must complete so required
+# status checks resolve correctly.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+jobs:
+  fmt:
+    name: fmt
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          # Clippy and test do NOT share a cache scope — clippy doesn't
+          # fully codegen, test does, and sharing one `target/` cache
+          # silently invalidates work on every alternation.
+          prefix-key: v0-clippy
+          shared-key: ""
+      - name: cargo fetch
+        run: cargo fetch --locked
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          prefix-key: v0-test
+          shared-key: ""
+      - name: cargo fetch
+        run: cargo fetch --locked
+      - name: cargo test
+        # `--no-fail-fast` here means "report all failing test binaries
+        # in one CI run" — it is unrelated to the matrix-strategy
+        # `fail-fast: false` knob, which doesn't apply (no matrix yet).
+        run: cargo test --workspace --all-targets --locked --no-fail-fast

--- a/.planning/0-1-ci-bootstrap.plan.md
+++ b/.planning/0-1-ci-bootstrap.plan.md
@@ -1,0 +1,204 @@
+# Plan: bootstrap GitHub Actions CI
+
+Roadmap item: Phase 0 — "Set up CI (GitHub Actions): `cargo fmt --check`,
+`cargo clippy -D warnings`, `cargo test --workspace`, on push and PR"
+
+Status: **revised after rust-expert review** (verdict: REVISE → all five
+revise-level items applied below; nits 6, 7, 9, 10 also folded in; nits
+1, 2, 3, 5, 8 deferred or accepted as documented).
+
+## Goal
+
+Every push to `main` and every PR runs format, lint, and test checks. A
+red CI run blocks merge. CI completes in under 5 minutes on a cold cache,
+under 90 seconds on a warm cache. CI builds are reproducible (`--locked`
+everywhere) and supply-chain-hardened (third-party actions SHA-pinned,
+minimal token permissions).
+
+## Approach
+
+### Preconditions
+
+- `Cargo.lock` **must** be committed (already is, from the bootstrap
+  commit). `.gitignore` does not list `Cargo.lock` (verified — it lists
+  `Cargo.lock.bak` only). `--locked` in CI is now meaningful.
+
+### Workflow shape
+
+Single workflow `.github/workflows/ci.yml` with three parallel jobs:
+`fmt`, `clippy`, `test`.
+
+Workflow-level config:
+
+```yaml
+name: ci
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+```
+
+Notes:
+- **No `RUSTFLAGS: -D warnings`** — that nukes warnings in dependency
+  builds too and bakes a chronic-pain footgun into the foundation.
+  Workspace-own warnings are denied via clippy's `-- -D warnings` only,
+  which respects `--cap-lints=warn` on deps.
+- `cancel-in-progress` is scoped off `main` so back-to-back merges don't
+  cancel each other's CI run (which would leave required-checks
+  unsatisfied).
+- `permissions: contents: read` is the minimum needed; widen per-job
+  later if/when a job needs to write.
+- `CARGO_NET_GIT_FETCH_WITH_CLI=true` is a cheap preventative for the
+  flaky libgit2 fetch path; matters once Phase 5 may pull a git dep.
+
+### Jobs
+
+All three jobs run on `ubuntu-24.04` and have `timeout-minutes: 15`.
+
+**Common steps** (every job):
+1. `actions/checkout@v4` (SHA-pinned).
+2. `dtolnay/rust-toolchain@stable` (SHA-pinned, action ref). The
+   *toolchain* still floats on `stable`; that is intentional. We pin
+   the *action* because GitHub recommends SHA-pinning third-party
+   actions for supply-chain hygiene, but do not freeze the toolchain
+   version (no MSRV enforcement until a dedicated MSRV job lands as a
+   roadmap follow-up — see "Out of scope").
+3. `Swatinem/rust-cache@v2` (SHA-pinned) with **distinct `prefix-key`
+   per job** so clippy and test don't fight over the same `target/`
+   cache (clippy doesn't fully codegen; test does).
+
+**Job 1: `fmt`**
+- Components: `rustfmt`.
+- No cache (formatter only; cache is wasted overhead here).
+- `cargo fmt --all -- --check`.
+
+**Job 2: `clippy`**
+- Components: `clippy`, `rustfmt` (rustfmt not strictly needed but the
+  toolchain action installs both for free).
+- `cache prefix-key: v0-clippy`.
+- `cargo fetch --locked` (fail-fast on registry / network errors;
+  separates them from compile errors in CI logs).
+- `cargo clippy --workspace --all-targets --locked -- -D warnings`.
+- **No `--all-features`** — defer until features actually exist (Phase 6+);
+  add a `cargo hack --feature-powerset` job at that point. Avoids
+  pre-baking a wrong default.
+
+**Job 3: `test`**
+- `cache prefix-key: v0-test`.
+- `cargo fetch --locked`.
+- `cargo test --workspace --all-targets --locked --no-fail-fast`.
+- `--no-fail-fast` here means "report all failing test binaries in one
+  CI run", **not** the matrix-strategy `fail-fast: false` (no matrix
+  exists). When a matrix lands in Phase 12, that knob will be set
+  separately at the `strategy:` level.
+- `--all-targets` so bench/example *compilation* breakage is caught.
+
+### Action SHA-pinning
+
+Pinned at write time using the highest available release on the action's
+`v*` ref. Renovate / Dependabot can bump these later; not in scope for
+this PR. Specific SHAs to be looked up at implementation time:
+- `actions/checkout@v4` → SHA of `v4` tip.
+- `dtolnay/rust-toolchain@stable` → SHA of `stable` branch tip.
+- `Swatinem/rust-cache@v2` → SHA of `v2` tip.
+
+If looking up SHAs at implementation time becomes a yak shave, fall back
+to tag refs (`@v4`, `@stable`, `@v2`) and file a follow-up roadmap item
+to SHA-pin them. Document whichever choice is made in the workflow
+itself with a comment.
+
+## Files to touch
+
+- `.github/workflows/ci.yml` — new file, the entire workflow.
+- `README.md` — add CI status badge near the top:
+
+  ```markdown
+  [![ci](https://github.com/humancto/mango/actions/workflows/ci.yml/badge.svg)](https://github.com/humancto/mango/actions/workflows/ci.yml)
+  ```
+
+That's it. No code changes, no new crates.
+
+## Edge cases
+
+- **Empty workspace later** — if a future commit drops the placeholder
+  crate before adding real ones, `cargo test --workspace` would fail
+  with "no members". Mitigated by always keeping at least one
+  buildable crate.
+- **Clippy pedantic friction** — `Cargo.toml` enables `clippy::pedantic`
+  at warn level. Predictable pain points (per rust-expert review):
+  `must_use_candidate`, `needless_pass_by_value`,
+  `cast_possible_truncation`, `cast_sign_loss`, `similar_names`. Policy
+  for handling: any pedantic allow added in a feature PR is a one-line
+  `[workspace.lints.clippy]` change with a `# justification: ...`
+  comment in the same PR — no separate PR required. This makes the
+  friction predictable instead of surprising. Documented here so future
+  PR authors know the policy.
+- **Cache poisoning** — `Swatinem/rust-cache@v2` keys on `Cargo.lock`
+  hash + rustc version, so a toolchain bump or a dep update naturally
+  invalidates the cache. No manual cache-bust strings needed.
+- **MSRV drift** — `rust-version = "1.80"` is set in
+  `[workspace.package]`. CI uses `stable`. MSRV is not actively
+  enforced in this PR; tracked as a roadmap follow-up.
+- **Path filters vs required checks** — *not* adding `paths-ignore` in
+  this PR. The robust pattern (skipped-then-required gate job) is more
+  config than a Phase-0 PR should carry; revisit when README-only
+  changes become frequent. Documented here so the next person who
+  reaches for `paths-ignore` knows the trap.
+
+## Test strategy
+
+- Open the PR; observe CI runs and all three jobs go green.
+- Locally, run the same commands the workflow runs and confirm parity:
+  ```
+  cargo fmt --all -- --check
+  cargo fetch --locked
+  cargo clippy --workspace --all-targets --locked -- -D warnings
+  cargo test  --workspace --all-targets --locked --no-fail-fast
+  ```
+- Push a deliberately broken commit to a throwaway branch (extra
+  whitespace) to confirm `fmt` fails red, then revert. (Optional
+  pre-merge sanity check; not part of the PR.)
+
+## Rollback
+
+The workflow is additive and pure-config. Roll back by reverting the
+single commit that introduced `.github/workflows/ci.yml` and the README
+badge.
+
+## Out of scope (explicit, do not do in this PR)
+
+- `cargo-deny` job — its own roadmap item later in Phase 0.
+- Multi-OS / multi-arch matrix — Phase 12.
+- Code coverage upload — not on the roadmap.
+- Caching `~/.rustup` — `dtolnay/rust-toolchain` re-uses the runner's
+  preinstalled toolchain when versions match; not worth optimizing.
+- Required-status-checks branch protection — repo admin setting, not a
+  code change. Note for the user separately.
+- Adding a dedicated MSRV job — file as a roadmap follow-up.
+- `cargo doc --no-deps -D warnings` job — cheap and useful but adding a
+  fourth job in this PR is scope creep. File as a roadmap follow-up.
+- Path filters (`paths-ignore`) — see Edge Cases above; defer.
+
+## Disagreements with reviewer (and why)
+
+None substantive. All five REVISE-level items adopted verbatim. Of the
+nits:
+- Pre-emptively allowing the predictable pedantic lints (Risk #1 in the
+  review) — **not doing in this PR**. Reason: don't pollute lint config
+  with allows for lints that haven't fired yet; do it in the PR that
+  causes them to fire. The policy is documented above so the friction
+  is predictable.
+- `cargo doc` job (Missing #8) — **deferred** as a roadmap follow-up,
+  see Out of Scope. Reason: scope, one PR one item.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mango
 
+[![ci](https://github.com/humancto/mango/actions/workflows/ci.yml/badge.svg)](https://github.com/humancto/mango/actions/workflows/ci.yml)
+
 A distributed, reliable key-value store written in Rust. Mango is a ground-up
 port of [etcd](https://github.com/etcd-io/etcd) — same problem space, same
 guarantees (linearizable KV over Raft, watch streams, leases, MVCC), but a

--- a/crates/mango/src/lib.rs
+++ b/crates/mango/src/lib.rs
@@ -10,7 +10,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_is_set() {
-        assert!(!VERSION.is_empty());
+    fn version_matches_cargo_manifest() {
+        assert_eq!(VERSION, "0.1.0");
     }
 }


### PR DESCRIPTION
## Roadmap item

Phase 0 — "Set up CI (GitHub Actions): `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test --workspace`, on push and PR."

## Summary

Adds the first-and-only CI workflow for the project: three parallel jobs (`fmt`, `clippy`, `test`) on `ubuntu-24.04`, gated on every push to `main` and every pull request. Every cargo invocation is `--locked` and every third-party action is SHA-pinned. Verified locally to match the exact commands CI runs.

This PR is intentionally narrow: it sets up the gate that all subsequent ROADMAP PRs will pass through. `cargo-deny`, multi-OS matrix, MSRV enforcement, and `cargo doc` jobs are out of scope here and tracked as follow-ups.

## What's in here

- `.github/workflows/ci.yml` — the workflow.
- `README.md` — CI status badge near the top.
- `crates/mango/src/lib.rs` — fixes a `clippy::const-is-empty` lint that the new pipeline surfaced in the placeholder smoke test.
- `.planning/0-1-ci-bootstrap.plan.md` — the plan (committed in a separate commit so the planning artifact is easy to find).

## Hardening / correctness choices

(All driven by the rust-expert review of the plan; details in the plan doc.)

- Action SHAs pinned: `actions/checkout@34e114876b...` (v4), `dtolnay/rust-toolchain@29eef336d9...` (stable), `Swatinem/rust-cache@e18b497796...` (v2). Toolchain itself floats on `stable`.
- `--locked` everywhere so `Cargo.lock` drift fails CI instead of silently regenerating.
- Distinct `prefix-key` per cache scope (clippy vs test) — they compile `target/` differently and sharing one scope silently invalidates work.
- No global `RUSTFLAGS=-D warnings` — that would deny dependency warnings too. The only `-D warnings` is on clippy's trailing args, which respects `--cap-lints=warn` on deps.
- `cancel-in-progress` scoped off `main` so back-to-back merges don't cancel each other's required-status-check runs.
- `permissions: contents: read` workflow-level minimum.
- `timeout-minutes` on every job.
- Separate `cargo fetch --locked` step so registry/network failures show up distinct from compile failures.

## Test plan

- [x] `cargo fmt --all -- --check` passes locally.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes locally.
- [x] `cargo test --workspace --all-targets --locked --no-fail-fast` passes locally (1 test, 0 failures).
- [x] Workflow YAML parses cleanly.
- [ ] All three CI jobs go green on this PR.

## Out of scope (filed as follow-ups)

- `cargo-deny` job (separate ROADMAP item later in Phase 0).
- Multi-OS / multi-arch matrix (Phase 12).
- MSRV-enforcement job.
- `cargo doc --no-deps -D warnings` job.
- Path-based filters (`paths-ignore`) — interacts badly with required-status-checks; revisit when README-only changes get frequent.
- Branch protection / required-status-checks settings — repo admin action, not a code change.

## Plan + review

- Plan: `.planning/0-1-ci-bootstrap.plan.md`
- Review: rust-expert verdict was REVISE; all five revise-level items adopted, plus four of the eight nits. Disagreements (with reasons) documented at the bottom of the plan.
