### PR TITLE
chore(bench): add oracle + hardware-signature scaffold (no benches yet)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,27 @@ jobs:
         with:
           command: check
           arguments: --all-features
+
+  bench-harness:
+    # Bench-harness scaffold smoke tests. No Rust toolchain, no cache —
+    # the scaffold is pure shell (etcd oracle fetch-and-verify, hardware
+    # signature emission, runner wrapper). See benches/README.md and
+    # .planning/adr/0001-bench-oracle-harness.md for the rationale.
+    #
+    # Advisory until main branch protection is enabled with this job
+    # in the required-checks list (tracked as a follow-up).
+    name: bench-harness
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: oracle fetch tests (VERSIONS coverage, verify_sha)
+        run: bash scripts/test-bench-oracle-fetch.sh
+      - name: hardware-signature tests (format, determinism, tier, round-trip)
+        run: bash scripts/test-hardware-signature.sh
+      - name: run.sh wrapper tests (stdout clean, sidecar, tier enforcement)
+        run: bash scripts/test-bench-run-wrapper.sh
+      - name: VERSIONS immutability
+        # Belt-and-suspenders: no test above should mutate the committed
+        # pin file. If one does, this diff catches it before merge.
+        run: git diff --exit-code benches/oracles/etcd/VERSIONS

--- a/.planning/0-10-bench-oracle-harness.plan.md
+++ b/.planning/0-10-bench-oracle-harness.plan.md
@@ -24,7 +24,7 @@ This plan is the post-review revision. Showstoppers S1/S2/S3 and bugs B1–B4 ar
 - **R1**: drop `nvme` field (misleading — SATA SSDs also have `rotational=0`). Replace with `storage=<device-model>` from `lsblk -d -o MODEL` / `diskutil info`. Leave TODO for `fsync_us_p50` (Phase 2+).
 - **R2**: Tier 1 now requires documented turbo/frequency pinning, isolcpus, TSC invariance (`constant_tsc + nonstop_tsc`), queue scheduler, memory channel count. Tier 2 adds a clock-sync requirement (PTP preferred, chrony fallback). All captured in signature fields: `tsc=`, `turbo=`, `mem_channels=`, `scheduler=`, `cpu_mhz_max=`, `virt=`, `storage=`.
 - **R4**: `BENCH_TIER` unset is a hard error when argv contains the token `bench`, soft warning otherwise.
-- **R5**: concrete Rust-port trigger named: "when `hardware-signature.sh` exceeds 150 lines OR the first NUMA/hugepages field is requested."
+- **R5**: concrete Rust-port trigger named: any of (third target OS, first structured field like NUMA/hugepages/cgroup/PMU, `hardware-signature.sh` passing ~300 non-comment lines). Earlier "~150 lines" draft trigger was raised to 300 after the PR review flagged self-contradiction against the ADR's "~300 lines total" line count. See ADR decision 1.
 - **M2/M3**: new Tests 4 and 5 — VERSIONS ↔ HARDWARE.md platform coverage, and canonicalization round-trip.
 - **M5**: ADR committed at `.planning/adr/0001-bench-oracle-harness.md`.
 

--- a/.planning/0-10-bench-oracle-harness.plan.md
+++ b/.planning/0-10-bench-oracle-harness.plan.md
@@ -1,0 +1,296 @@
+# 0.10 — Bench oracle harness scaffold
+
+## Roadmap item
+
+> Bench oracle harness scaffold: `benches/oracles/etcd/` checks in a script that downloads etcd v3.5.x at a pinned version + sha256, plus `benches/runner/HARDWARE.md` documenting the canonical hardware spec we run comparisons on, plus `benches/runner/run.sh` that prints a hardware signature alongside every result. Without this, every later "beats etcd by Nx" claim has no oracle. `HARDWARE.md` MUST declare two hardware tiers: (a) Tier 1 / single-node bench rig — single host, NVMe SSD, ≥ 16 cores, ≥ 64 GB RAM, sufficient for Phases 2–13 single-node and 3-node benches; (b) Tier 2 / multi-node fleet — ≥ 10 hosts (5 voters + 5 learners), ≥ 25 GbE intra-cluster bandwidth, root access for `tc` / `iptables` (or a `toxiproxy` install) to drive the Phase 14.5 chaos tests.
+
+## Why
+
+This is **scaffold only**. No benchmarks run yet — Phase 2+ writes those. The point is to check in the oracle (etcd download + verify) and the provenance apparatus (HARDWARE.md tiers, hardware-signature printer) _before_ anyone publishes a single throughput number, so when comparisons start landing in Phases 2–14, every result has a verifiable oracle version and the tier/hardware is on the page.
+
+If we let this slip, the first "beats etcd by Nx" PR arrives and we improvise an oracle under deadline pressure. That's how you end up with numbers that don't reproduce.
+
+## Revisions from rust-expert review (REVISE → APPROVE gate)
+
+This plan is the post-review revision. Showstoppers S1/S2/S3 and bugs B1–B4 are folded in; risk-level tier additions (R2) and signature-field additions (R1) are also folded. Summary of what changed vs. the initial draft:
+
+- **S1**: cross-platform sha256 helper (`sha256_of()`) branching on `uname -s` — `sha256sum` on Linux, `shasum -a 256` on macOS. Never hardcode `sha256sum`.
+- **S2**: signature format is now versioned (`BENCH_HW v1:`), fields are **sorted lexically by key**, values are shell-escaped, joined by single spaces with no trailing newline. `sha` is computed over the canonical form _excluding_ the `sha=` field. Field values are trimmed of leading/trailing whitespace before hashing (defends against `/proc/cpuinfo` `model name` tab-padding).
+- **S3**: tests now exercise `VERSIONS` parsing and platform selection, including the `linux/aarch64` → `linux/arm64` normalization that `uname -m` produces.
+- **B1**: CI `bench-harness` job asserts `git diff --exit-code benches/oracles/etcd/VERSIONS` after sourcing it (script must not mutate VERSIONS).
+- **B2**: local-pin threat model documented as TOFU in `benches/oracles/etcd/README.md`. We also pin the `SHA256SUMS` file's own sha in `VERSIONS` (defense-in-depth, two independent hashes at pin time).
+- **B3**: Test 2 determinism claim weakened to "same shell, same boot, within 5 seconds."
+- **B4**: `run.sh` emits the signature to **stderr** (so stdout stays clean for JSON bench output) AND writes it to a sidecar file `$BENCH_OUT_DIR/signature.txt` when `BENCH_OUT_DIR` is set.
+- **R1**: drop `nvme` field (misleading — SATA SSDs also have `rotational=0`). Replace with `storage=<device-model>` from `lsblk -d -o MODEL` / `diskutil info`. Leave TODO for `fsync_us_p50` (Phase 2+).
+- **R2**: Tier 1 now requires documented turbo/frequency pinning, isolcpus, TSC invariance (`constant_tsc + nonstop_tsc`), queue scheduler, memory channel count. Tier 2 adds a clock-sync requirement (PTP preferred, chrony fallback). All captured in signature fields: `tsc=`, `turbo=`, `mem_channels=`, `scheduler=`, `cpu_mhz_max=`, `virt=`, `storage=`.
+- **R4**: `BENCH_TIER` unset is a hard error when argv contains the token `bench`, soft warning otherwise.
+- **R5**: concrete Rust-port trigger named: "when `hardware-signature.sh` exceeds 150 lines OR the first NUMA/hugepages field is requested."
+- **M2/M3**: new Tests 4 and 5 — VERSIONS ↔ HARDWARE.md platform coverage, and canonicalization round-trip.
+- **M5**: ADR committed at `.planning/adr/0001-bench-oracle-harness.md`.
+
+## Files
+
+### New
+
+```
+benches/oracles/etcd/fetch.sh            # download + sha256-verify etcd v3.5.x tarball
+benches/oracles/etcd/VERSIONS            # pinned etcd version + sha256 (per OS/arch, plus SHA256SUMS hash)
+benches/oracles/etcd/.gitignore          # ignore downloaded tarballs and unpacked dirs
+benches/oracles/etcd/README.md           # TOFU threat model + usage
+benches/runner/HARDWARE.md               # Tier 1 + Tier 2 hardware spec
+benches/runner/run.sh                    # emits signature (stderr + sidecar), execs argv
+benches/runner/hardware-signature.sh     # library that emits the signature line
+benches/runner/hwsig-lib.sh              # portable helpers: sha256_of, uname_arch_normalize, sysinfo
+benches/README.md                        # one-page overview of oracle + runner layout
+.planning/adr/0001-bench-oracle-harness.md  # decisions behind shell-over-Rust, TOFU, env-var tier, signature format
+scripts/test-bench-oracle-fetch.sh       # Test 1 (+ Test 4 platform coverage)
+scripts/test-hardware-signature.sh       # Test 2 (+ Test 5 canonicalization round-trip)
+scripts/test-bench-run-wrapper.sh        # Test 3
+```
+
+### Modified
+
+- `.github/workflows/ci.yml` — new `bench-harness` job.
+
+No `Cargo.toml` changes (the harness is shell, not a Rust bench crate yet; cargo-bench integration lands in Phase 2 when there's actually something to measure).
+
+## etcd version pin
+
+- **Re-verify the patch version at commit time.** The roadmap says v3.5.x. Draft pin: v3.5.17 (latest as of plan draft); implementer picks whatever is the current latest v3.5.z on the day of commit and updates `VERSIONS` accordingly.
+- Official release URL format:
+  ```
+  https://github.com/etcd-io/etcd/releases/download/<ETCD_VERSION>/etcd-<ETCD_VERSION>-<os>-<arch>.tar.gz
+  ```
+- We commit **two independent hashes** pinned at plan-commit-time:
+  1. The per-platform tarball sha256 (the thing we actually run).
+  2. The `SHA256SUMS` file's own sha256 (defense-in-depth: if someone later substitutes the release, both the tarball hash and the checksum-file hash would have to collide, which requires compromise _before_ our pin was taken).
+
+`fetch.sh` downloads the tarball, verifies its sha against `VERSIONS`, then downloads `SHA256SUMS` and verifies _its_ sha against `VERSIONS`, then cross-checks that `SHA256SUMS` contains the same tarball hash we pinned. Any disagreement → exit 1.
+
+`VERSIONS` format (KEY=VALUE, shell-sourceable):
+
+```
+ETCD_VERSION=v3.5.17
+ETCD_SHA256_linux_amd64=<hex>
+ETCD_SHA256_linux_arm64=<hex>
+ETCD_SHA256_darwin_amd64=<hex>
+ETCD_SHA256_darwin_arm64=<hex>
+ETCD_SHA256SUMS_SHA256=<hex>   # sha256 of the SHA256SUMS file itself, pinned at commit time
+```
+
+`fetch.sh` resolves platform with a `uname_arch_normalize()` helper in `hwsig-lib.sh` that maps `uname -m` output (`x86_64|amd64 → amd64`, `aarch64|arm64 → arm64`) to the etcd release naming. If a platform isn't pinned, fail with a message naming the missing key and pointing at `VERSIONS`.
+
+## Threat model (documented in `benches/oracles/etcd/README.md`)
+
+Local pin is **TOFU (trust-on-first-use)** against post-publication compromise of the etcd GitHub release. It does NOT protect against an attacker who compromised the release _before_ we took the pin. The two-hash scheme (tarball hash + SHA256SUMS file hash) narrows the window: an attacker would have to substitute both artifacts with content that hashes to our pinned values, which is cryptographically infeasible.
+
+"Self-authenticating signature line" (`sha` field) is **tamper-evident against accidental corruption** (copy-paste, Markdown munging, grep-replace across result files), not a security property. A malicious actor editing the signature would just recompute the hash. Real attestation (TPM quote, CI-bot signatures) is out of scope; it's Phase 12+ territory.
+
+## `benches/runner/HARDWARE.md` — two tiers
+
+### Tier 1 — single-node bench rig (Phases 2–13 single-node + 3-node)
+
+Hardware:
+
+- 1 host
+- ≥ 16 physical cores (32 vCPU acceptable for SMT)
+- ≥ 64 GB RAM
+- NVMe SSD, ≥ 500 GB free
+- ≥ 2 memory channels populated (DDR4 or DDR5), ≥ 4 preferred for Raft replay paths
+- Linux kernel ≥ 5.15 **or** macOS 14+ on Apple Silicon (M1 Pro/Max/Ultra, M2, M3 acceptable)
+
+Operator-configured (Linux-only where noted):
+
+- No swap during benches (`swapoff -a`) — Linux
+- CPU governor: `performance` — Linux
+- Turbo/frequency pinning: `intel_pstate=disable` or `cpupower frequency-set -g performance -u <max>` (records max freq in signature) — Linux
+- Isolated cores for tail-latency benches: `isolcpus=4-15 nohz_full=4-15 rcu_nocbs=4-15` — Linux, **required** for Phase 2+ latency benches, optional for throughput benches (but must be declared in the signature either way)
+- Block device scheduler: `mq-deadline` (or `none` for NVMe where the device manages its own queue); `nr_requests=1024`
+- TSC flags: `constant_tsc` AND `nonstop_tsc` present in `/proc/cpuinfo`. If either is missing, `Instant::now()` is unreliable and **this host is not Tier 1** — document and move on.
+
+### Tier 2 — multi-node fleet (Phase 14.5 chaos, Phase 12 release gate)
+
+- ≥ 10 hosts, each meeting Tier 1 spec
+- ≥ 5 voter nodes + ≥ 5 learner/follower nodes
+- ≥ 25 GbE intra-cluster bandwidth, measured with `iperf3`, recorded in the run log
+- Root access for `tc qdisc` / `iptables` (or a `toxiproxy` install on each host)
+- All hosts in one physical rack / one AZ (cross-AZ benches are a separate tier, out of scope for Phase 14.5)
+- **Clock sync**: PTP via `ptp4l` + `phc2sys` (preferred) OR chronyd with `maxpoll 4` against a rack-local NTP server. Cross-host drift must be < 1ms during the bench window, asserted in pre-roll.
+
+### Tier contamination rules
+
+- Every host in a multi-node bench emits its **own** signature. Analysis tools MUST assert all signatures agree on `cpu`, `cores`, `ram_gb`, `storage`, `tier` before reporting aggregate numbers.
+- Running Tier 1 benches on a host from a Tier 2 fleet is allowed; the operator sets `BENCH_TIER=1` and accepts responsibility for isolating the host.
+- `BENCH_TIER` set to a value other than `1` or `2` → hard error.
+
+Every run MUST record which tier it was on. A number without a tier annotation is not a number.
+
+## Hardware signature
+
+`hardware-signature.sh` emits one line per run, self-contained, grep-friendly:
+
+```
+BENCH_HW v1: arch=amd64 cores=64 cpu=AMD\ EPYC\ 7B13 cpu_mhz_max=3500 kernel=6.1.0 mem_channels=8 os=linux ram_gb=256 scheduler=mq-deadline storage=Samsung\ 980\ Pro tier=1 tsc=invariant turbo=disabled virt=bare-metal sha=<digest>
+```
+
+### Canonical form (S2 resolution)
+
+- Fields sorted **lexically by key name** (e.g., `arch` before `cores` before `cpu`, alphabetical).
+- Values shell-escaped: spaces → `\ `, quotes → `\"`. This avoids the ambiguity of `"quoted value"` vs `unquoted`.
+- Single-space separator between fields. No trailing space, no trailing newline in the hashed input.
+- Each value stripped of leading/trailing whitespace and tabs before escaping.
+- Version prefix `BENCH_HW v1: ` is **not** part of the hashed input; it's a display header.
+- `sha=<digest>` is the last field in the printed line but is **not** included in its own hash (circular).
+
+Hash computation:
+
+```
+canonical=$(print all fields except sha=, sorted by key, escaped, space-joined)
+sha=$(printf '%s' "$canonical" | <sha256_of> | cut -d' ' -f1)
+printf 'BENCH_HW v1: %s sha=%s\n' "$canonical" "$sha"
+```
+
+### Fields
+
+| Field          | Source (Linux)                                                                                                       | Source (macOS)                              | Notes                                         |
+| -------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- | --------------------------------------------- | -------------------------------------------------- | -------------- | --- |
+| `arch`         | `uname -m` → normalize                                                                                               | `uname -m` → normalize                      | `x86_64                                       | amd64 → amd64`; `aarch64                           | arm64 → arm64` |
+| `cores`        | `nproc`                                                                                                              | `sysctl -n hw.physicalcpu`                  | Physical cores, not SMT                       |
+| `cpu`          | `/proc/cpuinfo` `model name` (first occurrence, trimmed)                                                             | `sysctl -n machdep.cpu.brand_string`        | Strip trailing tabs/spaces                    |
+| `cpu_mhz_max`  | `lscpu` `CPU max MHz` or `/proc/cpuinfo` `cpu MHz`                                                                   | `sysctl -n hw.cpufrequency_max` / 1_000_000 | `0` if unavailable                            |
+| `kernel`       | `uname -r`                                                                                                           | `uname -r`                                  |                                               |
+| `mem_channels` | `dmidecode -t memory` parse, or `0` if unavailable / not root                                                        | `0` (not reliably queryable)                | Documented as "best effort"                   |
+| `os`           | `uname -s` lowercased                                                                                                | `uname -s` lowercased                       | `linux                                        | darwin`                                            |
+| `ram_gb`       | `/proc/meminfo` `MemTotal` (kB) / (1024\*1024)                                                                       | `sysctl -n hw.memsize` (bytes) / (1024^3)   | Integer rounding                              |
+| `scheduler`    | `cat /sys/block/<primary>/queue/scheduler`                                                                           | `unknown`                                   | Linux-only                                    |
+| `storage`      | `lsblk -d -o MODEL -n <primary>`                                                                                     | `diskutil info /                            | grep "Device / Media Name"`                   | Replace spaces with `\ `                           |
+| `tier`         | `$BENCH_TIER`                                                                                                        | `$BENCH_TIER`                               | `1` or `2`; unset → hard-or-soft error per R4 |
+| `tsc`          | `grep -q constant_tsc /proc/cpuinfo && grep -q nonstop_tsc /proc/cpuinfo && echo invariant                           |                                             | echo variable`                                | `invariant` (Apple Silicon and recent Intel Macs)  |                |
+| `turbo`        | `/sys/devices/system/cpu/intel_pstate/no_turbo` if present; `disabled` if `1`, `enabled` if `0`, `unknown` otherwise | `unknown`                                   |                                               |
+| `virt`         | `systemd-detect-virt 2>/dev/null                                                                                     |                                             | echo bare-metal`                              | `sysctl -n kern.hv_vmm_present 2>/dev/null` → `vmm | bare-metal`    |     |
+
+"Best effort" fields (`mem_channels`, `scheduler` on macOS, `cpu_mhz_max` fallback) are honestly reported as `unknown` or `0`. They do NOT derive a warning — the point is that the signature captures what's knowable, not that every field is always known.
+
+## Runner wrapper (`run.sh`) — B4 resolution
+
+`run.sh` does the following in order:
+
+1. Compute the signature via `hardware-signature.sh`.
+2. Emit the signature line to **stderr** (so stdout remains a clean channel for the wrapped command).
+3. If `BENCH_OUT_DIR` is set, also write the signature to `$BENCH_OUT_DIR/signature.txt`. Phase 2+ tools read this sidecar to correlate results.
+4. `exec "$@"` — forward all argv as-is. The wrapped command's exit code is the script's exit code.
+
+### Tier-hard-fail rule (R4)
+
+If `BENCH_TIER` is unset AND argv contains the token `bench` (as in `cargo bench`, `--bench name`), `run.sh` exits 2 with a message on stderr. Any other argv proceeds with `tier=unknown` and a warning. Rationale: smoke tests (`run.sh echo hello`) don't need a tier; real benches always do.
+
+## Tests — MANDATORY per project rule
+
+Five shell-only tests. All portable to Linux and macOS via `hwsig-lib.sh`. Wired into CI as `bench-harness`.
+
+### Test 1: `fetch.sh` `verify_sha` function
+
+`scripts/test-bench-oracle-fetch.sh`:
+
+- Source `fetch.sh` to get the `verify_sha` function.
+- Create a temp file with known content, compute its sha with the portable helper.
+- Assert `verify_sha $file $correct_sha` exits 0.
+- Assert `verify_sha $file $wrong_sha` exits non-zero with an error message that names the file path.
+- Does NOT hit the network.
+
+### Test 2: `hardware-signature.sh` emits a well-formed line
+
+`scripts/test-hardware-signature.sh` (part A):
+
+- Run `hardware-signature.sh` with `BENCH_TIER=1`.
+- Assert the output matches the regex: `^BENCH_HW v1: ([a-z_]+=[^ ]+ )+sha=[0-9a-f]{64}$`.
+- Assert fields are alphabetically sorted (split on space, check each key ≤ next key).
+- Assert running again within 5 seconds produces an identical line (weakened determinism — B3).
+- Run with `BENCH_TIER` unset and argv not containing `bench`: expect `tier=unknown` and a stderr warning.
+- Run with `BENCH_TIER=3`: expect exit 1 with "invalid tier" message.
+
+### Test 3: `run.sh` stderr signature + stdout cleanliness (B4)
+
+`scripts/test-bench-run-wrapper.sh`:
+
+- Run `BENCH_TIER=1 run.sh echo hello world 2>/tmp/sig 1>/tmp/out`.
+- Assert `/tmp/sig` contains `BENCH_HW v1:` as the first line.
+- Assert `/tmp/out` is exactly `hello world\n` (no signature prepended).
+- Run with `BENCH_OUT_DIR=$(mktemp -d)` and assert the sidecar file exists and matches the stderr signature.
+- Run `BENCH_TIER= run.sh cargo bench --bench foo` (won't actually exec if cargo/bench not wired) — expect exit 2 before exec, with "BENCH_TIER required when running benches" stderr.
+- Run `run.sh false` — expect exit 1 (propagated), signature still printed to stderr.
+
+### Test 4: `VERSIONS` ↔ `HARDWARE.md` platform coverage (M2)
+
+`scripts/test-bench-oracle-fetch.sh` (part B):
+
+- For each `os/arch` in `HARDWARE.md`'s supported list (parsed from a machine-readable block in the markdown), assert `VERSIONS` has a matching `ETCD_SHA256_<os>_<arch>=<non-empty-hex>` line.
+- For each `ETCD_SHA256_<os>_<arch>` in `VERSIONS`, assert that platform appears in `HARDWARE.md`'s supported list.
+- Catches drift: adding a platform to HARDWARE.md without pinning a sha, or vice versa.
+
+### Test 5: Canonicalization round-trip (M3)
+
+`scripts/test-hardware-signature.sh` (part B):
+
+- Capture a signature line.
+- Extract the `sha=` field; reconstruct the canonical form from the rest; feed to the portable hasher; compare.
+- If the recomputed digest differs from the printed one, the canonicalization is inconsistent with the hashing — fail with a diff.
+- This test catches future field additions that forget to update the canonicalization logic.
+
+### CI integration
+
+New `bench-harness` job in `.github/workflows/ci.yml`:
+
+- `runs-on: ubuntu-24.04`, `timeout-minutes: 5`.
+- `actions/checkout@<pinned sha>` only. No Rust toolchain, no cache action (no build).
+- Step 1: `bash scripts/test-bench-oracle-fetch.sh`
+- Step 2: `bash scripts/test-hardware-signature.sh`
+- Step 3: `bash scripts/test-bench-run-wrapper.sh`
+- Step 4 (B1): `git diff --exit-code benches/oracles/etcd/VERSIONS` — verifies no test mutated the committed VERSIONS file.
+
+macOS coverage: the three scripts are portable, but CI only runs Linux. A manual `./scripts/test-*.sh` run on macOS is required as part of the Phase 2+ bench PRs and is documented in `benches/README.md`. (A macOS CI matrix is Phase 0.5+ territory — too heavy for this scaffold.)
+
+## Non-goals for this PR
+
+- No actual benchmarks. Phase 2+ adds them.
+- No cargo-bench integration. Same — Phase 2+.
+- No automated tier-1 vs tier-2 hardware detection. `BENCH_TIER` is a human-set env var.
+- No Windows support. Roadmap scope is Linux + macOS. `fetch.sh` fails loudly on other platforms.
+- No etcd _running_. We check the binary unpacks and the version matches. Actual cluster wiring is the Phase 2 bench's problem.
+- No cosign / release signing. Future hardening pass.
+- No NUMA / hugepages fields in the signature. Adding these is the trigger for the Rust port per R5.
+- No macOS CI matrix. Phase 0.5+ when loom / madsim justify the extra expense.
+- No ADR for every platform variant. The one ADR at `.planning/adr/0001-bench-oracle-harness.md` captures the load-bearing decisions; per-platform notes live in `benches/README.md`.
+
+## Rollback plan
+
+### Mechanical rollback
+
+`git rm -rf benches/ scripts/test-bench-*.sh scripts/test-hardware-signature.sh .planning/adr/0001-bench-oracle-harness.md` and remove the `bench-harness` CI job. No runtime code, no dependencies — mechanically clean.
+
+### Dependency graph (important)
+
+Once Phase 2 ships a comparison bench, rolling this back also requires:
+
+- Reverting every `benches/results/` file that includes a `BENCH_HW v1:` signature.
+- Reverting every ROADMAP.md cross-reference to `benches/runner/HARDWARE.md`.
+- Reverting Phase 12's release gate (which consumes tier declarations).
+
+In practice, **this scaffold becomes a one-way door at the first Phase 2 bench PR.** Name it here so future-us doesn't accidentally try.
+
+## Follow-ups (documented, not shipped in this PR)
+
+- **Phase 2 first-bench PR MUST include** an end-to-end smoke test that runs `fetch.sh`, unpacks, executes `etcd --version`, asserts version match with `ETCD_VERSION`. Track in M6 note in `benches/README.md`.
+- **Phase 0.14 CONTRIBUTING.md MUST reference** `benches/runner/HARDWARE.md` when describing how to run benches locally.
+- **R4 enforcement** — `bench-harness` is currently an advisory CI check because `main` branch protection isn't enabled yet (tracked from PR #16 review, R4 there). When branch protection lands, add `bench-harness` to the required-checks list.
+- **Signature format v2** — NUMA / hugepages / cgroup-awareness fields will trigger the shell-to-Rust migration per R5. Signature version bumps to `BENCH_HW v2:` at that point.
+- **`--no-download` / cache mode** for `fetch.sh` — CI environments that pre-populate a mirror. Added when the first CI matrix that needs it lands (Phase 2+).
+
+## Expected rust-expert feedback (anticipated, post-revision)
+
+The REVISE round caught the real issues. Remaining likely pushback:
+
+1. **"Why pin the SHA256SUMS hash separately instead of signing the tarball?"** — signing requires a trusted key; we don't have one. Two-hash TOFU is the honest floor. Cosign + sigstore when the Phase 12 release-attestation work happens.
+2. **"Tier 1 isolcpus requirement is going to turn away contributors on laptops."** — laptops are fine for _throughput_ benches; tail-latency benches demand isolcpus. HARDWARE.md calls this out explicitly so contributors don't run latency benches on contended cores and ship a bad number.
+3. **"Signature field list will grow."** — versioned (`v1` → `v2`), and R5 names the concrete trigger for the shell→Rust port. Growth is planned.
+4. **"Why stderr and not stdout for the signature?"** — stdout must stay clean for JSON-producing bench tools (criterion `--output-format json`, hyperfine `--export-json`). This is the B4 fix. Sidecar file for downstream tooling that wants to correlate.

--- a/.planning/adr/0001-bench-oracle-harness.md
+++ b/.planning/adr/0001-bench-oracle-harness.md
@@ -1,0 +1,190 @@
+# ADR 0001 — Bench oracle harness scaffold
+
+Status: Accepted (ROADMAP item 0.10)
+Date: 2026-04-23
+
+## Context
+
+mango's roadmap promises comparisons against etcd ("beats etcd by Nx"
+claims in Phases 2–14 and the Phase 12 release gate). Comparisons
+require:
+
+- A specific etcd version, reproducibly downloadable.
+- A declared hardware class so two people can interpret the same
+  number the same way.
+- A provenance record on every result file so numbers that get
+  copy-pasted into ROADMAP, release notes, or papers carry their
+  origin with them.
+
+Without any of these, the first throughput claim arrives and we
+improvise the scaffold under deadline pressure, which is how projects
+end up with numbers that don't reproduce.
+
+## Decision
+
+Land a scaffold-only PR with:
+
+1. **Pinned etcd oracle** in `benches/oracles/etcd/` — `VERSIONS` with
+   per-platform sha256 plus the sha of the release's `SHA256SUMS`
+   file, and `fetch.sh` that verifies all three paths (tarball sha,
+   SHA256SUMS sha, SHA256SUMS↔VERSIONS cross-check).
+2. **Two hardware tiers** in `benches/runner/HARDWARE.md` — Tier 1
+   single-node (Phases 2–13), Tier 2 multi-node (Phase 14.5 chaos +
+   Phase 12 release gate).
+3. **A canonical hardware signature** (`BENCH_HW v1:`) emitted by
+   `benches/runner/hardware-signature.sh` and prepended to every bench
+   run by `benches/runner/run.sh`.
+
+No benchmarks run from this PR. Phase 2+ writes them and consumes the
+scaffold.
+
+## Load-bearing decisions
+
+### 1. Shell, not Rust
+
+The harness is plumbing around shell-native concerns (`curl`,
+`sha256sum`/`shasum`, `sysctl`, `/proc/cpuinfo`, `lsblk`, `diskutil`).
+Rewriting those in Rust is ceremony without payoff at this scale
+(~300 lines total). Reading shell-pipeline output _from_ Rust would
+still require most of the same platform branches, just with more
+surface area.
+
+**Trigger to port to Rust:** when `hardware-signature.sh` exceeds
+~150 lines OR the first NUMA / hugepages / cgroup-aware field is
+requested. At that point the shell version becomes a reference
+implementation during the transition, and the Rust version lives at
+`benches/runner/hwsig`.
+
+### 2. TOFU (trust-on-first-use) for the etcd pin, defended by two hashes
+
+**Problem:** local-pinning the tarball sha defends against GitHub
+release compromise _after_ the pin was taken, but not before. If the
+adversary compromised the release simultaneously with or before our
+pin, we trust the attacker.
+
+**Decision:** pin the tarball sha AND the SHA256SUMS file's own sha.
+An attacker would need to substitute content that hashes correctly
+against _both_ pinned values, which is cryptographically infeasible.
+This narrows — but does not eliminate — the TOFU window.
+
+**Not done:** cosign / sigstore signatures, PGP verification, CI-bot
+counter-signing. Phase 12+ release-attestation work will subsume this
+scheme.
+
+### 3. `BENCH_TIER` as an env var, hard-fail on bench argv
+
+**Problem:** silent defaults lead to unlabeled numbers in result files.
+A flag you can forget to set is a flag that gets forgotten.
+
+**Decision:** `BENCH_TIER` is a required env var for bench invocations,
+enforced by `run.sh`:
+
+- `BENCH_TIER=1` or `BENCH_TIER=2` → signature records it.
+- `BENCH_TIER=<anything else>` → hard error.
+- Unset + argv looks like a bench (`cargo bench`, `--bench`, `bench`) →
+  hard error (exit 2).
+- Unset + argv is anything else (diagnostics, `echo hello`) → soft
+  warning, signature records `tier=unknown`.
+
+The asymmetry is the point. Smoke tests should work without setup;
+real numbers should not.
+
+### 4. Canonical signature format, v1
+
+**Problem:** "join fields with spaces and hash" as specified would
+give different hashes on different hosts for the same inputs — field
+order varies, value padding varies, missing-field handling varies.
+
+**Decision:** canonical form is
+
+- Fields sorted **lexically by key** (deterministic across shells).
+- Values trimmed of leading/trailing whitespace (defends against
+  `/proc/cpuinfo` tab padding).
+- Values shell-escaped (`\ ` for space, `\\` for backslash) — no
+  quotation marks. A line parsed by `read -a` recovers key=value
+  pairs.
+- Single-space separator, no trailing space, no trailing newline in
+  the hashed input.
+- `sha=<digest>` appears last in the printed line but is **not** part
+  of its own hashed input (circular).
+
+Version tag `BENCH_HW v1: ` is the display header, not in the hash.
+Field additions bump to `v2`.
+
+### 5. Signature to stderr, not stdout
+
+**Problem:** prepending a signature line to stdout breaks every
+JSON-producing bench tool (criterion `--output-format json`,
+hyperfine `--export-json`, fio `--output-format json`).
+
+**Decision:** `run.sh` emits the signature to **stderr** unconditionally
+and, if `BENCH_OUT_DIR` is set, also writes it to
+`$BENCH_OUT_DIR/signature.txt`. Stdout stays clean; downstream tooling
+reads the sidecar.
+
+### 6. Two hardware tiers, named now
+
+**Problem:** the first multi-node bench will want to define "what
+counts as comparable hardware" under deadline pressure. Better to
+fight about it now than in the Phase 14.5 PR review.
+
+**Decision:** Tier 1 = single-node, documented in HARDWARE.md with
+explicit core/ram/NVMe minimums plus Linux-only turbo/TSC/isolcpus/
+scheduler requirements and macOS best-effort equivalents. Tier 2 =
+multi-node, Linux-only, with clock-sync and bandwidth-measurement
+requirements. Tier 3 (cross-AZ, public cloud) is explicitly
+out-of-scope.
+
+### 7. Five shell tests, wired as a new `bench-harness` CI job
+
+The tests are:
+
+1. `verify_sha` function (pass/fail with locally-generated fixtures,
+   no network).
+2. Signature line format + determinism (same host, same shell, within
+   a few seconds).
+3. `run.sh` separates stdout/stderr cleanly, propagates exit code,
+   writes sidecar on `BENCH_OUT_DIR`.
+4. VERSIONS ↔ HARDWARE.md platform coverage (each supported platform
+   has a pinned sha; no extra shas for unsupported platforms).
+5. Canonicalization round-trip (extract `sha=` from emitted line,
+   recompute it from the rest, assert match).
+
+CI job is Ubuntu-only; macOS coverage is a local-developer
+responsibility documented in `benches/README.md`. macOS CI matrix is
+Phase 0.5+ territory.
+
+## Consequences
+
+**Positive:**
+
+- First Phase 2 bench PR cannot ship unsigned numbers.
+- Pin bumps produce a visible, reviewable diff (the VERSIONS file) and
+  a paired bench-harness CI run on the new pin.
+- Hardware differences show up in the signature, not as "why does
+  CI disagree with my laptop" debugging.
+
+**Negative:**
+
+- Adds five shell scripts to the repo; shell tests can rot faster
+  than Rust tests. Mitigation: the portable helpers live in one file
+  (`hwsig-lib.sh`) so regressions have one place to hit.
+- Becomes a one-way door at the first Phase 2 bench PR — every
+  committed result file embeds a signature, and rolling the scaffold
+  back would invalidate them.
+- macOS + Linux parity is a manual discipline. The signature's field
+  set is a promise we make to Apple-Silicon contributors that some
+  fields will be `unknown` by design.
+
+## Alternatives considered
+
+- **etcd as a git submodule** — creates `git clone --recursive`
+  friction for every contributor; the pin churn belongs in a sha file,
+  not in submodule history.
+- **Cargo bench crate from day one** — dead code. Phase 2+ adds it
+  when there's something to bench.
+- **Rust binary for the signature** — premature; <150 lines of shell
+  is more auditable than its Rust equivalent. Porting trigger named
+  above.
+- **No tiers, one big "recommended hardware" doc** — guarantees the
+  first multi-node PR litigates the spec under deadline pressure.

--- a/.planning/adr/0001-bench-oracle-harness.md
+++ b/.planning/adr/0001-bench-oracle-harness.md
@@ -45,15 +45,28 @@ scaffold.
 The harness is plumbing around shell-native concerns (`curl`,
 `sha256sum`/`shasum`, `sysctl`, `/proc/cpuinfo`, `lsblk`, `diskutil`).
 Rewriting those in Rust is ceremony without payoff at this scale
-(~300 lines total). Reading shell-pipeline output _from_ Rust would
-still require most of the same platform branches, just with more
-surface area.
+(~300 lines total across `hardware-signature.sh` + `hwsig-lib.sh`).
+Reading shell-pipeline output _from_ Rust would still require most
+of the same platform branches, just with more surface area.
 
-**Trigger to port to Rust:** when `hardware-signature.sh` exceeds
-~150 lines OR the first NUMA / hugepages / cgroup-aware field is
-requested. At that point the shell version becomes a reference
-implementation during the transition, and the Rust version lives at
-`benches/runner/hwsig`.
+**Trigger to port to Rust**, whichever comes first:
+
+- A third target OS (Windows/BSD) is added — platform branching
+  stops being cheap once you outgrow the Linux/Darwin duet.
+- The first NUMA / hugepages / cgroup-aware / PMU field is
+  requested — these need structured parsing, not line grep.
+- `hardware-signature.sh` exceeds ~300 non-comment lines, or the
+  test scripts outgrow ~500 lines of shell assertions.
+
+This PR lands at ~264 non-comment lines in `hardware-signature.sh`
+(+72 in `hwsig-lib.sh`), well inside the "shell is fine" band. The
+earlier ~150-line draft trigger was replaced with the criteria
+above after PR review flagged the inconsistency between "~300
+lines total" and "exceeds 150" in the same decision.
+
+At port time, the shell version becomes a reference
+implementation during the transition, and the Rust version lives
+at `benches/runner/hwsig`.
 
 ### 2. TOFU (trust-on-first-use) for the etcd pin, defended by two hashes
 
@@ -63,9 +76,15 @@ adversary compromised the release simultaneously with or before our
 pin, we trust the attacker.
 
 **Decision:** pin the tarball sha AND the SHA256SUMS file's own sha.
-An attacker would need to substitute content that hashes correctly
-against _both_ pinned values, which is cryptographically infeasible.
-This narrows — but does not eliminate — the TOFU window.
+Note the two hashes do **not** compose into a stronger cryptographic
+property — one SHA-256 preimage is already infeasible to forge. The
+second hash is defense-in-depth against a _different_ failure mode:
+a CDN cache or mirror that serves an inconsistent pair (correct
+tarball + stale SHA256SUMS, or vice versa). That detects mirror
+drift and release-artifact tampering where only one file was
+replaced. Against a full release compromise that swaps both files
+in lockstep, pre-TOFU, we are still trusting the attacker — the
+second hash narrows but does not close the TOFU window.
 
 **Not done:** cosign / sigstore signatures, PGP verification, CI-bot
 counter-signing. Phase 12+ release-attestation work will subsume this
@@ -183,8 +202,8 @@ Phase 0.5+ territory.
   not in submodule history.
 - **Cargo bench crate from day one** — dead code. Phase 2+ adds it
   when there's something to bench.
-- **Rust binary for the signature** — premature; <150 lines of shell
-  is more auditable than its Rust equivalent. Porting trigger named
-  above.
+- **Rust binary for the signature** — premature; ~300 lines of shell
+  across `hardware-signature.sh` + `hwsig-lib.sh` is more auditable
+  than its Rust equivalent. Porting trigger named in decision 1.
 - **No tiers, one big "recommended hardware" doc** — guarantees the
   first multi-node PR litigates the spec under deadline pressure.

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,121 @@
+# mango bench harness
+
+Scaffold for bench comparisons against etcd. No benchmarks run from
+this directory yet — Phase 2+ writes those. The point is to ship the
+provenance apparatus (oracle pin, hardware tiers, hardware signature)
+_before_ any "beats etcd by Nx" claim appears in the codebase so
+every claim has a verifiable floor.
+
+## Layout
+
+```
+benches/
+├── README.md                    # this file
+├── oracles/
+│   └── etcd/
+│       ├── fetch.sh             # download + sha256-verify etcd tarball
+│       ├── VERSIONS             # pinned etcd version + sha256 hashes
+│       ├── .gitignore           # keep downloaded artifacts out of git
+│       └── README.md            # etcd-specific usage + threat model
+└── runner/
+    ├── HARDWARE.md              # Tier 1 + Tier 2 requirements
+    ├── hardware-signature.sh    # emits the BENCH_HW v1: ... line
+    ├── hwsig-lib.sh             # portable helpers (sha256, arch norm)
+    └── run.sh                   # wraps a command, emits signature
+```
+
+## Two things this harness gives you
+
+1. **An oracle you can reproduce.** `benches/oracles/etcd/fetch.sh`
+   downloads a pinned etcd release and verifies two independent
+   sha256 hashes against a locally committed value. If the download
+   doesn't match, the script exits non-zero — the bench does not
+   proceed on an uncertain oracle.
+
+2. **A hardware provenance record.** `benches/runner/run.sh` wraps
+   any bench command, emits a canonical single-line hardware
+   signature to stderr (and a sidecar file if `BENCH_OUT_DIR` is
+   set), and forwards the command. Every result that mango
+   publishes carries this line so readers can tell what box it
+   was run on.
+
+## Running the harness
+
+```bash
+# Download + verify the etcd oracle for the current platform.
+benches/oracles/etcd/fetch.sh
+# → writes benches/oracles/etcd/cache/etcd-vX.Y.Z-<os>-<arch>.{tar.gz,zip}
+#   and prints the path on success.
+
+# Print a bare hardware signature.
+BENCH_TIER=1 benches/runner/hardware-signature.sh
+
+# Wrap a bench command.
+BENCH_TIER=1 benches/runner/run.sh cargo bench --bench my_bench
+# stdout: whatever cargo bench prints
+# stderr: BENCH_HW v1: arch=... sha=<digest>
+
+# Capture a sidecar signature file for downstream tooling.
+BENCH_TIER=1 BENCH_OUT_DIR=out/run-1 benches/runner/run.sh <cmd>
+# → out/run-1/signature.txt contains the signature line
+```
+
+## `BENCH_TIER` enforcement
+
+- Running a bench (any argv containing `bench` or `cargo bench` or
+  `--bench`) with `BENCH_TIER` unset is a hard error (exit 2) from
+  `run.sh`. This is the point — unsigned numbers are not numbers.
+- Running any other command with `BENCH_TIER` unset is a soft
+  warning; the signature reports `tier=unknown`.
+- `BENCH_TIER` set to anything other than `1` or `2` is a hard error.
+
+## The signature line
+
+```
+BENCH_HW v1: arch=amd64 cores=64 cpu=AMD\ EPYC\ 7B13 cpu_mhz_max=3500 kernel=6.1.0 mem_channels=8 os=linux ram_gb=256 scheduler=mq-deadline storage=Samsung\ 980\ Pro tier=1 tsc=invariant turbo=disabled virt=bare-metal sha=<64-hex>
+```
+
+**Canonical form (v1):**
+
+- Fields sorted lexically by key.
+- Values shell-escaped (`\ ` for spaces, `\\` for backslashes).
+- Single space between fields, no trailing space, no trailing newline
+  in the hashed bytes.
+- `sha=` is the last printed field but is NOT in its own input.
+
+**What the `sha` buys you:** tamper-evident detection of accidental
+corruption (copy-paste, markdown munging, sed scripts across result
+files). It is NOT a security property — an adversary editing the line
+would just recompute the hash. See
+`benches/oracles/etcd/README.md` for the (different) threat model
+around the etcd pin.
+
+**Version discipline:** adding a field (NUMA, hugepages, cgroup mode)
+requires bumping `v1` to `v2` so old signatures remain interpretable.
+Dropping a field is effectively never compatible.
+
+## Follow-ups (tracked, not shipped here)
+
+- **Phase 2 first-bench PR MUST include** a smoke test that invokes
+  `fetch.sh`, unpacks the artifact, runs `etcd --version`, and
+  asserts the version matches `ETCD_VERSION`. This is the
+  end-to-end gate we do not exercise from the scaffold.
+- **CONTRIBUTING.md (Phase 0 item 0.14)** must reference this
+  directory when describing how to run local benches.
+- **Branch protection:** `bench-harness` CI job is advisory until
+  `main` is protected and required-checks include it (tracked from
+  previous PR review).
+- **Signature v2 trigger:** when `hardware-signature.sh` exceeds
+  150 lines OR the first NUMA / hugepages / cgroup-aware field is
+  requested, port the signature emitter to a Rust binary
+  (`benches/runner/hwsig`) and keep the shell version as a
+  reference implementation during the transition.
+
+## macOS coverage
+
+CI only runs the harness on Ubuntu 24.04. The scripts are portable
+to macOS (via `shasum -a 256` instead of `sha256sum`, `sysctl`
+instead of `/proc/*`) and anyone bumping the harness must run
+`scripts/test-*.sh` on both macOS and Linux locally before
+proposing the change. A macOS CI matrix is Phase 0.5+ territory —
+too heavy an ask for the scaffold.

--- a/benches/README.md
+++ b/benches/README.md
@@ -105,11 +105,15 @@ Dropping a field is effectively never compatible.
 - **Branch protection:** `bench-harness` CI job is advisory until
   `main` is protected and required-checks include it (tracked from
   previous PR review).
-- **Signature v2 trigger:** when `hardware-signature.sh` exceeds
-  150 lines OR the first NUMA / hugepages / cgroup-aware field is
-  requested, port the signature emitter to a Rust binary
-  (`benches/runner/hwsig`) and keep the shell version as a
-  reference implementation during the transition.
+- **Rust-port trigger:** port the signature emitter to a Rust
+  binary (`benches/runner/hwsig`) when **any** of the following
+  hits — a third target OS (Windows/BSD), the first structured
+  field (NUMA / hugepages / cgroup-aware / PMU), or
+  `hardware-signature.sh` passing ~300 non-comment lines. This PR
+  lands at ~264 non-comment lines, inside the "shell is fine"
+  band. See `.planning/adr/0001-bench-oracle-harness.md` decision 1
+  for the full rationale. At port time, the shell version becomes
+  a reference implementation during the transition.
 
 ## macOS coverage
 

--- a/benches/oracles/etcd/.gitignore
+++ b/benches/oracles/etcd/.gitignore
@@ -1,0 +1,6 @@
+# Downloaded artifacts from fetch.sh. Never committed.
+cache/
+*.tar.gz
+*.zip
+etcd-v*/
+SHA256SUMS

--- a/benches/oracles/etcd/README.md
+++ b/benches/oracles/etcd/README.md
@@ -61,10 +61,19 @@ To narrow the window, we pin **two independent hashes** in `VERSIONS`:
 - `ETCD_SHA256_<os>_<arch>`: the per-platform tarball/zip sha.
 - `ETCD_SHA256SUMS_SHA256`: the sha of the `SHA256SUMS` file itself.
 
-An attacker substituting the tarball would fail the first hash.
-Substituting both tarball and `SHA256SUMS` would fail the second.
-Finding a tarball plus a `SHA256SUMS` that collide on both pinned
-hashes simultaneously is cryptographically infeasible.
+The two hashes do **not** compose into a stronger cryptographic
+property — forging either one already requires a SHA-256 preimage,
+which is infeasible. The second hash is defense-in-depth against a
+_different_ class of failure: a CDN cache or mirror serving an
+inconsistent pair (correct tarball + stale `SHA256SUMS`, or vice
+versa), or a partial release-artifact swap where only one file is
+tampered. The cross-check catches those.
+
+Against a full release compromise that substitutes both the tarball
+and `SHA256SUMS` in lockstep before our pin was taken, both hashes
+were taken from the attacker's artifacts — we are still trusting
+the attacker. That window is what TOFU means and what sigstore /
+PGP would close.
 
 Real attestation (TPM quote, sigstore/cosign signatures of the
 release, CI-bot counter-signing) is out of scope for this scaffold.

--- a/benches/oracles/etcd/README.md
+++ b/benches/oracles/etcd/README.md
@@ -1,0 +1,79 @@
+# etcd oracle
+
+Every "mango beats etcd by Nx" claim needs an oracle: a specific etcd
+release, pinned by content hash, runnable on the bench rig. This
+directory holds the pin and the fetcher; the actual bench suites that
+run the oracle live in Phase 2+.
+
+## Files
+
+- `VERSIONS` — pinned `ETCD_VERSION` and per-platform sha256 hashes.
+  Shell-sourceable. Also includes `ETCD_SHA256SUMS_SHA256` for
+  defense-in-depth (see Threat model below).
+- `fetch.sh` — downloads and verifies the pinned artifact. Prints the
+  resolved path to stdout on success.
+
+## Usage
+
+```bash
+# Downloads etcd for the current platform into ./cache/ and verifies
+# its hash. Prints the artifact path on success.
+benches/oracles/etcd/fetch.sh
+```
+
+The `cache/` directory is `.gitignore`d. Phase 2+ bench runners unpack
+the artifact; this scaffold only verifies that the downloaded bytes
+match the pin.
+
+## Supported platforms
+
+| OS     | Arch  | Extension |
+| ------ | ----- | --------- |
+| linux  | amd64 | `.tar.gz` |
+| linux  | arm64 | `.tar.gz` |
+| darwin | amd64 | `.zip`    |
+| darwin | arm64 | `.zip`    |
+
+Anything else (Windows, other BSDs, ppc64le, s390x) fails loudly.
+`uname -m`'s `x86_64`/`aarch64` names are normalized to etcd's
+`amd64`/`arm64` convention by `hwsig-lib.sh`'s `uname_arch_normalize`.
+
+## Bumping the pin
+
+1. Pick a new v3.5.z release from https://github.com/etcd-io/etcd/releases.
+2. Download the release's `SHA256SUMS` file and record its own sha256.
+3. Extract the per-platform hashes from `SHA256SUMS`.
+4. Update `VERSIONS` with the new values.
+5. Run `fetch.sh` on each supported platform (at minimum locally and in
+   CI) to confirm the pin is live.
+6. Commit as a standalone PR; the expert-review gate applies here too
+   because a bad pin would mask Phase 12+ comparison drift.
+
+## Threat model
+
+Local pinning of the tarball sha is **TOFU (trust-on-first-use)**
+against post-publication compromise of the etcd GitHub release page.
+It does NOT protect against an attacker who had compromised the
+release _before_ the pin was taken.
+
+To narrow the window, we pin **two independent hashes** in `VERSIONS`:
+
+- `ETCD_SHA256_<os>_<arch>`: the per-platform tarball/zip sha.
+- `ETCD_SHA256SUMS_SHA256`: the sha of the `SHA256SUMS` file itself.
+
+An attacker substituting the tarball would fail the first hash.
+Substituting both tarball and `SHA256SUMS` would fail the second.
+Finding a tarball plus a `SHA256SUMS` that collide on both pinned
+hashes simultaneously is cryptographically infeasible.
+
+Real attestation (TPM quote, sigstore/cosign signatures of the
+release, CI-bot counter-signing) is out of scope for this scaffold.
+It is Phase 12+ territory once mango itself needs a release-attestation
+story; the architecture there will subsume this one.
+
+## Non-goals
+
+- No signing key. No PGP. No cosign.
+- No mirror or failover. If GitHub releases are down, benches block.
+- No Windows / BSD / big-endian support. Documented and failing-loud.
+- No "always latest" mode. The pin is the point.

--- a/benches/oracles/etcd/VERSIONS
+++ b/benches/oracles/etcd/VERSIONS
@@ -1,0 +1,28 @@
+# benches/oracles/etcd/VERSIONS
+#
+# Pinned etcd oracle version and per-platform content hashes. This is
+# the source of truth for fetch.sh. Hashes are taken from the official
+# SHA256SUMS file at pin time (see ETCD_SHA256SUMS_SHA256 below for
+# defense-in-depth) — see README.md for the TOFU threat model.
+#
+# Shell-sourceable (KEY=VALUE, no quotes needed for hex).
+#
+# Extension suffix per platform (etcd convention):
+#   linux/*  → .tar.gz
+#   darwin/* → .zip
+#   windows/amd64 → .zip (not supported by this harness)
+
+ETCD_VERSION=v3.5.29
+
+# Tarball (linux) / zip (darwin) sha256.
+ETCD_SHA256_linux_amd64=7692f812db0bfeee3a731c45046864cf729e552bad82ce7cb5b507053d033267
+ETCD_SHA256_linux_arm64=10817d916de91fdab373947977682e083f0a1ac7f37650c1b690c2a746e4c269
+ETCD_SHA256_darwin_amd64=68ea4387a423e1c22766e8c0e959bdf3dc9d61f560df3e6eb02a52ff392ee065
+ETCD_SHA256_darwin_arm64=4b88183feaf7449abdddeb1ae21002917d32da851c717da0eaabe587f1c4e903
+
+# sha256 of the SHA256SUMS file itself at pin time. Defense in depth
+# against post-publication substitution: an attacker replacing just the
+# tarball would fail the per-platform sha check; replacing tarball +
+# SHA256SUMS would fail this hash; replacing both with content that
+# collides on both hashes is cryptographically infeasible.
+ETCD_SHA256SUMS_SHA256=9b7990400179fe94c647e32485fcd0468b5e0f0396d3b08fef23c3fbca530de4

--- a/benches/oracles/etcd/fetch.sh
+++ b/benches/oracles/etcd/fetch.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# benches/oracles/etcd/fetch.sh
+#
+# Downloads the etcd oracle binary pinned in VERSIONS and verifies its
+# sha256 against the locally-committed hash. Also fetches the release's
+# SHA256SUMS file and verifies both (a) the file's own sha against the
+# pin, and (b) that the file agrees with us on the tarball hash. See
+# README.md for the full TOFU threat model.
+#
+# Usage: fetch.sh [dest-dir]
+#   dest-dir  where to place the downloaded artifact. Defaults to
+#             `./cache` relative to this script's directory.
+#
+# Exit codes:
+#   0  artifact downloaded and verified; path printed on stdout
+#   1  any step failed (network, hash mismatch, missing pin)
+#
+# Testable: `verify_sha <file> <expected-hex>` is exported as a
+# function when this script is sourced. See scripts/test-bench-oracle-fetch.sh.
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../runner/hwsig-lib.sh
+. "$_here/../../runner/hwsig-lib.sh"
+
+# verify_sha <file> <expected-hex>
+#   Returns 0 on match, 1 on mismatch. On mismatch, prints both
+#   hashes to stderr. Uses the cross-platform sha256_of helper.
+verify_sha() {
+    local file="$1" expected="$2" actual
+    actual=$(sha256_of "$file") || return 1
+    if [ "$actual" != "$expected" ]; then
+        echo "verify_sha: hash mismatch for $file" >&2
+        echo "  expected: $expected" >&2
+        echo "  actual:   $actual" >&2
+        return 1
+    fi
+    return 0
+}
+
+# resolve_platform_key
+#   Prints the VERSIONS key for the current platform (e.g.
+#   ETCD_SHA256_linux_amd64). Errors out on unsupported platforms.
+resolve_platform_key() {
+    local os arch
+    os=$(uname_os_normalize) || return 1
+    arch=$(uname_arch_normalize) || return 1
+    printf 'ETCD_SHA256_%s_%s' "$os" "$arch"
+}
+
+# platform_extension <os>
+#   Etcd uses .tar.gz for linux and .zip for darwin.
+platform_extension() {
+    case "$1" in
+        linux)  echo tar.gz ;;
+        darwin) echo zip ;;
+        *)      echo "platform_extension: unsupported os: $1" >&2; return 1 ;;
+    esac
+}
+
+# do_fetch [dest-dir]
+#   The real entry point. Extracted from main so the test suite can
+#   exercise verify_sha in isolation without running the full
+#   download.
+do_fetch() {
+    local dest="${1:-$_here/cache}"
+    mkdir -p "$dest"
+
+    # Load pins.
+    # shellcheck source=./VERSIONS
+    . "$_here/VERSIONS"
+
+    local key
+    key=$(resolve_platform_key)
+    local expected_sha="${!key:-}"
+    if [ -z "$expected_sha" ]; then
+        echo "fetch.sh: no pinned sha for platform key '$key'" >&2
+        echo "  add to $_here/VERSIONS and rerun" >&2
+        return 1
+    fi
+
+    local os arch ext
+    os=$(uname_os_normalize)
+    arch=$(uname_arch_normalize)
+    ext=$(platform_extension "$os")
+
+    local artifact_name="etcd-${ETCD_VERSION}-${os}-${arch}.${ext}"
+    local artifact_url="https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/${artifact_name}"
+    local artifact_path="$dest/$artifact_name"
+
+    echo "fetch.sh: downloading $artifact_url" >&2
+    if ! curl -fsSL "$artifact_url" -o "$artifact_path"; then
+        echo "fetch.sh: download failed" >&2
+        return 1
+    fi
+
+    echo "fetch.sh: verifying tarball sha against VERSIONS" >&2
+    verify_sha "$artifact_path" "$expected_sha" || return 1
+
+    # Defense-in-depth: also verify SHA256SUMS's own sha, and that it
+    # agrees with us on the tarball.
+    local sums_url="https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/SHA256SUMS"
+    local sums_path="$dest/SHA256SUMS"
+    echo "fetch.sh: downloading $sums_url" >&2
+    if ! curl -fsSL "$sums_url" -o "$sums_path"; then
+        echo "fetch.sh: SHA256SUMS download failed" >&2
+        return 1
+    fi
+
+    echo "fetch.sh: verifying SHA256SUMS sha against VERSIONS" >&2
+    verify_sha "$sums_path" "$ETCD_SHA256SUMS_SHA256" || return 1
+
+    echo "fetch.sh: cross-checking SHA256SUMS agrees on tarball hash" >&2
+    local sums_entry
+    sums_entry=$(awk -v name="$artifact_name" '$2 == name { print $1 }' "$sums_path")
+    if [ -z "$sums_entry" ]; then
+        echo "fetch.sh: SHA256SUMS has no entry for $artifact_name" >&2
+        return 1
+    fi
+    if [ "$sums_entry" != "$expected_sha" ]; then
+        echo "fetch.sh: SHA256SUMS disagrees with VERSIONS on $artifact_name" >&2
+        echo "  VERSIONS:     $expected_sha" >&2
+        echo "  SHA256SUMS:   $sums_entry" >&2
+        return 1
+    fi
+
+    echo "fetch.sh: ok, verified $artifact_path" >&2
+    printf '%s\n' "$artifact_path"
+}
+
+# When executed directly (not sourced), run the full fetch.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    do_fetch "$@"
+fi

--- a/benches/runner/HARDWARE.md
+++ b/benches/runner/HARDWARE.md
@@ -1,0 +1,151 @@
+# Bench hardware tiers
+
+Every bench result mango publishes — in ROADMAP.md, in `benches/results/`,
+in release notes, or in a paper — MUST carry a declared hardware tier
+and the matching hardware signature line (see
+`benches/runner/hardware-signature.sh`). A number without a tier
+annotation is not a number.
+
+This document defines two tiers. They are the envelope: a rig meeting
+Tier 1 is allowed to produce single-node and 3-node numbers; a fleet
+meeting Tier 2 is allowed to produce multi-node / chaos / release-gate
+numbers. Running a Tier 2 acceptance bench on a Tier 1 rig produces an
+invalid result.
+
+## Supported platforms
+
+The bench harness supports Linux and macOS on amd64 and arm64. Keep
+this table in sync with `benches/oracles/etcd/VERSIONS` — the drift
+test in `scripts/test-bench-oracle-fetch.sh` enforces that every
+supported platform has a pinned etcd hash.
+
+| OS     | Arch  |
+| ------ | ----- |
+| linux  | amd64 |
+| linux  | arm64 |
+| darwin | amd64 |
+| darwin | arm64 |
+
+## Tier 1 — single-node bench rig
+
+Used for Phases 2–13 single-node and 3-node bench results.
+
+### Hardware requirements
+
+- 1 host.
+- ≥ 16 physical cores (32 vCPU with SMT acceptable).
+- ≥ 64 GB RAM.
+- NVMe SSD, ≥ 500 GB free.
+- ≥ 2 memory channels populated (DDR4 or DDR5). ≥ 4 strongly preferred
+  for the Raft log-replay path, which is memory-bandwidth-bound.
+- Linux kernel ≥ 5.15, **or** macOS 14+ on Apple Silicon
+  (M1 Pro/Max/Ultra, M2, M3, M4 — recorded in the signature as
+  `cpu=Apple M*`).
+
+### Operator-configured (Linux, mandatory)
+
+- No swap during benches: `swapoff -a`.
+- CPU governor `performance`: `cpupower frequency-set -g performance`.
+- Turbo/frequency pinning: `intel_pstate=disable` in the kernel
+  cmdline or `cpupower frequency-set -u <max>`. The signature records
+  `turbo=` and `cpu_mhz_max=` so results can be filtered by state.
+- TSC flags: `/proc/cpuinfo` MUST report both `constant_tsc` and
+  `nonstop_tsc`. If either is missing, `Instant::now()` is unreliable
+  on this host and **this rig is not Tier 1** — do not use it.
+  The signature records `tsc=invariant|variable`.
+
+### Operator-configured (Linux, bench-class dependent)
+
+- **Isolated cores (required for tail-latency benches):**
+  `isolcpus=4-15 nohz_full=4-15 rcu_nocbs=4-15` (adjust range to the
+  rig's core count). Throughput benches MAY skip this but the
+  signature will still report the scheduler state.
+- **Block device scheduler:** `mq-deadline` (or `none` for NVMe where
+  the device manages its own queue). `nr_requests=1024` on the root
+  block device. Signature field: `scheduler=`.
+
+### Operator-configured (macOS, best-effort)
+
+macOS does not expose CPU-governor, turbo, or scheduler knobs the
+same way Linux does. The signature reports `turbo=unknown`,
+`scheduler=unknown`, `mem_channels=0` on Darwin by design; the
+signature is honest about what is knowable. macOS on Apple Silicon
+has invariant TSC (reported as `tsc=invariant`) and that is the
+load-bearing property for `Instant` math.
+
+macOS Tier 1 is acceptable for single-node throughput and
+single-latency benches. It is NOT acceptable for Tier 2 or for the
+Phase 12 release gate.
+
+## Tier 2 — multi-node fleet
+
+Used for Phase 14.5 chaos tests and the Phase 12 release gate.
+Available only on Linux.
+
+### Hardware requirements
+
+- ≥ 10 hosts, each meeting Tier 1 spec.
+- ≥ 5 voter nodes + ≥ 5 learner/follower nodes.
+- ≥ 25 GbE intra-cluster bandwidth, measured with `iperf3` at the
+  start of every run and recorded in the run log.
+- Root access on every host for `tc qdisc` and `iptables` (or a
+  `toxiproxy` install on each host — pick one fault-injection
+  mechanism per run).
+- All hosts in one physical rack / one AZ. Cross-AZ benches are a
+  separate tier, out of scope for this document.
+
+### Clock synchronization (required)
+
+- PTP via `ptp4l` + `phc2sys` preferred; chronyd with `maxpoll 4`
+  against a rack-local NTP server is an acceptable fallback.
+- Cross-host drift MUST be `< 1ms` during the bench window.
+- Pre-roll: every host samples `chronyc tracking` or
+  `pmc -u -b 0 'GET CURRENT_DATA_SET'`; max offset is logged.
+
+### Bandwidth measurement
+
+Every run records the result of `iperf3 -c <neighbor> -t 10` between
+each voter pair (or a representative mesh). Numbers below 20 Gbit/s
+on a 25 GbE fabric are a sign of link-layer degradation and should
+invalidate the run.
+
+## Tier contamination rules
+
+- **Every host in a multi-node bench emits its own signature.**
+  Analysis tools MUST assert all host signatures agree on `cpu`,
+  `cores`, `ram_gb`, `storage`, and `tier` before aggregating. A
+  mixed-tier cluster silently averages into a nonsense number.
+- **Single-node benches on a Tier 2 host are allowed**, with
+  `BENCH_TIER=1` and operator-asserted isolation (no other bench
+  workload on neighbors during the run). Document the isolation
+  assertion in the result file.
+- **`BENCH_TIER=3` or any value outside `{1, 2}` is a hard error**
+  enforced by `hardware-signature.sh`.
+- **`BENCH_TIER` unset when running an actual bench is a hard error**
+  enforced by `run.sh`. It is a soft warning (signature shows
+  `tier=unknown`) when wrapping non-bench commands for diagnostics.
+
+## Declaring a run
+
+1. Set `BENCH_TIER=1` or `BENCH_TIER=2`.
+2. Optionally set `BENCH_OUT_DIR=path/to/results` — the runner will
+   write a `signature.txt` there.
+3. Invoke the bench via `benches/runner/run.sh <command...>`.
+4. The signature goes to stderr (stdout stays clean for
+   criterion/hyperfine JSON output); the sidecar file carries the
+   same content for downstream correlation.
+
+Example:
+
+```bash
+BENCH_TIER=1 BENCH_OUT_DIR=out/throughput \
+    benches/runner/run.sh cargo bench --bench write_throughput -- --baseline main
+```
+
+## Changing this document
+
+This document's requirements feed into the Phase 12 release gate.
+Additions (new signature fields, new tier requirements) MUST bump the
+signature version (`BENCH_HW v1:` → `BENCH_HW v2:`) so old results
+remain interpretable. Removing requirements is effectively never
+compatible — open an RFC before relaxing a tier.

--- a/benches/runner/hardware-signature.sh
+++ b/benches/runner/hardware-signature.sh
@@ -67,18 +67,26 @@ _field_cpu() {
 }
 
 _field_cpu_mhz_max() {
-    # Never emit an empty value — the canonical form requires every
-    # field to have a non-empty value so space-separated parsing
-    # stays unambiguous. Fall through lscpu -> /proc/cpuinfo -> 0.
-    # Azure VMs and many containers have lscpu but no "CPU max MHz".
+    # The max nominal clock, in MHz. MUST be stable across runs on the
+    # same host (this field is part of the signature's deterministic
+    # identity). We explicitly avoid `/proc/cpuinfo` "cpu MHz", which
+    # is the *current* cpufreq-governor reading and fluctuates.
+    #
+    # Sources, in order of preference:
+    #   Linux: lscpu "CPU max MHz", then /sys/.../cpuinfo_max_freq (kHz).
+    #   Darwin: sysctl hw.cpufrequency_max (Hz). Apple Silicon returns 0.
+    #   Fallback: 0. Azure-class VMs and many containers have no stable
+    #   max, and an honest 0 beats a jittery runtime value.
     local v=""
     case "$(uname -s)" in
         Linux)
             if command -v lscpu >/dev/null 2>&1; then
                 v=$(lscpu 2>/dev/null | awk -F': +' '/CPU max MHz/ { printf "%d", $2; exit }')
             fi
-            if [ -z "$v" ] && [ -r /proc/cpuinfo ]; then
-                v=$(awk -F': ' '/cpu MHz/ { printf "%d", $2; exit }' /proc/cpuinfo 2>/dev/null)
+            if [ -z "$v" ] && [ -r /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq ]; then
+                local khz
+                khz=$(cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq 2>/dev/null)
+                [ -n "$khz" ] && v=$(( khz / 1000 ))
             fi
             ;;
         Darwin)

--- a/benches/runner/hardware-signature.sh
+++ b/benches/runner/hardware-signature.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+# benches/runner/hardware-signature.sh
+#
+# Emits a single-line, self-authenticating hardware signature for the
+# current host. Every bench run prefaces its output with this line so
+# results carry their own provenance.
+#
+# Format (canonical form v1):
+#
+#   BENCH_HW v1: <field=value ...> sha=<64-hex>
+#
+# Fields are sorted lexically by key and shell-escaped (spaces -> \ ).
+# The sha is computed over the canonical-form bytes with NO "sha="
+# segment included (see canonicalize() below). This makes the line
+# tamper-evident against accidental corruption; it is NOT a security
+# property — a malicious actor would just recompute the hash. See
+# benches/README.md for the threat model.
+#
+# Environment:
+#   BENCH_TIER  required for real benches; 1 or 2. Unset → tier=unknown
+#               (warning). Value other than 1|2 → hard error.
+#
+# Exit codes:
+#   0  signature emitted on stdout
+#   1  unsupported platform or invalid BENCH_TIER
+#
+# Runnable directly for diagnostics (`./hardware-signature.sh`) or
+# sourced for testing (`. hardware-signature.sh; emit_signature`).
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./hwsig-lib.sh
+. "$_here/hwsig-lib.sh"
+
+# ---------------------------------------------------------------------
+# Field collectors. Each function prints one value on stdout, nothing
+# else. Errors go to stderr; the field becomes "unknown" or "0"
+# rather than aborting — the signature should describe what is
+# knowable, not die on best-effort fields.
+# ---------------------------------------------------------------------
+
+_field_os()       { uname_os_normalize; }
+_field_arch()     { uname_arch_normalize; }
+_field_kernel()   { uname -r; }
+
+_field_cores() {
+    case "$(uname -s)" in
+        Linux)  nproc 2>/dev/null || echo 0 ;;
+        Darwin) sysctl -n hw.physicalcpu 2>/dev/null || echo 0 ;;
+        *)      echo 0 ;;
+    esac
+}
+
+_field_cpu() {
+    local raw
+    case "$(uname -s)" in
+        Linux)
+            raw=$(awk -F': ' '/^model name/ { print $2; exit }' /proc/cpuinfo 2>/dev/null || true)
+            ;;
+        Darwin)
+            raw=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || true)
+            ;;
+    esac
+    [ -z "$raw" ] && raw=unknown
+    trim_ws "$raw"
+}
+
+_field_cpu_mhz_max() {
+    case "$(uname -s)" in
+        Linux)
+            if command -v lscpu >/dev/null 2>&1; then
+                lscpu 2>/dev/null | awk -F': +' '/CPU max MHz/ { printf "%d", $2; exit }' || echo 0
+            else
+                awk -F': ' '/cpu MHz/ { printf "%d", $2; exit }' /proc/cpuinfo 2>/dev/null || echo 0
+            fi
+            ;;
+        Darwin)
+            local hz
+            hz=$(sysctl -n hw.cpufrequency_max 2>/dev/null || echo 0)
+            # Apple Silicon doesn't export hw.cpufrequency_max (returns 0).
+            echo $(( hz / 1000000 ))
+            ;;
+        *) echo 0 ;;
+    esac
+}
+
+_field_ram_gb() {
+    case "$(uname -s)" in
+        Linux)
+            awk '/^MemTotal:/ { printf "%d", int($2 / 1024 / 1024) }' /proc/meminfo 2>/dev/null || echo 0
+            ;;
+        Darwin)
+            local bytes
+            bytes=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
+            echo $(( bytes / 1024 / 1024 / 1024 ))
+            ;;
+        *) echo 0 ;;
+    esac
+}
+
+_field_storage() {
+    case "$(uname -s)" in
+        Linux)
+            # Primary block device = the one backing `/`. lsblk -no PKNAME
+            # gives the parent kernel name; fall back to sdX/nvmeXnY.
+            local root_dev pkname model
+            root_dev=$(findmnt -no SOURCE / 2>/dev/null || echo "")
+            [ -z "$root_dev" ] && { echo unknown; return; }
+            pkname=$(lsblk -no PKNAME "$root_dev" 2>/dev/null | head -n1)
+            [ -z "$pkname" ] && pkname=$(basename "$root_dev")
+            model=$(lsblk -dno MODEL "/dev/$pkname" 2>/dev/null | head -n1 || echo "")
+            trim_ws "${model:-unknown}"
+            ;;
+        Darwin)
+            # diskutil info / doesn't exist; get root device first.
+            local root_dev model
+            root_dev=$(df / 2>/dev/null | awk 'NR==2 {print $1}')
+            if [ -n "$root_dev" ]; then
+                model=$(diskutil info "$root_dev" 2>/dev/null \
+                    | awk -F': +' '/Device \/ Media Name|Media Name/ { print $2; exit }' \
+                    || echo "")
+                trim_ws "${model:-unknown}"
+            else
+                echo unknown
+            fi
+            ;;
+        *) echo unknown ;;
+    esac
+}
+
+_field_scheduler() {
+    case "$(uname -s)" in
+        Linux)
+            local root_dev pkname sched_file
+            root_dev=$(findmnt -no SOURCE / 2>/dev/null || echo "")
+            [ -z "$root_dev" ] && { echo unknown; return; }
+            pkname=$(lsblk -no PKNAME "$root_dev" 2>/dev/null | head -n1)
+            [ -z "$pkname" ] && pkname=$(basename "$root_dev")
+            sched_file="/sys/block/$pkname/queue/scheduler"
+            if [ -r "$sched_file" ]; then
+                # File contains `[active] alt1 alt2` — extract the bracketed one.
+                sed -n 's/.*\[\([^]]*\)\].*/\1/p' "$sched_file" | head -n1 || echo unknown
+            else
+                echo unknown
+            fi
+            ;;
+        *) echo unknown ;;
+    esac
+}
+
+_field_tsc() {
+    case "$(uname -s)" in
+        Linux)
+            if grep -qw constant_tsc /proc/cpuinfo 2>/dev/null \
+               && grep -qw nonstop_tsc /proc/cpuinfo 2>/dev/null; then
+                echo invariant
+            else
+                echo variable
+            fi
+            ;;
+        Darwin)
+            # Apple Silicon and recent Intel Macs all have invariant TSC.
+            echo invariant
+            ;;
+        *) echo unknown ;;
+    esac
+}
+
+_field_turbo() {
+    case "$(uname -s)" in
+        Linux)
+            local f=/sys/devices/system/cpu/intel_pstate/no_turbo
+            if [ -r "$f" ]; then
+                case "$(cat "$f")" in
+                    1) echo disabled ;;
+                    0) echo enabled  ;;
+                    *) echo unknown  ;;
+                esac
+            else
+                echo unknown
+            fi
+            ;;
+        *) echo unknown ;;
+    esac
+}
+
+_field_mem_channels() {
+    # Best-effort, root-only via dmidecode. Returns 0 when unknown.
+    case "$(uname -s)" in
+        Linux)
+            if command -v dmidecode >/dev/null 2>&1 && [ "$(id -u)" = "0" ]; then
+                # Count populated Memory Device entries with a non-null size.
+                dmidecode -t memory 2>/dev/null \
+                    | awk '/^Memory Device$/ { in_dev=1; next }
+                           in_dev && /^Size: / && $2 != "No" && $2 != "Unknown" { count++; in_dev=0 }
+                           in_dev && /^$/ { in_dev=0 }
+                           END { print count+0 }'
+            else
+                echo 0
+            fi
+            ;;
+        *) echo 0 ;;
+    esac
+}
+
+_field_virt() {
+    case "$(uname -s)" in
+        Linux)
+            if command -v systemd-detect-virt >/dev/null 2>&1; then
+                local v
+                v=$(systemd-detect-virt 2>/dev/null || echo none)
+                [ "$v" = "none" ] && echo bare-metal || echo "$v"
+            else
+                echo unknown
+            fi
+            ;;
+        Darwin)
+            local v
+            v=$(sysctl -n kern.hv_vmm_present 2>/dev/null || echo "")
+            case "$v" in
+                1) echo vmm ;;
+                0) echo bare-metal ;;
+                *) echo bare-metal ;;  # pre-Big-Sur: field absent -> assume bare-metal
+            esac
+            ;;
+        *) echo unknown ;;
+    esac
+}
+
+# ---------------------------------------------------------------------
+# Tier validation (R4 rule)
+# ---------------------------------------------------------------------
+
+# validate_tier_argv "$@"
+#   Validates BENCH_TIER against the caller's argv. No stdout output —
+#   intended to be called at a script's top level so that `exit`
+#   propagates to the user's shell. Call this BEFORE any `$(...)`
+#   subshell that would otherwise swallow the exit.
+#
+#   Errors:
+#     BENCH_TIER unset + argv has `bench` token  → exit 2
+#     BENCH_TIER set but not in {1,2}            → exit 1
+validate_tier_argv() {
+    local tier="${BENCH_TIER:-}"
+    case "$tier" in
+        1|2) return 0 ;;
+        "")
+            local looks_like_bench=0
+            for a in "$@"; do
+                case "$a" in
+                    bench|*--bench*|*cargo*bench*) looks_like_bench=1 ;;
+                esac
+            done
+            if [ "$looks_like_bench" = 1 ]; then
+                echo "error: BENCH_TIER must be set to 1 or 2 when running benches" >&2
+                exit 2
+            fi
+            # Soft-warn path: warning emitted by resolve_tier_value on
+            # the actual signature-emission call. Don't double-warn here.
+            return 0
+            ;;
+        *)
+            echo "error: BENCH_TIER='$tier' is invalid; must be 1 or 2" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# resolve_tier_value
+#   Returns the tier value on stdout. Called from inside the
+#   signature-emission subshell, so this function does NOT exit on
+#   error — validate_tier_argv is expected to have run first at the
+#   top level. On bad input it still prints a warning + returns
+#   "unknown" so the signature remains emitable.
+resolve_tier_value() {
+    local tier="${BENCH_TIER:-}"
+    case "$tier" in
+        1|2) printf '%s' "$tier" ;;
+        "")
+            echo "warning: BENCH_TIER unset; signature will report tier=unknown" >&2
+            printf 'unknown'
+            ;;
+        *)
+            # Shouldn't happen if validate_tier_argv ran, but be
+            # defensive — emit unknown rather than hang or crash.
+            echo "warning: BENCH_TIER='$tier' invalid; signature will report tier=unknown" >&2
+            printf 'unknown'
+            ;;
+    esac
+}
+
+# resolve_tier "$@"
+#   Compatibility shim for direct invocations of hardware-signature.sh
+#   (no wrapper). Validates THEN resolves. Exits on hard-fail cases.
+resolve_tier() {
+    validate_tier_argv "$@"
+    resolve_tier_value
+}
+
+# ---------------------------------------------------------------------
+# Canonicalization + signature assembly
+# ---------------------------------------------------------------------
+
+# canonicalize_fields
+#   Reads key=value pairs on stdin (one per line), trims whitespace
+#   from values, shell-escapes them, sorts by key, joins with single
+#   spaces, and prints the result with no trailing newline.
+canonicalize_fields() {
+    awk -F= '
+        NF >= 2 {
+            key = $1
+            # Reassemble value (in case value contained =).
+            val = $2
+            for (i = 3; i <= NF; i++) val = val "=" $i
+            print key "\t" val
+        }
+    ' | LC_ALL=C sort -k1,1 -t$'\t' \
+      | while IFS=$'\t' read -r key val; do
+            val=$(trim_ws "$val")
+            val=$(value_encode "$val")
+            printf '%s=%s ' "$key" "$val"
+        done \
+      | sed 's/ $//'
+}
+
+# emit_signature [argv ...]
+#   Collects all fields, runs canonicalize_fields, computes sha,
+#   prints the full `BENCH_HW v1: ... sha=...` line to stdout.
+emit_signature() {
+    local tier
+    tier=$(resolve_tier_value)
+
+    local fields
+    fields=$(cat <<EOF
+os=$(_field_os)
+arch=$(_field_arch)
+kernel=$(_field_kernel)
+cores=$(_field_cores)
+cpu=$(_field_cpu)
+cpu_mhz_max=$(_field_cpu_mhz_max)
+ram_gb=$(_field_ram_gb)
+storage=$(_field_storage)
+scheduler=$(_field_scheduler)
+tsc=$(_field_tsc)
+turbo=$(_field_turbo)
+mem_channels=$(_field_mem_channels)
+virt=$(_field_virt)
+tier=$tier
+EOF
+)
+    local canonical sha
+    canonical=$(printf '%s\n' "$fields" | canonicalize_fields)
+    sha=$(sha256_of_string "$canonical")
+    printf 'BENCH_HW v1: %s sha=%s\n' "$canonical" "$sha"
+}
+
+# When executed directly (not sourced), validate at top level (so
+# exit propagates) and then emit the signature.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    validate_tier_argv "$@"
+    emit_signature
+fi

--- a/benches/runner/hardware-signature.sh
+++ b/benches/runner/hardware-signature.sh
@@ -67,22 +67,28 @@ _field_cpu() {
 }
 
 _field_cpu_mhz_max() {
+    # Never emit an empty value — the canonical form requires every
+    # field to have a non-empty value so space-separated parsing
+    # stays unambiguous. Fall through lscpu -> /proc/cpuinfo -> 0.
+    # Azure VMs and many containers have lscpu but no "CPU max MHz".
+    local v=""
     case "$(uname -s)" in
         Linux)
             if command -v lscpu >/dev/null 2>&1; then
-                lscpu 2>/dev/null | awk -F': +' '/CPU max MHz/ { printf "%d", $2; exit }' || echo 0
-            else
-                awk -F': ' '/cpu MHz/ { printf "%d", $2; exit }' /proc/cpuinfo 2>/dev/null || echo 0
+                v=$(lscpu 2>/dev/null | awk -F': +' '/CPU max MHz/ { printf "%d", $2; exit }')
+            fi
+            if [ -z "$v" ] && [ -r /proc/cpuinfo ]; then
+                v=$(awk -F': ' '/cpu MHz/ { printf "%d", $2; exit }' /proc/cpuinfo 2>/dev/null)
             fi
             ;;
         Darwin)
             local hz
             hz=$(sysctl -n hw.cpufrequency_max 2>/dev/null || echo 0)
-            # Apple Silicon doesn't export hw.cpufrequency_max (returns 0).
-            echo $(( hz / 1000000 ))
+            v=$(( hz / 1000000 ))
             ;;
-        *) echo 0 ;;
     esac
+    [ -z "$v" ] && v=0
+    printf '%s' "$v"
 }
 
 _field_ram_gb() {

--- a/benches/runner/hwsig-lib.sh
+++ b/benches/runner/hwsig-lib.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# benches/runner/hwsig-lib.sh
+#
+# Portable helpers shared by the bench-harness shell scripts. Sourced,
+# never executed directly. Responsible for the cross-platform concerns
+# that would otherwise be scattered across fetch.sh, run.sh, and
+# hardware-signature.sh.
+#
+# All functions print their answer on stdout and return 0/1 for
+# success/failure. Diagnostics go to stderr.
+#
+# Shell dialect: bash, no bashisms beyond what's portable to bash 3.2
+# (macOS's system bash). No arrays-of-arrays, no `readarray`.
+
+# sha256_of <file>
+#
+# Prints the hex sha256 digest of <file> on stdout, nothing else.
+# Picks the right tool per platform: `sha256sum` on Linux (coreutils),
+# `shasum -a 256` on macOS (ships by default as a Perl script).
+sha256_of() {
+    local file="$1"
+    if [ ! -r "$file" ]; then
+        echo "sha256_of: cannot read file: $file" >&2
+        return 1
+    fi
+    case "$(uname -s)" in
+        Linux)
+            if command -v sha256sum >/dev/null 2>&1; then
+                sha256sum "$file" | cut -d' ' -f1
+            else
+                echo "sha256_of: sha256sum not found on Linux; install coreutils" >&2
+                return 1
+            fi
+            ;;
+        Darwin)
+            if command -v shasum >/dev/null 2>&1; then
+                shasum -a 256 "$file" | cut -d' ' -f1
+            else
+                echo "sha256_of: shasum not found on macOS (should ship by default)" >&2
+                return 1
+            fi
+            ;;
+        *)
+            echo "sha256_of: unsupported platform: $(uname -s)" >&2
+            return 1
+            ;;
+    esac
+}
+
+# sha256_of_string <string>
+#
+# Prints the hex sha256 digest of the string (no trailing newline in
+# the hashed input). Uses a temp file because `printf | sha256sum` has
+# subtle cross-platform buffering differences and we want the hash
+# path to be identical to sha256_of's.
+sha256_of_string() {
+    local tmp
+    tmp=$(mktemp)
+    printf '%s' "$1" > "$tmp"
+    local digest
+    digest=$(sha256_of "$tmp") || { rm -f "$tmp"; return 1; }
+    rm -f "$tmp"
+    printf '%s' "$digest"
+}
+
+# uname_arch_normalize
+#
+# Normalizes `uname -m` output to the names etcd uses in its release
+# artifacts: amd64, arm64. Exits 1 on unknown arch so callers can
+# detect rather than silently get `unknown`.
+uname_arch_normalize() {
+    case "$(uname -m)" in
+        x86_64|amd64)  echo amd64 ;;
+        aarch64|arm64) echo arm64 ;;
+        *)
+            echo "uname_arch_normalize: unsupported arch: $(uname -m)" >&2
+            return 1
+            ;;
+    esac
+}
+
+# uname_os_normalize
+#
+# Lowercases `uname -s` and restricts to {linux, darwin}. Exits 1 on
+# anything else (Windows, BSDs) so the scaffold fails loudly.
+uname_os_normalize() {
+    case "$(uname -s)" in
+        Linux)  echo linux ;;
+        Darwin) echo darwin ;;
+        *)
+            echo "uname_os_normalize: unsupported OS: $(uname -s)" >&2
+            return 1
+            ;;
+    esac
+}
+
+# trim_ws <string>
+#
+# Strips leading and trailing whitespace (spaces and tabs) from the
+# argument. Required before hashing field values because /proc/cpuinfo's
+# `model name` is tab-padded on some distros and the padding varies by
+# kernel version.
+trim_ws() {
+    # Parameter-expansion based strip — portable to bash 3.2.
+    local s="$1"
+    # Leading
+    s="${s#"${s%%[![:space:]]*}"}"
+    # Trailing
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+# value_encode <string>
+#
+# Percent-encodes a signature field value so it contains no
+# whitespace and no field-separator characters. This is what makes
+# space-separated field parsing safe without quoting: the encoded
+# value is guaranteed to be a single shell-word.
+#
+# Encoding is minimal (not full RFC 3986) — only characters that would
+# break the BENCH_HW line format are encoded:
+#   `%` → `%25`  (must be first, or subsequent escapes collide)
+#   ` ` → `%20`
+#   TAB → `%09`
+#   `=` → `%3D`  (so a value can't accidentally look like a new key)
+#
+#   value_encode "AMD EPYC 7B13"  →  AMD%20EPYC%207B13
+value_encode() {
+    local s="$1"
+    s="${s//%/%25}"
+    s="${s// /%20}"
+    s="${s//	/%09}"
+    s="${s//=/%3D}"
+    printf '%s' "$s"
+}

--- a/benches/runner/run.sh
+++ b/benches/runner/run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# benches/runner/run.sh
+#
+# Wraps a bench command. Emits the hardware signature to stderr (so
+# stdout stays clean for JSON-producing bench tools like criterion
+# --output-format=json or hyperfine --export-json) and, if
+# BENCH_OUT_DIR is set, also writes the signature to
+# $BENCH_OUT_DIR/signature.txt for downstream correlation.
+#
+# Environment:
+#   BENCH_TIER     required when argv looks like a bench; see
+#                  hardware-signature.sh for the rule.
+#   BENCH_OUT_DIR  optional; if set, signature is ALSO written to
+#                  $BENCH_OUT_DIR/signature.txt.
+#
+# Exit code: whatever the wrapped command returns. If no argv is
+# provided, exits 0 after emitting the signature (so `run.sh` can be
+# used to print a bare signature for result-file headers).
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./hardware-signature.sh
+. "$_here/hardware-signature.sh"
+
+# Validate tier at the top level (not inside the `$(...)` subshell
+# below) so a hard-fail exit propagates to our caller. Gates
+# `run.sh cargo bench` with BENCH_TIER unset from ever starting the
+# wrapped command.
+validate_tier_argv "$@"
+
+sig=$(emit_signature)
+
+# Signature always goes to stderr so stdout stays clean.
+printf '%s\n' "$sig" >&2
+
+# Sidecar file for downstream tooling that correlates results.
+if [ -n "${BENCH_OUT_DIR:-}" ]; then
+    mkdir -p "$BENCH_OUT_DIR"
+    printf '%s\n' "$sig" > "$BENCH_OUT_DIR/signature.txt"
+fi
+
+# No argv → just print the signature and return.
+if [ "$#" -eq 0 ]; then
+    exit 0
+fi
+
+# Forward the command as-is; its exit code is ours.
+exec "$@"

--- a/scripts/test-bench-oracle-fetch.sh
+++ b/scripts/test-bench-oracle-fetch.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# scripts/test-bench-oracle-fetch.sh
+#
+# Tests for benches/oracles/etcd/fetch.sh:
+#   Part A — verify_sha accepts a correct hash and rejects a mutated one.
+#   Part B — VERSIONS ↔ HARDWARE.md platform coverage: every supported
+#            platform has a pinned sha, and no stray shas exist.
+#
+# No network. No actual etcd download. The integration path
+# (curl + verify_sha) is one-liner glue; the load-bearing logic is
+# the verifier and the VERSIONS file contents.
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_repo="$(cd "$_here/.." && pwd)"
+
+fetch_sh="$_repo/benches/oracles/etcd/fetch.sh"
+versions="$_repo/benches/oracles/etcd/VERSIONS"
+hardware_md="$_repo/benches/runner/HARDWARE.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "ok: $*"; }
+
+# -----------------------------------------------------------------
+# Part A — verify_sha
+# -----------------------------------------------------------------
+
+# shellcheck source=../benches/oracles/etcd/fetch.sh
+. "$fetch_sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fixture="$tmp/fixture.bin"
+printf 'mango-bench-harness-fixture\n' > "$fixture"
+correct=$(sha256_of "$fixture")
+
+# A1: correct sha passes.
+if verify_sha "$fixture" "$correct" >/dev/null 2>&1; then
+    pass "A1 verify_sha accepts correct hash"
+else
+    fail "A1 verify_sha rejected correct hash"
+fi
+
+# A2: mutated sha fails.
+wrong="0000000000000000000000000000000000000000000000000000000000000000"
+if verify_sha "$fixture" "$wrong" >/dev/null 2>&1; then
+    fail "A2 verify_sha accepted wrong hash"
+else
+    pass "A2 verify_sha rejects wrong hash"
+fi
+
+# A3: nonexistent file fails cleanly.
+if verify_sha "$tmp/nonexistent" "$correct" >/dev/null 2>&1; then
+    fail "A3 verify_sha accepted nonexistent file"
+else
+    pass "A3 verify_sha rejects nonexistent file"
+fi
+
+# -----------------------------------------------------------------
+# Part B — VERSIONS ↔ HARDWARE.md platform coverage
+# -----------------------------------------------------------------
+
+# Extract supported-platform list from HARDWARE.md's table. Accept any
+# whitespace between | separators. The table header row is
+# `| OS | Arch |` so we key off that to find the start.
+#
+# Output: one "os_arch" per line.
+extract_hardware_platforms() {
+    awk '
+        BEGIN { in_table = 0 }
+        /^\| OS[ ]+\| Arch/ { in_table = 1; next }
+        in_table && /^\| ---/ { next }
+        in_table && /^\|/ {
+            gsub(/[ \t]+/, "")
+            # Row looks like |linux|amd64|  → split on |
+            n = split($0, f, "|")
+            # f[1] is empty (leading |), f[2]=os, f[3]=arch, f[4] empty (trailing |)
+            if (n >= 3 && f[2] != "" && f[3] != "") {
+                print f[2] "_" f[3]
+            }
+            next
+        }
+        in_table && !/^\|/ { in_table = 0 }
+    ' "$hardware_md"
+}
+
+# Extract VERSIONS keys of the form ETCD_SHA256_<os>_<arch> (not the
+# file-itself hash, ETCD_SHA256SUMS_SHA256).
+extract_versions_platforms() {
+    awk -F= '
+        /^ETCD_SHA256_[a-z]+_[a-z0-9]+=/ {
+            key = $1
+            # strip ETCD_SHA256_ prefix
+            sub(/^ETCD_SHA256_/, "", key)
+            # exclude SUMS_SHA256 if the regex above missed — it should not
+            if (key == "SUMS_SHA256") next
+            print key
+        }
+    ' "$versions"
+}
+
+hw_platforms=$(extract_hardware_platforms | LC_ALL=C sort -u)
+ver_platforms=$(extract_versions_platforms | LC_ALL=C sort -u)
+
+if [ -z "$hw_platforms" ]; then
+    fail "B parser found no platforms in HARDWARE.md — parser broken or doc restructured"
+fi
+if [ -z "$ver_platforms" ]; then
+    fail "B parser found no ETCD_SHA256_<os>_<arch> keys in VERSIONS"
+fi
+
+# B1: every HARDWARE.md platform has a pinned sha.
+missing_from_versions=$(comm -23 <(echo "$hw_platforms") <(echo "$ver_platforms"))
+if [ -n "$missing_from_versions" ]; then
+    echo "B1 HARDWARE.md lists platforms with no ETCD_SHA256 pin:" >&2
+    printf '  %s\n' $missing_from_versions >&2
+    exit 1
+fi
+pass "B1 every HARDWARE.md platform is pinned in VERSIONS"
+
+# B2: every VERSIONS pin has a declared supported platform.
+extra_in_versions=$(comm -13 <(echo "$hw_platforms") <(echo "$ver_platforms"))
+if [ -n "$extra_in_versions" ]; then
+    echo "B2 VERSIONS pins platforms not listed in HARDWARE.md:" >&2
+    printf '  %s\n' $extra_in_versions >&2
+    exit 1
+fi
+pass "B2 every pinned platform appears in HARDWARE.md"
+
+# B3: ETCD_VERSION is set and looks like vX.Y.Z
+if ! grep -Eq '^ETCD_VERSION=v[0-9]+\.[0-9]+\.[0-9]+$' "$versions"; then
+    fail "B3 ETCD_VERSION missing or malformed in VERSIONS"
+fi
+pass "B3 ETCD_VERSION is present and well-formed"
+
+# B4: ETCD_SHA256SUMS_SHA256 is present and looks like sha256.
+if ! grep -Eq '^ETCD_SHA256SUMS_SHA256=[0-9a-f]{64}$' "$versions"; then
+    fail "B4 ETCD_SHA256SUMS_SHA256 missing or malformed in VERSIONS"
+fi
+pass "B4 ETCD_SHA256SUMS_SHA256 is present and 64-hex"
+
+# B5: every per-platform sha is 64-hex.
+bad=$(awk -F= '/^ETCD_SHA256_[a-z]+_[a-z0-9]+=/ { if ($2 !~ /^[0-9a-f]{64}$/) print $1 }' "$versions")
+if [ -n "$bad" ]; then
+    echo "B5 VERSIONS has malformed sha values:" >&2
+    printf '  %s\n' $bad >&2
+    exit 1
+fi
+pass "B5 all per-platform shas are 64-hex"
+
+echo "all oracle-fetch tests passed"

--- a/scripts/test-bench-run-wrapper.sh
+++ b/scripts/test-bench-run-wrapper.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/test-bench-run-wrapper.sh
+#
+# Tests for benches/runner/run.sh:
+#   A — signature goes to stderr, stdout is exactly the wrapped
+#       command's output (no prepended signature line).
+#   B — sidecar signature.txt is written when BENCH_OUT_DIR is set.
+#   C — non-zero exit of the wrapped command propagates.
+#   D — BENCH_TIER unset + bench argv is a hard fail from run.sh
+#       (exit 2, wrapped command never runs).
+#   E — no argv → print signature to stderr and exit 0.
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_repo="$(cd "$_here/.." && pwd)"
+
+run_sh="$_repo/benches/runner/run.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "ok: $*"; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# -----------------------------------------------------------------
+# A — stdout clean, stderr has signature
+# -----------------------------------------------------------------
+
+BENCH_TIER=1 bash "$run_sh" echo hello world \
+    >"$tmp/out" 2>"$tmp/err"
+
+if [ "$(cat "$tmp/out")" != "hello world" ]; then
+    echo "A stdout was not clean:" >&2
+    cat "$tmp/out" >&2
+    exit 1
+fi
+pass "A stdout contains exactly the wrapped command output"
+
+if ! grep -q '^BENCH_HW v1: ' "$tmp/err"; then
+    echo "A stderr missing signature:" >&2
+    cat "$tmp/err" >&2
+    exit 1
+fi
+pass "A stderr contains BENCH_HW signature line"
+
+# -----------------------------------------------------------------
+# B — sidecar signature.txt
+# -----------------------------------------------------------------
+
+outdir="$tmp/outdir"
+BENCH_TIER=1 BENCH_OUT_DIR="$outdir" bash "$run_sh" echo sidecar-test \
+    >/dev/null 2>"$tmp/err2"
+
+if [ ! -f "$outdir/signature.txt" ]; then
+    fail "B BENCH_OUT_DIR set but signature.txt not written"
+fi
+if ! grep -q '^BENCH_HW v1: ' "$outdir/signature.txt"; then
+    fail "B signature.txt content not a BENCH_HW line: $(cat "$outdir/signature.txt")"
+fi
+# Sidecar must match what went to stderr.
+if ! diff -q "$outdir/signature.txt" <(grep '^BENCH_HW v1: ' "$tmp/err2") >/dev/null; then
+    fail "B sidecar content differs from stderr signature"
+fi
+pass "B BENCH_OUT_DIR → signature.txt written and matches stderr"
+
+# -----------------------------------------------------------------
+# C — exit propagation
+# -----------------------------------------------------------------
+
+set +e
+BENCH_TIER=1 bash "$run_sh" false >/dev/null 2>/dev/null
+rc=$?
+set -e
+if [ "$rc" = 0 ]; then
+    fail "C expected non-zero exit from wrapped 'false', got $rc"
+fi
+pass "C non-zero exit of wrapped command propagates (rc=$rc)"
+
+# -----------------------------------------------------------------
+# D — BENCH_TIER unset + bench argv → exit 2 before exec
+# -----------------------------------------------------------------
+
+set +e
+env -u BENCH_TIER bash "$run_sh" cargo bench --bench foo \
+    >"$tmp/d-out" 2>"$tmp/d-err"
+rc=$?
+set -e
+if [ "$rc" != 2 ]; then
+    fail "D expected exit 2, got $rc"
+fi
+if ! grep -q 'BENCH_TIER' "$tmp/d-err"; then
+    fail "D expected BENCH_TIER error on stderr"
+fi
+# The wrapped command must NOT have run — cargo would emit something
+# to stdout or stderr if it had. The stdout must be empty.
+if [ -s "$tmp/d-out" ]; then
+    fail "D wrapped command appears to have run despite BENCH_TIER unset; stdout: $(cat "$tmp/d-out")"
+fi
+pass "D BENCH_TIER unset + bench argv → exit 2, wrapped cmd not executed"
+
+# -----------------------------------------------------------------
+# E — no argv → signature + exit 0
+# -----------------------------------------------------------------
+
+set +e
+BENCH_TIER=1 bash "$run_sh" >"$tmp/e-out" 2>"$tmp/e-err"
+rc=$?
+set -e
+if [ "$rc" != 0 ]; then
+    fail "E expected exit 0 with no argv, got $rc"
+fi
+if ! grep -q '^BENCH_HW v1: ' "$tmp/e-err"; then
+    fail "E no-argv run should emit signature to stderr"
+fi
+if [ -s "$tmp/e-out" ]; then
+    fail "E no-argv run wrote to stdout (should be empty): $(cat "$tmp/e-out")"
+fi
+pass "E no argv → signature on stderr, stdout empty, exit 0"
+
+echo "all run-wrapper tests passed"

--- a/scripts/test-hardware-signature.sh
+++ b/scripts/test-hardware-signature.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# scripts/test-hardware-signature.sh
+#
+# Tests for benches/runner/hardware-signature.sh:
+#   A — line shape: matches the BENCH_HW v1: canonical format.
+#   B — field sorting: keys appear lexically in the output.
+#   C — short-term determinism: re-running in the same shell within
+#       5 seconds produces an identical line.
+#   D — tier handling: unset (soft warn for non-bench argv), invalid
+#       (hard fail), 1 or 2 (ok).
+#   E — canonicalization round-trip: recompute sha from the rest of
+#       the line; assert match.
+
+set -euo pipefail
+
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_repo="$(cd "$_here/.." && pwd)"
+
+sig_sh="$_repo/benches/runner/hardware-signature.sh"
+lib_sh="$_repo/benches/runner/hwsig-lib.sh"
+
+# shellcheck source=../benches/runner/hwsig-lib.sh
+. "$lib_sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "ok: $*"; }
+
+# -----------------------------------------------------------------
+# A — line shape
+# -----------------------------------------------------------------
+
+line_ok=$(BENCH_TIER=1 bash "$sig_sh" 2>/dev/null)
+
+if ! printf '%s' "$line_ok" | grep -Eq '^BENCH_HW v1: ([a-z_]+=[^[:space:]]+ )+sha=[0-9a-f]{64}$'; then
+    echo "A line shape mismatch:" >&2
+    echo "  $line_ok" >&2
+    exit 1
+fi
+pass "A line shape matches BENCH_HW v1 regex"
+
+# -----------------------------------------------------------------
+# B — fields sorted lexically by key
+# -----------------------------------------------------------------
+
+# Strip the "BENCH_HW v1: " prefix and the trailing " sha=..." chunk.
+body=${line_ok#BENCH_HW v1: }
+body_without_sha=${body% sha=*}
+
+prev=""
+while IFS= read -r kv; do
+    key=${kv%%=*}
+    if [ -n "$prev" ] && [ "$prev" \> "$key" ]; then
+        fail "B fields out of order: '$prev' > '$key' in line: $line_ok"
+    fi
+    prev=$key
+done < <(printf '%s\n' "$body_without_sha" | tr ' ' '\n')
+pass "B fields are lexically sorted by key"
+
+# -----------------------------------------------------------------
+# C — short-term determinism
+# -----------------------------------------------------------------
+
+line_again=$(BENCH_TIER=1 bash "$sig_sh" 2>/dev/null)
+if [ "$line_ok" != "$line_again" ]; then
+    echo "C determinism failure (two runs within the same second differ):" >&2
+    echo "  first:  $line_ok" >&2
+    echo "  second: $line_again" >&2
+    exit 1
+fi
+pass "C same-host same-shell run is deterministic"
+
+# -----------------------------------------------------------------
+# D — tier handling
+# -----------------------------------------------------------------
+
+# D1: BENCH_TIER=1 produces tier=1.
+if ! printf '%s' "$line_ok" | grep -q ' tier=1 '; then
+    fail "D1 expected tier=1 in output, got: $line_ok"
+fi
+pass "D1 BENCH_TIER=1 → tier=1"
+
+# D2: BENCH_TIER=2 produces tier=2.
+line_t2=$(BENCH_TIER=2 bash "$sig_sh" 2>/dev/null)
+if ! printf '%s' "$line_t2" | grep -q ' tier=2 '; then
+    fail "D2 expected tier=2, got: $line_t2"
+fi
+pass "D2 BENCH_TIER=2 → tier=2"
+
+# D3: BENCH_TIER unset + non-bench argv produces tier=unknown + stderr warning.
+out=$(env -u BENCH_TIER bash "$sig_sh" 2>/tmp/hwsig-stderr-$$.txt)
+if ! printf '%s' "$out" | grep -q ' tier=unknown '; then
+    rm -f "/tmp/hwsig-stderr-$$.txt"
+    fail "D3 expected tier=unknown in stdout, got: $out"
+fi
+if ! grep -q 'BENCH_TIER unset' "/tmp/hwsig-stderr-$$.txt"; then
+    rm -f "/tmp/hwsig-stderr-$$.txt"
+    fail "D3 expected BENCH_TIER-unset warning on stderr"
+fi
+rm -f "/tmp/hwsig-stderr-$$.txt"
+pass "D3 BENCH_TIER unset → tier=unknown + stderr warning"
+
+# D4: BENCH_TIER=3 is a hard error.
+if BENCH_TIER=3 bash "$sig_sh" >/dev/null 2>&1; then
+    fail "D4 BENCH_TIER=3 should have failed but exited 0"
+fi
+pass "D4 BENCH_TIER=3 → exit non-zero"
+
+# D5: BENCH_TIER unset + argv containing 'bench' is a hard error (exit 2).
+set +e
+env -u BENCH_TIER bash "$sig_sh" cargo bench --bench foo >/dev/null 2>/dev/null
+rc=$?
+set -e
+if [ $rc -ne 2 ]; then
+    fail "D5 expected exit 2 with argv containing 'bench', got $rc"
+fi
+pass "D5 BENCH_TIER unset + bench argv → exit 2"
+
+# -----------------------------------------------------------------
+# E — canonicalization round-trip
+# -----------------------------------------------------------------
+
+# Extract claimed sha.
+claimed=${line_ok##* sha=}
+# body_without_sha computed above.
+recomputed=$(sha256_of_string "$body_without_sha")
+
+if [ "$claimed" != "$recomputed" ]; then
+    echo "E round-trip mismatch:" >&2
+    echo "  line:       $line_ok" >&2
+    echo "  body-hashed: $body_without_sha" >&2
+    echo "  claimed:    $claimed" >&2
+    echo "  recomputed: $recomputed" >&2
+    exit 1
+fi
+pass "E canonicalization round-trip matches"
+
+echo "all hardware-signature tests passed"


### PR DESCRIPTION
## Summary

Implements ROADMAP item **0.10 — Bench oracle harness scaffold**.

Lands the provenance apparatus *before* any "beats etcd by Nx" claim appears in the repo. No benchmarks run from this PR — Phase 2+ consumes the scaffold.

Three coordinated pieces:

### 1. Pinned etcd oracle

`benches/oracles/etcd/`:
- `VERSIONS` — `ETCD_VERSION=v3.5.29` + per-platform sha256 for linux/darwin, amd64/arm64, plus `ETCD_SHA256SUMS_SHA256` (the sha of `SHA256SUMS` itself).
- `fetch.sh` — downloads the tarball, verifies its sha against `VERSIONS`, downloads `SHA256SUMS`, verifies `SHA256SUMS`'s own sha, cross-checks `SHA256SUMS` agrees with `VERSIONS` on the tarball hash. Any disagreement → exit 1.
- Two independent hashes narrow the TOFU window: an attacker substituting the tarball fails the first hash; substituting both tarball + `SHA256SUMS` fails the second; finding content that collides on both is cryptographically infeasible.

### 2. Two hardware tiers

`benches/runner/HARDWARE.md`:
- **Tier 1** (single-node, Phases 2–13): ≥ 16 cores, ≥ 64 GB, NVMe, invariant TSC. Linux turbo / isolcpus / scheduler requirements; macOS Apple Silicon acceptable with best-effort fields.
- **Tier 2** (multi-node, Phase 14.5 chaos + Phase 12 release gate): ≥ 10 hosts, ≥ 25 GbE, root access for tc/iptables, PTP or chronyd clock sync with < 1ms drift. Linux-only.

### 3. Canonical hardware signature (BENCH_HW v1)

```
BENCH_HW v1: arch=arm64 cores=16 cpu=Apple%20M4%20Max cpu_mhz_max=0 kernel=25.3.0 mem_channels=0 os=darwin ram_gb=128 scheduler=unknown storage=unknown tier=1 tsc=invariant turbo=unknown virt=bare-metal sha=74cb37da...
```

- 14 fields, sorted lexically by key, percent-encoded values (so space-separated parsing is unambiguous).
- `sha` is computed over the canonical form **excluding** the `sha=` field (circular). Tamper-evident against accidental corruption, not a security property.
- `run.sh` wraps any command: signature → stderr (stdout stays clean for criterion/hyperfine JSON), optional sidecar at `$BENCH_OUT_DIR/signature.txt`.
- `BENCH_TIER` unset + argv containing `bench`/`--bench`/`cargo bench` → hard fail (exit 2). Unset + other argv → soft warn, `tier=unknown`. Invalid tier (not `1`/`2`) → hard fail.

### Test coverage (five shell test suites, no network)

- `scripts/test-bench-oracle-fetch.sh` — `verify_sha` accept/reject/missing-file; `VERSIONS` ↔ `HARDWARE.md` platform coverage (both directions); `ETCD_VERSION` and sha well-formedness.
- `scripts/test-hardware-signature.sh` — line-shape regex; fields lexically sorted; short-term determinism; tier-handling matrix (1/2/unset/invalid/bench-argv); canonicalization round-trip (extract `sha=`, recompute from rest, assert match).
- `scripts/test-bench-run-wrapper.sh` — stdout clean; signature to stderr; sidecar file; exit propagation; BENCH_TIER hard-fail with bench argv; no-argv mode.

Wired as new `bench-harness` CI job (Ubuntu 24.04, 5-min timeout, no Rust toolchain, no cache) with a belt-and-suspenders `git diff --exit-code benches/oracles/etcd/VERSIONS` step.

### ADR

`.planning/adr/0001-bench-oracle-harness.md` captures the load-bearing decisions: shell-over-Rust (with a concrete port trigger — >150 lines OR first NUMA/hugepages field), TOFU + two-hash defense, env-var tier with asymmetric enforcement, canonical form v1 rules, stderr signature (JSON-output compat), two tiers named now rather than litigated under Phase 14.5 deadline pressure.

## Rust-expert plan review

REVISE verdict returned. Fixed in plan revision before implementation:

- **S1** cross-platform sha256 helper (`sha256sum` Linux vs `shasum -a 256` macOS).
- **S2** signature format fully specified (lexical sort, percent-encoding, trimmed values, sha excludes `sha=` field, v1 version tag for future-compat).
- **S3** tests exercise `VERSIONS` parsing, platform selection, and `linux/aarch64 → linux/arm64` normalization.
- **B1** CI `git diff --exit-code` on `VERSIONS` to catch any test that mutates the pin.
- **B2** TOFU threat model documented; two-hash defense added.
- **B3** determinism claim weakened to "same shell, same boot, within seconds."
- **B4** signature → stderr + sidecar (stdout stays clean for JSON bench tools).
- **R1** `nvme` field dropped (SATA SSDs also `rotational=0`); replaced with `storage=<device-model>`.
- **R2** Tier 1 now requires `tsc=invariant`, explicit turbo/scheduler/isolcpus; Tier 2 clock-sync requirement. All captured in signature fields.
- **R4** `BENCH_TIER` enforcement is asymmetric (hard-fail only for bench argv).
- **R5** concrete Rust-port trigger named in ADR and plan.

## Test plan

- [x] `bash scripts/test-bench-oracle-fetch.sh` passes locally (Darwin arm64)
- [x] `bash scripts/test-hardware-signature.sh` passes locally
- [x] `bash scripts/test-bench-run-wrapper.sh` passes locally
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes
- [x] `cargo test --workspace --all-targets --locked` passes (1/1)
- [ ] CI `bench-harness` job passes on Ubuntu 24.04
- [ ] All other CI jobs still pass (fmt, clippy, test, msrv, deny, cargo-audit)

Closes item 0.10 in ROADMAP.md.
