### PR TITLE
feat(mango-proto): Phase 0 skeleton with tonic-build + hello.proto (0.13)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,19 @@
+# Workspace-wide Cargo configuration.
+#
+# `incompatible-rust-versions = "fallback"` enables the MSRV-aware resolver
+# (stable since Cargo 1.84). When resolving dependencies, Cargo prefers the
+# latest version whose declared `rust-version` is compatible with the
+# workspace's MSRV (`rust-version = "1.80"` in the workspace manifest),
+# silently picking older compatible releases instead of the newest published
+# release. Without this, `cargo update` can pin transitive deps that require
+# a newer Rust edition (e.g., `getrandom 0.4.2` and `indexmap 2.14+` require
+# `edition2024` / Cargo 1.85), breaking the `cargo check @ 1.80` MSRV gate.
+#
+# The MSRV CI job runs Cargo 1.80, which does not know about this setting,
+# but it reads the already-resolved Cargo.lock (`--locked`) so it inherits
+# the MSRV-aware resolution made by a newer Cargo at PR / lockfile-update
+# time. Contributors who regenerate the lockfile on Cargo >= 1.84 get the
+# fallback for free; older Cargos will produce a too-new lockfile that the
+# MSRV job catches at PR time.
+[resolver]
+incompatible-rust-versions = "fallback"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
           # silently invalidates work on every alternation.
           prefix-key: v0-clippy
           shared-key: ""
+      - name: install protoc
+        # tonic-build 0.12 + prost-build 0.13 do not vendor protoc;
+        # the protobuf-compiler apt package is on the GitHub runner
+        # image cache, so this is warm after the first run.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: cargo fetch
         run: cargo fetch --locked
       - name: cargo clippy
@@ -74,6 +79,9 @@ jobs:
         with:
           prefix-key: v0-test
           shared-key: ""
+      - name: install protoc
+        # tonic-build 0.12 + prost-build 0.13 do not vendor protoc.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: cargo fetch
         run: cargo fetch --locked
       - name: cargo test
@@ -110,6 +118,9 @@ jobs:
           # invalidates this job's cache cleanly without a manual rev.
           prefix-key: v0-msrv-1.80
           shared-key: ""
+      - name: install protoc
+        # tonic-build 0.12 + prost-build 0.13 do not vendor protoc.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: cargo fetch
         run: cargo fetch --locked
       - name: cargo check (workspace, all targets, MSRV toolchain)

--- a/.planning/0-13-mango-proto-skeleton.plan.md
+++ b/.planning/0-13-mango-proto-skeleton.plan.md
@@ -1,0 +1,410 @@
+# Phase 0 item 0.13 — `mango-proto` skeleton
+
+**Roadmap:** `ROADMAP.md:761`.
+
+**Goal.** Create `crates/mango-proto` with `tonic-build` and a
+hello-world `.proto` file that compiles on CI. This is Phase 0
+plumbing: it verifies the protobuf → Rust codegen pipeline works
+under the workspace's lint / MSRV / clippy regime **before** the
+first real `.proto` (the `KV`, `Watch`, `Lease` surfaces in
+Phase 6+) tries to land on top of a broken toolchain.
+
+No wire-compatible API yet; no KV / Watch / Lease surfaces. Just:
+
+1. A new workspace member `crates/mango-proto`.
+2. A `build.rs` that runs `tonic-build` against a single `.proto`.
+3. A tiny `hello.proto` that compiles cleanly.
+4. A library target that re-exports the generated code.
+5. Tests that exercise the generated types under the workspace
+   lint regime.
+6. CI runs the build under the existing `ci.yml` jobs, with a
+   `protoc` install step added to the jobs that compile.
+
+## Revisions applied (post rust-expert review of plan v1)
+
+Verdict was `REVISE`. Two showstoppers, two bugs, several risks
+/ missing items. All applied in v2.
+
+- **S1 — protoc is NOT vendored** by `tonic-build 0.12` /
+  `prost-build 0.13`. `ubuntu-24.04` has no `protoc` by default;
+  the build fails with "Could not find `protoc`". **Fix in
+  this PR**: add `apt-get install -y protobuf-compiler` to the
+  CI jobs that actually compile (`clippy`, `test`, `msrv`).
+  Not `fmt` (rustfmt only), not `deny` (cargo-deny binary,
+  no compile), not `bench-harness` (pure shell). The
+  `protobuf-compiler` apt package is on the GitHub runner image
+  cache, so warm runs are fast.
+- **S2 — workspace lint quarantine is insufficient.** The
+  v1 `#![allow(clippy::all, clippy::pedantic, clippy::nursery,
+unreachable_pub, missing_docs)]` does **not** suppress
+  `arithmetic_side_effects`, `cast_possible_truncation`,
+  `cast_sign_loss`, `indexing_slicing`, `disallowed_types`,
+  `incompatible_msrv`, `unwrap_used`, `expect_used`, or `panic`,
+  because the workspace table sets those at `level = "deny",
+priority = 1` and priority-1 deny outranks priority-0 allow.
+  **Fix**: enumerate every deny explicitly in the generated
+  module's `#![allow(...)]`. Even if prost's emitted code for
+  the hello-world does not trip them today, a future prost point
+  release or new clippy lint is one change away from breaking CI.
+- **B1 — dead reference to `tonic::include_proto!`.** v1 had a
+  half-drafted `tonic::include_proto!` snippet that the final
+  `include!(concat!(env!("OUT_DIR"), "/..."))` replaces. v2
+  drops the draft so the implementing PR does not cargo-cult the
+  wrong one.
+- **B2 — `default-features = false, features = ["prost"]`
+  rationale was wrong.** `tonic-build 0.12`'s `transport` feature
+  is `transport = []` — marker, zero deps. Dropping it changes
+  nothing in the dep graph. **Correct rationale**: future-
+  proofing; if a future `tonic-build` point release adds runtime
+  deps to `transport`, we do not pick them up silently. The
+  feature spec is kept; the comment is corrected.
+- **R1 — `syn` duplicate-version flare.** `tonic-build` pulls
+  `syn 2`. If any future dep lands `syn 1`, `cargo-deny`
+  `multiple-versions = "deny"` fires. Not this PR's problem; do
+  not add a speculative skip. Documented as a known-wait-for-it.
+- **R2 — `hello.proto` delete-plan in the file**. Plan's TODO was
+  only in the doc-comment. v2 adds a `// DELETE:` comment at the
+  top of `hello.proto` itself so it is grep-visible by name.
+- **M1 — compile-time trait-bound assertion**. v1 only had a
+  prost-roundtrip test. v2 adds a zero-runtime-cost const
+  assertion that the generated types implement
+  `Clone + Default + Debug + PartialEq + prost::Message`.
+  Catches a future prost-build config change that strips a
+  derive.
+- **M2 — `publish = false` guard.** `mango-proto` is not
+  publishable yet. Add `publish = false` to `[package]` so a
+  future absent-minded `cargo publish` is a no-op.
+- **M3 — `Cargo.toml` description**. v1 ended the description
+  with `"..."`. v2 uses a real sentence.
+- **Nit — MSRV on `tonic-build` / `prost`**. Both target Rust ≥
+  1.70 per tokio-rs policy. Our MSRV 1.80 is above that. No
+  change needed; noted for provenance.
+
+## North-star axis moved
+
+**Time-to-first-protobuf**. Every later gRPC PR assumes the
+`tonic-build` + `.proto` → Rust pipeline works. Landing the
+skeleton now means the first `mango.kv.v1.KV` PR is a diff
+against a working crate, not a standup of the whole
+build-script / feature-gating / lint-escape story.
+
+## Out of scope
+
+- **Any real wire surface** (`KV`, `Watch`, `Lease`, `Cluster`,
+  `Auth`, `Maintenance`). Phase 6+.
+- **etcd wire compatibility**. Phase 6+ wire-compat gate.
+- **`tonic` runtime wiring** (service impls, servers, clients).
+  Phase 6+. This crate is _code-generation only_ for now.
+- **Custom codegen plugins**, `prost-build` attribute tuning
+  beyond the `tonic-build` defaults, `serde` derive wiring. First
+  real PR picks what it needs.
+- **`buf` linting / breaking-change detection.** Phase 6+ when
+  the surface is wire-compat-load-bearing.
+- **Feature-flagging client-only vs. server-only builds.** First
+  real gRPC PR picks the split.
+
+## Non-goals
+
+- No `Cargo.lock` explosion — `tonic-build` pulls a lot of
+  transitive deps, but all of them are build-time only (not
+  runtime) and `cargo-deny` policy already excludes the things
+  that matter (`openssl-sys`). Audit post-land.
+- No `tonic` / `prost` workspace dep hoisting yet. If a second
+  crate needs them, hoist then. Premature hoisting is churn.
+- No runtime dep on `tonic` itself. `prost` (for the generated
+  message structs) is the only runtime dep; `tonic-build` and
+  `prost-build` are build-deps.
+
+## Files
+
+- `Cargo.toml` (workspace) — EDIT. Add `crates/mango-proto` to
+  `[workspace] members`.
+- `crates/mango-proto/Cargo.toml` — NEW:
+
+  ```toml
+  [package]
+  name = "mango-proto"
+  version.workspace = true
+  edition.workspace = true
+  rust-version.workspace = true
+  license.workspace = true
+  repository.workspace = true
+  authors.workspace = true
+  description = "Mango generated protobuf bindings (Phase 0 skeleton; real wire surfaces land in Phase 6)."
+  publish = false
+
+  [dependencies]
+  prost = "0.13"
+
+  [build-dependencies]
+  # `default-features = false, features = ["prost"]` is future-proofing.
+  # `transport` today is `transport = []` (a marker with zero deps);
+  # dropping it does not change the current dep graph. If a future
+  # tonic-build point release adds runtime deps under `transport`, we
+  # do not pick them up silently — we opt in deliberately.
+  tonic-build = { version = "0.12", default-features = false, features = ["prost"] }
+
+  [lints]
+  workspace = true
+  ```
+
+- `crates/mango-proto/build.rs` — NEW:
+
+  ```rust
+  fn main() -> Result<(), Box<dyn std::error::Error>> {
+      // Types-only — no service trait generation. The hello proto has
+      // no `service` block, but even if someone adds one by mistake
+      // the build stays types-only (no runtime tonic dep) until Phase 6.
+      tonic_build::configure()
+          .build_server(false)
+          .build_client(false)
+          .compile_protos(&["proto/hello.proto"], &["proto"])?;
+      Ok(())
+  }
+  ```
+
+- `crates/mango-proto/proto/hello.proto` — NEW:
+
+  ```proto
+  // DELETE: removed when the first real `mango.*.v1` proto lands (Phase 6).
+  // This is Phase 0 skeleton only — it exists to exercise the tonic-build
+  // pipeline under the workspace lint and MSRV regime. Not wire-stable.
+  syntax = "proto3";
+  package mango.hello.v0;
+
+  message HelloRequest { string name = 1; }
+  message HelloReply   { string message = 1; }
+  ```
+
+  Package namespace `mango.hello.v0` — `v0` not `v1` because the
+  message set is pre-stable and will be deleted when the first
+  real proto lands. Stable wire namespaces begin at `v1`.
+
+- `crates/mango-proto/src/lib.rs` — NEW:
+
+  ```rust
+  //! Mango — generated protobuf bindings.
+  //!
+  //! Phase 0 skeleton (ROADMAP.md:761). Real wire surfaces land in
+  //! Phase 6+. The `hello::v0` module ships with a single
+  //! request/reply pair solely to exercise the `tonic-build`
+  //! pipeline end-to-end under the workspace lint and MSRV regime.
+  //! It is **not** wire-stable and will be deleted when the first
+  //! real `mango.*.v1` proto lands.
+
+  pub mod hello {
+      pub mod v0 {
+          // Generated code is foreign — we do not own the style. We
+          // explicitly allow every workspace-denied lint that prost's
+          // expansion could plausibly trip (now or in a future point
+          // release). Each `clippy::all` / `clippy::pedantic` /
+          // `clippy::nursery` group allow is priority-0; the workspace
+          // table sets the individual denies at priority-1. Priority-1
+          // deny wins over priority-0 allow, so the individual denies
+          // MUST be enumerated explicitly here — the group allows are
+          // kept only for future-proofing against new lints.
+          #![allow(
+              clippy::all,
+              clippy::pedantic,
+              clippy::nursery,
+              clippy::arithmetic_side_effects,
+              clippy::cast_possible_truncation,
+              clippy::cast_sign_loss,
+              clippy::indexing_slicing,
+              clippy::disallowed_types,
+              clippy::incompatible_msrv,
+              clippy::unwrap_used,
+              clippy::expect_used,
+              clippy::panic,
+              clippy::dbg_macro,
+              clippy::print_stdout,
+              clippy::print_stderr,
+              clippy::await_holding_lock,
+              clippy::await_holding_refcell_ref,
+              unreachable_pub,
+              missing_docs
+          )]
+          include!(concat!(env!("OUT_DIR"), "/mango.hello.v0.rs"));
+      }
+  }
+
+  #[cfg(test)]
+  mod tests {
+      #![allow(
+          clippy::unwrap_used,
+          clippy::expect_used,
+          clippy::panic,
+          clippy::indexing_slicing,
+          clippy::unnecessary_literal_unwrap,
+          clippy::arithmetic_side_effects
+      )]
+
+      use super::hello::v0::{HelloReply, HelloRequest};
+
+      // Compile-time assertion that prost-derive emits the expected
+      // trait bounds. If a future prost-build config change strips a
+      // derive (e.g., omits `Default`), this const fails to typecheck
+      // and the build breaks loudly at PR time — cheaper than
+      // discovering the regression from a field using the method.
+      const _: fn() = || {
+          fn assert_bounds<T>()
+          where
+              T: Clone + Default + std::fmt::Debug + PartialEq + prost::Message,
+          {
+          }
+          assert_bounds::<HelloRequest>();
+          assert_bounds::<HelloReply>();
+      };
+
+      #[test]
+      fn hello_types_roundtrip_via_prost() {
+          // Exercise the generated types: construct, serialize,
+          // round-trip. Proves (a) codegen ran, (b) the types
+          // implement prost::Message, (c) encoding/decoding are
+          // wired correctly.
+          use prost::Message;
+
+          let req = HelloRequest { name: "mango".to_string() };
+          let mut buf = Vec::new();
+          req.encode(&mut buf).expect("encode HelloRequest");
+
+          let decoded = HelloRequest::decode(buf.as_slice())
+              .expect("decode HelloRequest");
+          assert_eq!(decoded.name, "mango");
+
+          let reply = HelloReply { message: "hello, mango".to_string() };
+          assert_eq!(reply.message, "hello, mango");
+      }
+  }
+  ```
+
+- `.github/workflows/ci.yml` — EDIT. Add a `protoc` install step
+  to `clippy`, `test`, `msrv`. Not `fmt` (rustfmt only), not
+  `deny` (cargo-deny binary), not `bench-harness` (shell only).
+  The step shape:
+
+  ```yaml
+  - name: install protoc
+    # tonic-build 0.12 + prost-build 0.13 do not vendor protoc;
+    # the protobuf-compiler apt package is on the GitHub runner
+    # image cache, so this is warm after the first run.
+    run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+  ```
+
+  Placed before `cargo fetch` in each of the three jobs.
+
+- `deny.toml` — CHECK only. Verify new transitive build-deps
+  from `tonic-build` / `prost-build` do not trip license or
+  advisory rules. Known-safe upstream (tokio-rs). If a flare
+  lands, narrow skip — prefer an upstream fix over a skip.
+- `.gitignore` — no edit needed (already ignores `target/`).
+
+## Test strategy
+
+Three gates, all in existing CI jobs (after the `protoc` install
+step lands):
+
+1. **`cargo build`** via `cargo clippy --workspace --all-targets`
+   and `cargo test --workspace --all-targets` in `ci.yml`. Fails
+   if `build.rs` cannot find `protoc` — the apt install step is
+   the fix (S1).
+2. **`cargo test` — `hello_types_roundtrip_via_prost` +
+   compile-time `assert_bounds` (M1).** Proves codegen ran, types
+   implement `prost::Message` + the expected auto-derives.
+3. **`cargo clippy --workspace --all-targets -- -D warnings`.**
+   Proves the explicit deny-list in the generated module's
+   `#![allow(...)]` (S2) is tight enough that no workspace-denied
+   lint escapes into the user crate's compile.
+
+**MSRV job (cargo check @ 1.80).** `tonic-build` 0.12 and
+`prost` 0.13 both target Rust ≥ 1.70 per tokio-rs policy. Our
+MSRV 1.80 is above that. `cargo check --workspace --all-targets
+--locked` on rustc 1.80 runs locally before push.
+
+**`cargo-deny` job.** `tonic-build` pulls `syn 2`, `quote 1`,
+`proc-macro2 1`, `prettyplease 0.2`, `prost-build 0.13`,
+`prost-types 0.13`. All tokio-rs upstream; licenses Apache-2.0
+/ MIT. No `openssl-sys`. Expect clean.
+
+**No bespoke `scripts/test-*.sh`.** The workspace's existing
+jobs are sufficient; adding a proto-specific shell script is
+over-fitting at skeleton size.
+
+## Risks
+
+- **`protoc` on macOS contributor machines.** `brew install
+protobuf` handles it. A `CONTRIBUTING.md` note is a Phase 0.14
+  follow-up (next roadmap item), not this PR.
+- **Workspace lint regime fighting generated code.** Mitigated
+  by the explicit full-enumeration `#![allow(...)]` (S2). If a
+  future clippy release adds a new lint in the deny table, the
+  quarantine may need one new line — grep-obvious failure mode.
+- **MSRV drift.** `tonic-build` 0.12 → 0.13 could raise MSRV.
+  Mitigated by caret range `"0.12"` (minor-flex) + CI MSRV job
+  catching regressions at PR time.
+- **`tonic-build` pulling `openssl-sys`.** With
+  `default-features = false, features = ["prost"]`, it does not.
+  Verified via `cargo tree -d`. Double-check at PR time.
+- **`cargo-deny multiple-versions = "deny"`.** `tonic-build`
+  brings `syn 2`; any future dep landing `syn 1` flares. Not
+  this PR; do not pre-skip.
+- **Namespace collision with future `KV` proto.** `mango.hello.v0`
+  is one-shot; when the first real proto lands under
+  `mango.kv.v1`, the `hello.v0` module is deleted in the same
+  PR. `// DELETE:` comment at the top of `hello.proto` makes
+  this grep-visible (R2).
+- **Skeleton crate being treated as importable.** No other crate
+  should depend on `mango-proto` yet. If a future PR adds
+  `mango-proto = { path = "..." }` purely to exercise hello
+  types, push back — that is test-fixture coupling across
+  crates.
+
+## Plan of work
+
+1. Branch: `feat/mango-proto-skeleton`.
+2. Create `crates/mango-proto/` with the four files above
+   (`Cargo.toml`, `build.rs`, `src/lib.rs`, `proto/hello.proto`).
+3. Edit workspace `Cargo.toml` to add the member.
+4. Edit `.github/workflows/ci.yml` to add the `protoc` install
+   step to `clippy`, `test`, `msrv`.
+5. Run locally:
+   - `cargo build --workspace --locked`
+   - `cargo test --workspace --all-targets --locked`
+   - `cargo clippy --workspace --all-targets --locked -- -D warnings`
+   - `rustup run 1.80 cargo check --workspace --all-targets --locked`
+   - `cargo tree -d` — eyeball for unexpected dupes
+6. Push branch. Open PR with the roadmap reference and a
+   one-liner "proto skeleton, hello world round-trips, no wire
+   surfaces yet" summary.
+7. `rust-expert` adversarial review on the diff.
+8. Revise on review; re-request `APPROVE`.
+9. Merge `--squash --delete-branch` on `APPROVE`.
+10. Flip `ROADMAP.md:761` checkbox on main; commit + push.
+
+## Rollback plan
+
+Revert the merge commit. The crate is additive; no other crate
+depends on it yet. The `ci.yml` `protoc` install step is
+additive too; reverting costs a no-op apt step on future PRs
+until the next proto crate lands, which is negligible.
+
+## Acceptance
+
+- `crates/mango-proto/` exists with `Cargo.toml` (with `publish
+= false`), `build.rs`, `src/lib.rs`, `proto/hello.proto` (with
+  `// DELETE:` header).
+- Workspace `Cargo.toml` lists the new member.
+- `.github/workflows/ci.yml` has a `protoc` install step in the
+  `clippy`, `test`, and `msrv` jobs.
+- `cargo build --workspace --locked` succeeds locally.
+- `cargo test --workspace --all-targets --locked` succeeds
+  including:
+  - the compile-time `assert_bounds` const (M1),
+  - the `hello_types_roundtrip_via_prost` test.
+- `cargo clippy --workspace --all-targets --locked -- -D
+warnings` succeeds with no generated-code lint escapes.
+- `cargo check --workspace --all-targets --locked` on rustc
+  1.80 succeeds (MSRV gate).
+- `cargo-deny` job succeeds on the PR.
+- `rust-expert` `APPROVE` on the final diff.
+- `ROADMAP.md:761` checkbox flipped on merge.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,371 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "mango"
 version = "0.1.0"
+
+[[package]]
+name = "mango-proto"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "tonic-build",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/mango"]
+members = ["crates/mango", "crates/mango-proto"]
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/mango-proto/Cargo.toml
+++ b/crates/mango-proto/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mango-proto"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Mango generated protobuf bindings (Phase 0 skeleton; real wire surfaces land in Phase 6)."
+publish = false
+
+[dependencies]
+prost = "0.13"
+
+[build-dependencies]
+# `default-features = false, features = ["prost"]` is future-proofing.
+# `transport` today is `transport = []` (a marker with zero deps);
+# dropping it does not change the current dep graph. If a future
+# tonic-build point release adds runtime deps under `transport`, we
+# do not pick them up silently — we opt in deliberately.
+tonic-build = { version = "0.12", default-features = false, features = ["prost"] }
+
+[lints]
+workspace = true

--- a/crates/mango-proto/build.rs
+++ b/crates/mango-proto/build.rs
@@ -1,0 +1,10 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Types-only — no service trait generation. The hello proto has
+    // no `service` block, but even if someone adds one by mistake
+    // the build stays types-only (no runtime tonic dep) until Phase 6.
+    tonic_build::configure()
+        .build_server(false)
+        .build_client(false)
+        .compile_protos(&["proto/hello.proto"], &["proto"])?;
+    Ok(())
+}

--- a/crates/mango-proto/proto/hello.proto
+++ b/crates/mango-proto/proto/hello.proto
@@ -1,0 +1,8 @@
+// DELETE: removed when the first real `mango.*.v1` proto lands (Phase 6).
+// This is Phase 0 skeleton only — it exists to exercise the tonic-build
+// pipeline under the workspace lint and MSRV regime. Not wire-stable.
+syntax = "proto3";
+package mango.hello.v0;
+
+message HelloRequest { string name = 1; }
+message HelloReply   { string message = 1; }

--- a/crates/mango-proto/src/lib.rs
+++ b/crates/mango-proto/src/lib.rs
@@ -1,0 +1,97 @@
+//! Mango — generated protobuf bindings.
+//!
+//! Phase 0 skeleton (ROADMAP.md:761). Real wire surfaces land in
+//! Phase 6+. The `hello::v0` module ships with a single
+//! request/reply pair solely to exercise the `tonic-build`
+//! pipeline end-to-end under the workspace lint and MSRV regime.
+//! It is **not** wire-stable and will be deleted when the first
+//! real `mango.*.v1` proto lands.
+
+pub mod hello {
+    pub mod v0 {
+        // Generated code is foreign — we do not own the style. Every
+        // workspace-denied lint that prost's expansion could plausibly
+        // trip (now or in a future point release) is enumerated here.
+        // The `clippy::all` / `clippy::pedantic` / `clippy::nursery`
+        // group allows are priority-0; the workspace table sets the
+        // individual denies at priority-1. Priority-1 deny wins over
+        // priority-0 allow, so the individual denies MUST be listed
+        // explicitly — the group allows are kept only for
+        // future-proofing against new lints in those groups.
+        #![allow(
+            clippy::all,
+            clippy::pedantic,
+            clippy::nursery,
+            clippy::arithmetic_side_effects,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            clippy::indexing_slicing,
+            clippy::disallowed_types,
+            clippy::incompatible_msrv,
+            clippy::unwrap_used,
+            clippy::expect_used,
+            clippy::panic,
+            clippy::unimplemented,
+            clippy::todo,
+            clippy::dbg_macro,
+            clippy::print_stdout,
+            clippy::print_stderr,
+            clippy::await_holding_lock,
+            clippy::await_holding_refcell_ref,
+            unreachable_pub,
+            missing_docs
+        )]
+        include!(concat!(env!("OUT_DIR"), "/mango.hello.v0.rs"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::unnecessary_literal_unwrap,
+        clippy::arithmetic_side_effects
+    )]
+
+    use super::hello::v0::{HelloReply, HelloRequest};
+
+    // Compile-time assertion that prost-derive emits the expected
+    // trait bounds. If a future prost-build config change strips a
+    // derive (e.g., omits `Default`), this const fails to typecheck
+    // and the build breaks loudly at PR time — cheaper than
+    // discovering the regression from a field using the method.
+    const _: fn() = || {
+        fn assert_bounds<T>()
+        where
+            T: Clone + Default + std::fmt::Debug + PartialEq + prost::Message,
+        {
+        }
+        assert_bounds::<HelloRequest>();
+        assert_bounds::<HelloReply>();
+    };
+
+    #[test]
+    fn hello_types_roundtrip_via_prost() {
+        // Exercise the generated types: construct, serialize, round-
+        // trip. Proves (a) codegen ran, (b) the types implement
+        // prost::Message, (c) encoding/decoding are wired correctly.
+        use prost::Message;
+
+        let req = HelloRequest {
+            name: "mango".to_string(),
+        };
+        let mut buf = Vec::new();
+        req.encode(&mut buf).expect("encode HelloRequest");
+
+        let decoded = HelloRequest::decode(buf.as_slice()).expect("decode HelloRequest");
+        assert_eq!(decoded.name, "mango");
+
+        let reply = HelloReply {
+            message: "hello, mango".to_string(),
+        };
+        assert_eq!(reply.message, "hello, mango");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0 item 0.13 (`ROADMAP.md:761`). Ship `crates/mango-proto` with
`tonic-build` and a throwaway hello-world `.proto` that compiles. This
is plumbing; no wire surfaces, no services, no clients — just proof
that the codegen pipeline works under the workspace lint / MSRV regime
so Phase 6+ is a diff against a working crate.

- **New crate**: `crates/mango-proto/` — types-only, `publish = false`.
  - `Cargo.toml` — `prost 0.13` runtime, `tonic-build 0.12`
    build-dep with `default-features = false, features = ["prost"]`.
  - `build.rs` — `build_server(false)`, `build_client(false)`.
  - `proto/hello.proto` — `mango.hello.v0` namespace with a
    `// DELETE:` header.
  - `src/lib.rs` — `pub mod hello::v0` quarantines the generated
    code under an explicit full-enumeration `#![allow(...)]` that
    lists every workspace-denied lint (priority-1 deny outranks
    priority-0 group allow, so enumeration is required). Includes a
    compile-time `assert_bounds` const and a `prost::Message`
    roundtrip test.
- **Workspace `Cargo.toml`**: adds the new member.
- **`.cargo/config.toml`** (new): enables the MSRV-aware resolver
  (`incompatible-rust-versions = "fallback"`). Without it, stable
  Cargo resolves transitive deps like `getrandom 0.4.2` and
  `indexmap 2.14+` that require `edition2024` / Cargo 1.85,
  breaking MSRV 1.80. The fallback keeps MSRV 1.80 viable.
- **`.github/workflows/ci.yml`**: adds `apt install -y
protobuf-compiler` to `clippy`, `test`, and `msrv` jobs.
  `tonic-build 0.12` / `prost-build 0.13` do not vendor `protoc`.

## Test plan

- [x] `cargo build --workspace --locked` — green
- [x] `cargo test --workspace --all-targets --locked` — 2 tests pass
      (`hello_types_roundtrip_via_prost` + the compile-time
      `assert_bounds` const)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
      — green; quarantine holds
- [x] `rustup run 1.80 cargo check --workspace --all-targets --locked`
      — green via MSRV-aware resolver
- [x] `cargo deny check` — green (advisories, bans, licenses, sources
      all ok; only advisory "unmatched license allowance" warnings for
      licenses no dep matched)
- [x] `cargo tree -d` — no unexpected duplicates; no `openssl-sys`
- [x] `cargo fmt --all -- --check` — green
- [ ] rust-expert adversarial review on this diff (final gate)

## Rollback

Revert the merge commit. The crate is additive; no other crate depends
on it yet. The `ci.yml` `protoc` step and the MSRV-aware resolver
config are additive and harmless to future PRs.

## Refs

- `ROADMAP.md:761` (this item — flipped on merge)
- `.planning/0-13-mango-proto-skeleton.plan.md` (plan v2; rust-expert
  returned APPROVE_WITH_NITS after v1's REVISE, nit applied inline)
