### PR TITLE
chore(ci): add cargo-deny supply-chain gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,22 @@ jobs:
         # in one CI run" — it is unrelated to the matrix-strategy
         # `fail-fast: false` knob, which doesn't apply (no matrix yet).
         run: cargo test --workspace --all-targets --locked --no-fail-fast
+
+  deny:
+    # Supply-chain policy gate: licenses, RustSec advisories, banned
+    # crates (openssl-*, native-tls), duplicate versions, git-deps.
+    # Policy lives in `deny.toml` at the repo root.
+    #
+    # The action downloads a pinned `cargo-deny` binary — no Rust
+    # toolchain needed. SHA-pinned per the same convention as the
+    # other jobs; Embark Studios owns both the action and the tool,
+    # so the pin tracks v2.0.17 (April 2026).
+    name: deny
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb  # v2.0.17
+        with:
+          command: check
+          arguments: --all-features

--- a/.planning/0-7-cargo-deny.plan.md
+++ b/.planning/0-7-cargo-deny.plan.md
@@ -1,0 +1,255 @@
+# Plan: `cargo-deny` config + CI job
+
+Roadmap item: Phase 0 — "Add `deny.toml` and a `cargo-deny` CI job
+(license + advisory + duplicate-version checks; ban `git`-deps without
+explicit allowlist; ban `openssl-sys` per the Security axis — use
+`rustls`)." (`ROADMAP.md:754`)
+
+## Goal
+
+Four overlapping guarantees enforced at PR time:
+
+1. **Licenses**: only an allowlisted set of SPDX identifiers may
+   appear in the transitive dep tree. Catches the "quietly pulled in
+   GPL" failure mode.
+2. **Advisories**: block any dep with a RustSec advisory. Paired with
+   the future `cargo-audit` nightly job (`ROADMAP.md:755`) that
+   **auto-files an issue** — this PR-time gate stops new advisories
+   from landing; the nightly catches advisories published against
+   already-merged code.
+3. **`git`-deps ban**: prod dep tree must come from crates.io, unless
+   an explicit allowlist entry says otherwise. `git`-deps are mutable
+   refs that don't version-lock reliably and skip supply-chain vetting.
+4. **Specific crate bans**: `openssl-sys` is banned — the Security
+   axis commits us to `rustls` for TLS. Also ban duplicate-version
+   pile-ups (two incompatible versions of the same crate in the
+   graph) because they double attack surface and blow up binary size.
+
+## North-star axis
+
+**Security + Supply-chain.** Go etcd pulls in openssl transitively;
+mango doesn't. The ban is the enforcement, not a preference. A
+RustSec advisory or a GPL transitive dep MUST fail the PR, not
+"someone will notice during release."
+
+## Approach
+
+Two file touches. One new config. One CI workflow addition.
+
+### D1. `deny.toml` (NEW at workspace root)
+
+Four sections mapping to the four guarantees. Based on the
+`cargo-deny` 0.16 schema (the current stable major as of 2026-04).
+
+```toml
+# Mango supply-chain policy enforced by `cargo-deny`. Runs in CI on
+# every push and PR. Changes here need reviewer sign-off.
+#
+# Docs: https://embarkstudios.github.io/cargo-deny/
+# Version pin: cargo-deny 0.16+ schema.
+
+[graph]
+# Single-target today; expand when cross-compilation lands.
+targets = [{ triple = "x86_64-unknown-linux-gnu" }]
+all-features = false
+
+[output]
+feature-depth = 1
+
+[licenses]
+# SPDX identifiers we accept. Anything outside this set fails the PR.
+# Rationale per entry:
+#   Apache-2.0, MIT, BSD-3-Clause, BSD-2-Clause, ISC — standard
+#     permissive licenses, compatible with our Apache-2.0 release.
+#   Unicode-3.0, Unicode-DFS-2016 — `unicode-ident` and friends.
+#   Zlib — `adler`, `miniz_oxide`.
+#   CC0-1.0 — public-domain-equivalent.
+#   OpenSSL — explicitly permitted only for a future mandated dep.
+#     Today, none. Re-audit if any dep requires this.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "CC0-1.0",
+]
+confidence-threshold = 0.93
+# No `exceptions` today — any license not in `allow` fails the PR.
+
+[advisories]
+version = 2
+# `deny` fails on any advisory. `unmaintained = "all"` also fails on
+# unmaintained crates, which is the right posture — a maintainer
+# going dark is a supply-chain risk even without a filed CVE.
+yanked = "deny"
+unmaintained = "all"
+ignore = []
+
+[bans]
+multiple-versions = "deny"
+# When a dupe is unavoidable (during a major-version migration),
+# allowlist it here with an issue link and a removal target. Empty
+# today.
+skip = []
+skip-tree = []
+wildcards = "deny"
+# Crate-level bans: openssl-sys is the Security-axis banned crate.
+# `rustls` + `rustls-pki-types` is the one true TLS path.
+deny = [
+    { name = "openssl-sys", reason = "Mango's Security axis mandates rustls; no OpenSSL in the tree." },
+    { name = "openssl", reason = "Same as openssl-sys — use rustls." },
+    { name = "native-tls", reason = "Pulls OpenSSL on Linux by default; use rustls." },
+]
+
+[sources]
+# Prod dep tree must come from crates.io. Explicit allowlists below
+# for any git-dep or alternate registry. Empty today.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+```
+
+### D2. `.github/workflows/ci.yml` — add `deny` job
+
+New job parallel to the existing `fmt` / `clippy` / `test`. Uses the
+`EmbarkStudios/cargo-deny-action` which is the maintained action that
+tracks the binary's release cadence. SHA-pinned per the existing
+convention in `ci.yml`.
+
+```yaml
+deny:
+  name: deny
+  runs-on: ubuntu-24.04
+  timeout-minutes: 10
+  steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: EmbarkStudios/cargo-deny-action@<SHA> # v2.x
+      with:
+        command: check all
+        arguments: --all-features
+```
+
+The action downloads a pinned `cargo-deny` binary, so we don't need a
+Rust toolchain for this job.
+
+**Which SHA**: look up the latest `v2` release SHA on
+`EmbarkStudios/cargo-deny-action` at implementation time. This is a
+non-trivial security decision — an unpinned third-party action is
+exactly the supply-chain hole `deny.toml` is supposed to close.
+
+## Files to touch
+
+- `deny.toml` — NEW at workspace root (~60 lines with comments).
+- `.github/workflows/ci.yml` — add `deny` job (~10 lines added).
+
+No code changes.
+
+## Edge cases
+
+- **`cargo-deny` finds a pre-existing violation on the very first
+  run** — unlikely today (the only workspace member is a placeholder
+  crate with one dep, `serde_json`... actually zero non-stdlib deps).
+  Verified by `cargo metadata --format-version 1` grep. If a future
+  dep trips the allowlist, the PR that adds it handles the fix in the
+  same commit (either widen the allowlist with justification, or
+  swap the dep).
+- **License-detection false positives** — `cargo-deny` uses SPDX
+  identifier matching against `Cargo.toml` `license` fields with
+  fallback to `LICENSE` file scanning. The `confidence-threshold =
+0.93` is the recommended default; lower = more matches (unsafe),
+  higher = more false-rejects. Per-crate `clarify` entries handle
+  known edge cases; none needed today.
+- **Target scope** — `[graph] targets` gates which platforms' dep
+  trees are checked. Single Linux target today; we'll add macOS and
+  Windows entries when those platforms are tier-2-supported (post
+  Phase 6 or so). `cargo-deny` only checks deps reachable from a
+  listed target, so missing a target means missing some deps.
+- **`unmaintained = "all"`** — the most aggressive setting. A crate
+  published once and never touched (common for tiny utilities) will
+  fail the check. Realistic failure: `atty`, `once_cell` (superseded
+  by stdlib). None in the tree today. When encountered, the PR fixes
+  by either swapping the dep or adding a justified `ignore = [...]`
+  entry with a dated removal target.
+- **`multiple-versions = "deny"`** — the strictest. A common dep
+  (serde, tokio, rand) pulls in two incompatible version spans
+  occasionally. Realistic: we'll eventually need a `skip = []`
+  allowlist. Today the graph is tiny, so start strict and relax on
+  first violation with justification.
+- **`wildcards = "deny"`** — bans `*`-version requirements in
+  workspace `Cargo.toml`. None today. Easy to keep.
+- **GitHub Action SHA pinning** — `cargo-deny-action` is owned by
+  Embark Studios who maintain `cargo-deny` itself. Pin to a specific
+  v2 release SHA; update deliberately via Dependabot when that lands
+  (future item).
+- **`native-tls` ban** — added proactively even though it's not
+  mentioned in the roadmap text. It's the same class — `native-tls`
+  on Linux pulls OpenSSL by default. If we ban `openssl-sys` without
+  also banning `native-tls`, a dep could pull `native-tls` which
+  pulls `openssl-sys` and the ban would fire with a confusing
+  transitive error instead of a direct one. Banning both at the
+  top surfaces the root cause.
+
+## Test strategy
+
+Same playbook as prior config PRs. CI gate IS the test.
+
+1. **Existing checks stay green** — `fmt` / `clippy` / `test` all
+   still pass.
+2. **`cargo deny check all` passes locally** — run before pushing.
+   `cargo install cargo-deny --locked` once, then `cargo deny check
+all --all-features` from workspace root must exit 0.
+3. **`deny` CI job succeeds on the PR** — this is the persistent
+   regression gate.
+4. **Violation-injection audit (one-off)** — same shape as prior PRs.
+   Two micro-audits bundled:
+   - Add `openssl-sys = "*"` as a scratch dep to `crates/mango/Cargo.toml`;
+     `cargo deny check bans` must fail with the `openssl-sys` reason
+     string surfaced in the error. Revert.
+   - Add a fake git-dep `foo = { git = "https://example.com/foo.git" }`;
+     `cargo deny check sources` must fail. Revert. (Omit if the fake
+     dep can't resolve — `cargo-deny` reads `Cargo.lock`, so the dep
+     must actually resolve to trigger. If it can't resolve, the
+     ban-only audit is sufficient.)
+
+The CI gate is the persistent mechanism. A richer integration test
+is filed as a future hardening item — out of scope tonight.
+
+## Rollback
+
+Single squash commit. Revert → `deny.toml` disappears, CI job is
+removed, no enforcement. Zero runtime impact.
+
+## Out of scope (explicit, do not do in this PR)
+
+- **`cargo-audit` nightly job** — separate roadmap item
+  (`ROADMAP.md:755`).
+- **`cargo-msrv`** — separate roadmap item (`ROADMAP.md:756`).
+- **Dependabot config** — adjacent but orthogonal; file as a future
+  item.
+- **Per-crate `clarify` entries** — none needed today; add surgically
+  when a false-positive fires.
+- **Tier-2 target platforms in `[graph] targets`** — add when those
+  platforms are formally supported.
+- **ROADMAP checkbox flip** — separate commit to main per workflow.
+
+## Risks
+
+- **Third-party action SHA drift** — pinned SHA must be kept current.
+  Dependabot is the future fix; until then, quarterly manual audit
+  is acceptable for a CI-only action.
+- **License allowlist too tight** — a future dep with an obscure but
+  acceptable license (e.g., `BSL-1.0`) will fail. Fix: widen the
+  allowlist in the PR that adds the dep, with justification.
+- **`unmaintained = "all"` is noisy** — likely. Relax to `"workspace"`
+  (only direct deps) if it proves too noisy in practice; filed as a
+  future tuning item. Start strict.
+- **Local dev UX** — contributors need `cargo install cargo-deny`
+  locally to reproduce CI failures before pushing. Documented in
+  `CONTRIBUTING.md` when that item lands (`ROADMAP.md:761`); until
+  then, the CI failure is the signal.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,82 @@
+# Mango supply-chain policy enforced by `cargo-deny`. Runs in CI on
+# every push and PR — a failure blocks merge. Changes here need
+# reviewer sign-off.
+#
+# Docs: https://embarkstudios.github.io/cargo-deny/
+# Schema: cargo-deny 0.19.x (v2 schema — there is no longer an opt-in
+# `version` key; the shape below is the only shape the tool accepts
+# in current releases).
+
+[graph]
+# Single-target today; expand when cross-compilation lands.
+targets = [{ triple = "x86_64-unknown-linux-gnu" }]
+all-features = false
+
+[output]
+feature-depth = 1
+
+[licenses]
+# SPDX identifiers we accept. Anything outside this set fails the PR.
+# Rationale:
+#   Apache-2.0 (+ LLVM exception), MIT, BSD-3-Clause, BSD-2-Clause,
+#     ISC — standard permissive licenses, compatible with mango's
+#     Apache-2.0 release.
+#   Unicode-3.0, Unicode-DFS-2016 — `unicode-ident` and friends.
+#   Zlib — `adler`, `miniz_oxide`.
+#   CC0-1.0 — public-domain-equivalent.
+# MPL-2.0 is deliberately NOT here (file-level copyleft). When a dep
+# that requires it comes up, widen the list in that PR with a
+# justification. Same treatment for any other license.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "CC0-1.0",
+]
+# Tighter than the 0.8 upstream default — we want high confidence in
+# license detection before accepting a crate. Tune down only if a
+# legitimate dep gets rejected on ambiguous text.
+confidence-threshold = 0.93
+
+[advisories]
+# `deny` on yanked crates and "all" scopes for unmaintained/unsound
+# (default is "workspace" which silently passes transitive cases —
+# wrong posture for a consensus-database project).
+yanked = "deny"
+unmaintained = "all"
+unsound = "all"
+ignore = []
+
+[bans]
+multiple-versions = "deny"
+# When a dupe is unavoidable during a major-version migration, add an
+# entry here with an issue link and a removal target. Empty today.
+skip = []
+skip-tree = []
+wildcards = "deny"
+# Crate-level bans. Security axis mandates rustls — no OpenSSL path.
+# Belt-and-suspenders: ban the direct (`openssl-sys`), high-level
+# (`openssl`), vendored-build (`openssl-src`), and cross-platform-TLS
+# (`native-tls`) entrypoints, because any of them can pull OpenSSL
+# into the graph and a transitive ban produces a confusing error.
+deny = [
+    { name = "openssl-sys", reason = "Security axis mandates rustls; no OpenSSL in the tree." },
+    { name = "openssl", reason = "Use rustls." },
+    { name = "openssl-src", reason = "Vendored OpenSSL build — same ban class." },
+    { name = "native-tls", reason = "Pulls OpenSSL on Linux by default; use rustls." },
+]
+
+[sources]
+# Prod dep tree comes from crates.io. Any git-dep or alternate
+# registry requires an explicit allowlist entry below with a
+# justification — empty today.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,10 @@
 [graph]
 # Single-target today; expand when cross-compilation lands.
 targets = [{ triple = "x86_64-unknown-linux-gnu" }]
+# CI overrides with `--all-features` (see `.github/workflows/ci.yml`)
+# so every feature any downstream can enable is checked. This default
+# applies to a local `cargo deny check` without flags — useful when
+# iterating on `deny.toml` without waiting on feature resolution.
 all-features = false
 
 [output]
@@ -61,15 +65,16 @@ skip = []
 skip-tree = []
 wildcards = "deny"
 # Crate-level bans. Security axis mandates rustls — no OpenSSL path.
-# Belt-and-suspenders: ban the direct (`openssl-sys`), high-level
-# (`openssl`), vendored-build (`openssl-src`), and cross-platform-TLS
-# (`native-tls`) entrypoints, because any of them can pull OpenSSL
-# into the graph and a transitive ban produces a confusing error.
+# Belt-and-suspenders: ban every common entrypoint that can pull
+# OpenSSL into the graph, because a transitive ban produces a
+# confusing error message. `crate = ...` is the modern canonical form
+# (older `name = ...` still accepted but deprecated in 0.19.x).
 deny = [
-    { name = "openssl-sys", reason = "Security axis mandates rustls; no OpenSSL in the tree." },
-    { name = "openssl", reason = "Use rustls." },
-    { name = "openssl-src", reason = "Vendored OpenSSL build — same ban class." },
-    { name = "native-tls", reason = "Pulls OpenSSL on Linux by default; use rustls." },
+    { crate = "openssl-sys", reason = "Security axis mandates rustls; no OpenSSL in the tree." },
+    { crate = "openssl", reason = "Use rustls." },
+    { crate = "openssl-src", reason = "Vendored OpenSSL build — same ban class." },
+    { crate = "native-tls", reason = "Pulls OpenSSL on Linux by default; use rustls." },
+    { crate = "libssh2-sys", reason = "Drags OpenSSL via libgit2's ssh path; use a pure-Rust SSH stack or avoid git-over-SSH in-process." },
 ]
 
 [sources]


### PR DESCRIPTION
## Summary

Adds a `cargo-deny` supply-chain gate to CI. Roadmap: `ROADMAP.md:754`.

Four overlapping guarantees enforced at PR time:

1. **Licenses** — permissive-only allowlist (Apache-2.0 (+ LLVM exception), MIT, BSD-2/3-Clause, ISC, Unicode-3.0 / DFS-2016, Zlib, CC0-1.0). `MPL-2.0` and anything else (GPL, LGPL, BSL, ...) fails the PR. Widen with justification on the PR that needs it.
2. **Advisories** — `yanked = "deny"`, `unmaintained = "all"`, `unsound = "all"`. Stops new RustSec entries from landing; paired with the future `cargo-audit` nightly (`ROADMAP.md:755`) that catches advisories published against already-merged code.
3. **git-deps / alternate-registry ban** — prod dep tree must come from crates.io unless an explicit allowlist entry in `deny.toml` says otherwise. Empty today.
4. **Crate bans** — Security axis mandates rustls; no OpenSSL in the tree. Ban is belt-and-suspenders at every entrypoint: `openssl-sys` (direct FFI), `openssl` (high-level), `openssl-src` (vendored build), `native-tls` (pulls OpenSSL on Linux). `multiple-versions = "deny"` and `wildcards = "deny"` round it out.

## North-star axis

**Security + Supply-chain.** Go etcd pulls OpenSSL transitively; mango doesn't — and this file is the enforcement, not a preference. A RustSec advisory or a GPL transitive dep MUST fail the PR, not "someone will notice during release."

## Files

- `deny.toml` — NEW at workspace root, ~80 lines with comments explaining every non-default knob.
- `.github/workflows/ci.yml` — new `deny` job parallel to `fmt` / `clippy` / `test`, SHA-pinned to `EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb` (v2.0.17, April 2026).

No code changes.

## Schema correctness (rust-expert REVISE folded in)

The plan originally cited the 0.16 schema with `[advisories] version = 2`. That field is **removed** in `cargo-deny` 0.19.x (current stable) — passing it errors, it no longer silently warns. Corrections applied to the final `deny.toml`:

- No `version = 2` on `[advisories]`. (Same for `[licenses]`.)
- Added `unsound = "all"` alongside `unmaintained = "all"`.
- Added `openssl-src` (vendored OpenSSL build) to the ban list — otherwise a dep pulling vendored OpenSSL bypasses the ban.
- `confidence-threshold = 0.93` documented as **tighter than the 0.8 upstream default** (was described as matching the default in the earlier draft — wrong).

## Test plan (CI gate IS the test)

- [x] `cargo deny --version` → `cargo-deny 0.19.4`
- [x] Clean baseline: `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok` (with expected "license not encountered" warnings for the zero-dep workspace; those are informational and not failures).
- [x] `cargo fmt --all -- --check` green
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` green
- [x] `cargo test --workspace --all-targets --locked` green (1 test, passes)
- [ ] `deny` CI job succeeds on this PR
- [ ] rust-expert APPROVE on final diff

### Violation-injection audits (evidence the gate actually bites)

Two one-off audits run locally; scratch deps reverted before commit.

**Audit 1 — `openssl-sys` must be banned**

`crates/mango/Cargo.toml` temporarily gained `openssl-sys = "0.9"`; `cargo deny check bans`:

```
error[banned]: crate 'openssl-sys = 0.9.114' is explicitly banned
   ┌─ /Users/archithrapaka/claude-projects/mango/deny.toml:69:15
   │
69 │     { name = "openssl-sys", reason = "Security axis mandates rustls; no OpenSSL in the tree." },
   │               ━━━━━━━━━━━             ────────────────────────────────────────────────────── reason
   │               │
   │               banned here
   │
   ├ openssl-sys v0.9.114
     └── mango v0.1.0

bans FAILED
```

Reverted. `cargo deny check` back to clean.

**Audit 2 — git-deps must be banned**

`crates/mango/Cargo.toml` temporarily gained `cfg-if = { git = "https://github.com/rust-lang/cfg-if.git", tag = "1.0.0" }`; `cargo deny check sources`:

```
error[source-not-allowed]: detected 'git' source not explicitly allowed
  ┌─ /Users/archithrapaka/claude-projects/mango/Cargo.lock:1:14
  │
1 │ cfg-if 1.0.0 git+https://github.com/rust-lang/cfg-if.git?tag=1.0.0
  │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ source
  │
  ├ cfg-if v1.0.0
    └── mango v0.1.0

sources FAILED
```

Reverted. `cargo deny check` back to clean.

## Action pinning

`EmbarkStudios/cargo-deny-action` is owned by the same team that maintains `cargo-deny` itself. Pinned to commit `91bf2b620e09e18d6eb78b92e7861937469acedb` (tag `v2.0.17`). Bumps via Dependabot once that lands (future roadmap item).

## Out of scope

- **`cargo-audit` nightly** — separate roadmap item (`ROADMAP.md:755`).
- **`cargo-msrv`** — separate roadmap item (`ROADMAP.md:756`).
- **Dependabot config** — adjacent but orthogonal; future item.
- **Cross-compile targets in `[graph] targets`** — single Linux target today; add macOS / Windows when tier-2 platform support lands.
- **ROADMAP checkbox flip** — separate commit to main per workflow.

## Plan

`.planning/0-7-cargo-deny.plan.md` — rust-expert REVISE verdict folded in (schema corrections above, plus `unsound = "all"` and `openssl-src` addition).

Generated with [Claude Code](https://claude.com/claude-code)
