### PR TITLE
ci(test): switch test runner to cargo-nextest with per-class watchdog (0.5.1)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,71 @@
+# Test watchdog config for mango.
+#
+# Per-test hard timeouts. A wedged test is sent SIGTERM after its
+# class period and recorded as a failure, so one hung test never
+# burns the full GitHub Actions job budget.
+#
+# `slow-timeout = { period = "…", terminate-after = 1 }` is the
+# load-bearing shape: `slow-timeout` alone only prints a warning,
+# `terminate-after = N` is what turns it into a kill (SIGTERM after
+# N * period, SIGKILL after the grace window).
+#
+# Policy lives in [profile.default] so local `cargo nextest run`
+# enforces the same budgets as CI. See docs/testing.md and
+# ROADMAP.md item 0.5.1 for the policy; scripts/test-watchdog.sh
+# is the committed regression test that proves the watchdog still
+# kills wedged tests.
+
+[profile.default]
+# `unit` class default (30s). Covers anything not routed to a
+# more permissive class below.
+slow-timeout = { period = "30s", terminate-after = 1 }
+
+# Surface failures as they happen AND at the end. Default "final"
+# hides a minute-2 failure until minute 30 of a long run;
+# "immediate-final" prints each failure inline + a summary, which
+# is what nextest's own docs recommend for CI.
+failure-output = "immediate-final"
+
+# Continue running after a failure (equivalent to
+# `cargo test --no-fail-fast`). Exit code is still non-zero.
+fail-fast = false
+
+# Retries disabled. The project's test bar (CONTRIBUTING §4)
+# treats flaky tests as failures; silently retrying hides real
+# bugs. A test that is legitimately non-deterministic can carry
+# a narrow per-test override with a justification comment.
+retries = 0
+
+# integration class: crate-level `tests/*.rs` binaries.
+# `kind(test)` is nextest's canonical selector for integration-
+# test binaries. Budget: 5 minutes.
+[[profile.default.overrides]]
+filter = 'kind(test)'
+slow-timeout = { period = "5m", terminate-after = 1 }
+
+# loom class: concurrency model checking (scaffolding for
+# Phase 5+; no loom tests exist today). Filter matches any test
+# whose fully-qualified name contains `loom` — nextest prepends
+# the integration-test binary name to each test, so a test in
+# `tests/loom_foo.rs` reports as `loom_foo::bar` and matches.
+# `test(~…)` filters parse cleanly even when nothing matches,
+# which is required for forward-looking classes. Budget: 30 min.
+# Convention: name loom files `tests/loom_*.rs` (or put them
+# inside a module / crate whose name contains `loom`).
+[[profile.default.overrides]]
+filter = 'test(~loom)'
+slow-timeout = { period = "30m", terminate-after = 1 }
+
+# chaos class: fault-injection / crash-only recovery
+# (scaffolding for Phase 14.5; no chaos tests exist today).
+# Same convention as loom — name files `tests/chaos_*.rs` or
+# put them in a `chaos`-named module/crate. Budget: 24 hours.
+[[profile.default.overrides]]
+filter = 'test(~chaos)'
+slow-timeout = { period = "24h", terminate-after = 1 }
+
+[profile.ci]
+# CI inherits every policy field from [profile.default]. This
+# section exists so `--profile ci` is a valid invocation and to
+# leave room for CI-only tuning (e.g., a future JUnit-output
+# step for a test-report publisher).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -64,11 +64,13 @@ TODO/FIXME/unimplemented!), and #12 (axis-or-plumbing declared above). -->
 
 - [ ] `cargo fmt --all -- --check`
 - [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings`
-- [ ] `cargo test --workspace --all-targets --locked`
+- [ ] `cargo nextest run --workspace --all-targets --locked --profile ci`
+- [ ] `cargo test --doc --workspace --locked`
+- [ ] `bash scripts/test-watchdog.sh`
 - [ ] `cargo doc --workspace --no-deps`
 - [ ] `cargo deny check`
 - [ ] `cargo audit`
-- [ ] `rustup run 1.80 cargo check --workspace --all-targets --locked`
+- [ ] `rustup run 1.80 cargo check --workspace --all-targets --locked --target x86_64-unknown-linux-gnu`
 - [ ] No new `TODO` / `FIXME` / `unimplemented!` introduced
 - [ ] rust-expert adversarial review (final gate)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,36 @@ jobs:
       - name: install protoc
         # tonic-build 0.12 + prost-build 0.13 do not vendor protoc.
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      # cargo-nextest is installed via taiki-e/install-action (SHA-pinned
+      # per this repo's convention) and fetches the official release
+      # binary from cargo-nextest's GitHub releases with SHA256
+      # verification. Same supply-chain posture as EmbarkStudios/
+      # cargo-deny-action. See docs/testing.md for the watchdog policy
+      # that lives in `.config/nextest.toml`.
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458  # v2
+        with:
+          tool: cargo-nextest
       - name: cargo fetch
         run: cargo fetch --locked
-      - name: cargo test
-        # `--no-fail-fast` here means "report all failing test binaries
-        # in one CI run" — it is unrelated to the matrix-strategy
-        # `fail-fast: false` knob, which doesn't apply (no matrix yet).
-        run: cargo test --workspace --all-targets --locked --no-fail-fast
+      - name: cargo nextest run
+        # Per-test-class hard timeouts live in `.config/nextest.toml`.
+        # `--profile ci` inherits from [profile.default], so the class
+        # overrides (unit=30s, integration=5m, loom=30m, chaos=24h)
+        # apply here too. fail-fast is disabled in the profile — a
+        # failing test does not short-circuit the run.
+        run: cargo nextest run --workspace --all-targets --locked --profile ci
+      - name: cargo test --doc
+        # nextest does NOT run doctests; this step covers them.
+        # Placed after nextest so the workspace dep cache is warm and
+        # only doctest-specific artifacts recompile.
+        run: cargo test --doc --workspace --locked
+      - name: watchdog smoke (assert nextest kills runaway tests)
+        # Proves `slow-timeout = { ..., terminate-after = 1 }` actually
+        # kills. Without this, someone could silently drop
+        # terminate-after from nextest.toml and the watchdog would
+        # downgrade to warn-only without CI noticing.
+        run: bash scripts/test-watchdog.sh
 
   msrv:
     # MSRV enforcement. `cargo check` on the pinned 1.80 toolchain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,9 @@ from [`ROADMAP.md` § Working rules][working-rules]:
 - One roadmap item per PR. Small, atomic, mergeable.
 - Every plan declares the north-star axis + named test + measured
   number (or honestly marks plumbing).
-- `cargo test --workspace` green at every commit.
+- `cargo nextest run --workspace` green at every commit (plus
+  `cargo test --doc --workspace` for doctests, which nextest
+  does not cover — see [`docs/testing.md`](./docs/testing.md)).
 - Every hot-path PR ships a Criterion bench and a baseline number.
 - No `TODO` / `FIXME` / `unimplemented!()` / `todo!()` on `main` —
   follow-ups become new roadmap items, not comments in code.
@@ -268,23 +270,38 @@ pushing.
 ```bash
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --locked -- -D warnings
-cargo test --workspace --all-targets --locked
+cargo nextest run --workspace --all-targets --locked --profile ci
+cargo test --doc --workspace --locked
+bash scripts/test-watchdog.sh
 cargo doc --workspace --no-deps
 cargo deny check
 cargo audit
-rustup run 1.80 cargo check --workspace --all-targets --locked
+rustup run 1.80 cargo check --workspace --all-targets --locked \
+  --target x86_64-unknown-linux-gnu
 ```
 
 Notes:
 
+- `cargo nextest run`: the CI test runner. Per-test-class hard
+  timeouts live in `.config/nextest.toml`; policy in
+  [`docs/testing.md`](./docs/testing.md). `cargo test` still
+  works for local iteration — same test bodies, different
+  runner — but CI only runs nextest.
+- `cargo test --doc`: nextest does NOT run doctests; this step
+  covers them. Required to reproduce CI.
+- `bash scripts/test-watchdog.sh`: regression smoke that proves
+  nextest's `terminate-after` actually kills a runaway test.
+  Runs in ~30s.
 - `cargo doc`: the Definition of Done requires this to be
   warning-free. `cargo doc` `-D warnings` will gate once the
   doc-lint CI job lands.
-- `rustup run 1.80 …`: MSRV gate. Update the `1.80` when the
-  workspace MSRV bumps (single-sourcing from `rust-version` is a
-  future cleanup).
+- `rustup run 1.80 …`: MSRV gate. See
+  [`docs/msrv.md`](./docs/msrv.md) for the `--target` rationale.
 - `cargo deny`, `cargo audit`: install with
   `cargo install cargo-deny cargo-audit` if missing.
+- `cargo nextest`: install with
+  `cargo install cargo-nextest --locked` (or
+  `brew install cargo-nextest` on macOS) if missing.
 
 ## PR description format
 

--- a/crates/mango/src/lib.rs
+++ b/crates/mango/src/lib.rs
@@ -22,4 +22,17 @@ mod tests {
     fn version_matches_cargo_manifest() {
         assert_eq!(VERSION, "0.1.0");
     }
+
+    // Watchdog regression smoke. Sleeps past the 30s unit-class budget
+    // declared in `.config/nextest.toml` so `scripts/test-watchdog.sh`
+    // can assert nextest actually terminates it. `#[ignore]` keeps it
+    // out of the default CI pass; the script runs it explicitly with
+    // `--run-ignored only` plus a test-name filter. If anyone later
+    // removes `terminate-after` from `nextest.toml`, the script flips
+    // red. Do NOT remove without understanding why it is here.
+    #[test]
+    #[ignore = "watchdog smoke; run via scripts/test-watchdog.sh only"]
+    fn watchdog_kill_smoke() {
+        std::thread::sleep(std::time::Duration::from_secs(90));
+    }
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,207 @@
+# Testing policy
+
+Mango's CI test runner is [`cargo-nextest`](https://nexte.st/). The
+per-test-class timeout budgets, the watchdog enforcement, and the
+process-per-test model all flow from that choice.
+
+This doc is the policy. The config is
+[`.config/nextest.toml`](../.config/nextest.toml); the regression
+test is [`scripts/test-watchdog.sh`](../scripts/test-watchdog.sh).
+
+## Why `cargo-nextest`
+
+- **Per-test hard timeouts.** `cargo test` has no built-in watchdog;
+  a wedged test runs until the GitHub Actions job-level 15-minute
+  timeout expires, burning the whole budget on one test. nextest's
+  `slow-timeout = { period = "…", terminate-after = 1 }` sends
+  SIGTERM after the period elapses, records the test as failed, and
+  lets the rest of the suite continue.
+- **Process-per-test isolation.** nextest spawns each test in its
+  own process, so a `static` mutex, a global singleton, or a
+  `std::env::set_var` from one test cannot leak into another.
+  `cargo test` runs tests as threads in one process — subtle
+  cross-test coupling tends to hide there.
+- **Filter expressions for routing.** Timeouts are per-class, and
+  classes are defined by filter expressions (`kind(test)`,
+  `test(~loom)`, etc.), which is both automatic and reviewable.
+
+## Test classes and budgets
+
+| Class | Selector | Budget | Used for |
+|-------|----------|--------|----------|
+| `unit` | default (unclassified) | 30s | `#[cfg(test)] mod tests` in `src/`, pure function tests, codec round-trips |
+| `integration` | `kind(test)` | 5 min | `tests/*.rs` at each crate root; multi-module exercises |
+| `loom` | `test(~loom)` | 30 min | Concurrency model checking (Phase 5+) |
+| `chaos` | `test(~chaos)` | 24 h | Fault injection / crash-only recovery (Phase 14.5+) |
+
+The filter expressions live in
+[`.config/nextest.toml`](../.config/nextest.toml) under
+`[[profile.default.overrides]]`. Policy lives in `[profile.default]`
+so `cargo nextest run` locally enforces the same budgets as CI.
+`[profile.ci]` inherits from `default`; only CI-specific tuning
+goes there.
+
+### Class-naming convention
+
+- Put loom tests in files matching `tests/loom_*.rs`, or in a
+  module/crate whose name contains `loom`.
+- Put chaos tests in files matching `tests/chaos_*.rs`, or in a
+  module/crate whose name contains `chaos`.
+
+The filter is contains-match (`~`), not prefix — a file
+`tests/my_loom_scenario.rs` still matches `test(~loom)`. The
+convention is strict about presence of the keyword, lenient about
+position.
+
+If a test belongs to no class, it falls to the 30s `unit` budget.
+Default-to-strict is intentional; if your test legitimately needs
+more, move it to the matching class or open a PR that widens the
+budget with justification.
+
+## Flakiness policy
+
+`retries = 0` in `[profile.default]`. A test that fails the first
+time fails the build — we do not silently re-run and relabel as
+`FLAKY`. This aligns with the `CONTRIBUTING.md §4` test bar:
+"trust CI is not a test plan." A test that is legitimately
+infra-sensitive (e.g., a network-bound integration test) should
+carry a narrow per-test override with a `retries = N` line and a
+comment naming the specific transience being tolerated, rather
+than flipping the default.
+
+## Output format (`failure-output = "immediate-final"`)
+
+Failures print inline as they occur AND in a summary at the end of
+the run. The default `"final"` hides first failures until the
+whole suite completes, which is bad for long-running loom and
+chaos budgets — reviewers want to see the first failure fast.
+
+## Watchdog enforcement — how it works
+
+`slow-timeout` alone is just a warning. `terminate-after = N`
+multiplies the period by `N` and sends SIGTERM at the resulting
+moment. Example from our config:
+
+```toml
+slow-timeout = { period = "30s", terminate-after = 1 }
+```
+
+→ nextest warns at 30s, SIGTERMs at 60s (period * (1+1)), and
+records the test as `TIMEOUT` (exit code non-zero).
+
+That last sentence is the load-bearing invariant. If anyone
+removes `terminate-after`, the watchdog downgrades to warn-only.
+[`scripts/test-watchdog.sh`](../scripts/test-watchdog.sh) is the
+committed regression test: it runs a `#[ignore]`d test that sleeps
+90s under the 30s unit budget and asserts nextest actually kills
+it. The script fails loudly if the `TIMEOUT` marker disappears
+from output or if the test runs to natural completion.
+
+## Process-per-test footguns
+
+Before you add a test that depends on cross-test state, know:
+
+- **Global loggers** (`env_logger::init`, `tracing_subscriber::set_global_default`) — each test process calls `init` fresh. Fine in isolation; footgun only if you rely on state from a previous test. Prefer `try_init` to avoid panics from double-init inside a single process (belt-and-suspenders).
+- **`static` / `OnceLock` singletons** — each test process has its own copy. A test that assumes "the registry has 3 entries because the previous test added them" will fail under nextest. Fix: set up state per-test.
+- **`std::env::set_var`** — scoped to the process. Fine under nextest; nasty under `cargo test` (tests could race each other on env). Another reason to prefer nextest locally.
+- **tokio runtimes** — each test builds its own. No issue, but the cost-per-test is non-trivial; batch assertions into fewer tests where sensible.
+
+## Running tests locally
+
+Install nextest once:
+
+```bash
+cargo install cargo-nextest --locked
+# or, on macOS:
+brew install cargo-nextest
+```
+
+Run the full suite (what CI runs):
+
+```bash
+cargo nextest run --workspace --all-targets --locked --profile ci
+cargo test --doc --workspace --locked
+```
+
+Run a single test:
+
+```bash
+cargo nextest run -E 'test(my_test_name)'
+```
+
+Run under the default profile (friendlier output, same budgets):
+
+```bash
+cargo nextest run
+```
+
+Inspect the resolved config:
+
+```bash
+cargo nextest show-config test-groups --profile ci
+cargo nextest list --profile ci        # shows which tests land where
+```
+
+## Doctests
+
+nextest does **not** run doctests. CI runs `cargo test --doc
+--workspace --locked` as a separate step, placed after nextest so
+the dep cache is warm. Contributors must run both to reproduce
+CI; `CONTRIBUTING.md §8` lists both commands.
+
+## Adding a new test class
+
+1. Pick a keyword that is unique and memorable (e.g., `fuzz`).
+2. Choose the naming convention (`tests/fuzz_*.rs` is the blessed
+   shape — consistent with loom and chaos).
+3. Add a block to `.config/nextest.toml`:
+   ```toml
+   [[profile.default.overrides]]
+   filter = 'test(~fuzz)'
+   slow-timeout = { period = "1h", terminate-after = 1 }
+   ```
+4. Document the class in the table above.
+5. Update `scripts/test-watchdog.sh` only if the new class needs
+   its own regression — the existing smoke covers the unit class
+   and the enforcement mechanism (`terminate-after`), which is the
+   load-bearing property.
+
+## Escape hatch for intentionally long tests
+
+If a specific test must exceed the budget of its class — e.g., a
+chaos test that intentionally runs 48h — add a per-test override:
+
+```toml
+[[profile.default.overrides]]
+filter = 'test(=my_crate::the_really_long_test)'
+slow-timeout = { period = "72h", terminate-after = 1 }
+```
+
+Comment above the block with the justification. A PR that adds a
+new per-test override is a review signal; reviewers should push
+back unless the justification is concrete.
+
+## Forward references
+
+- **madsim** (ROADMAP.md:788): the `sim` CI profile
+  (`RUSTFLAGS="--cfg madsim"`) runs under nextest — same runner,
+  additional env var. We do not fork the test runner for
+  simulation; nextest is the one-and-only test orchestrator.
+- **Miri** (ROADMAP.md:795): the Miri CI job runs `cargo miri test`,
+  not nextest. Miri is an interpreter; it cannot do
+  process-per-test because there is no process separation at the
+  interpreter level. The nightly Miri workflow is its own job
+  with its own (long) timeout, not subject to this doc.
+- **10×-baseline regression detection** (ROADMAP.md:794): deferred
+  as a follow-up. nextest's flake-detector is a retry mechanism,
+  not a baseline comparator. A wrapper script over
+  `--message-format libtest-json` is needed; not productive until
+  the test suite has ~50+ tests.
+
+## See also
+
+- [`CONTRIBUTING.md §4`](../CONTRIBUTING.md) — the test bar.
+- [`CONTRIBUTING.md §8`](../CONTRIBUTING.md) — commands CI runs.
+- [`ROADMAP.md` item 0.5.1](../ROADMAP.md) — where this policy was declared.
+- [nextest docs — filtersets](https://nexte.st/docs/filtersets/reference/)
+- [nextest docs — slow tests and timeouts](https://nexte.st/docs/configuration/slow-tests/)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -79,15 +79,19 @@ chaos budgets — reviewers want to see the first failure fast.
 ## Watchdog enforcement — how it works
 
 `slow-timeout` alone is just a warning. `terminate-after = N`
-multiplies the period by `N` and sends SIGTERM at the resulting
-moment. Example from our config:
+turns the same field into a kill: nextest sends SIGTERM when the
+test has been slow for `N` consecutive periods. Example from our
+config:
 
 ```toml
 slow-timeout = { period = "30s", terminate-after = 1 }
 ```
 
-→ nextest warns at 30s, SIGTERMs at 60s (period * (1+1)), and
-records the test as `TIMEOUT` (exit code non-zero).
+→ nextest records the test as slow at 30s AND sends SIGTERM at
+30s (`terminate-after = 1` fires on the first period), marks the
+test as `TIMEOUT`, and exits non-zero. Empirically verified
+against cargo-nextest 0.9.133: the watchdog smoke is killed at
+~30.003s (see `scripts/test-watchdog.sh`).
 
 That last sentence is the load-bearing invariant. If anyone
 removes `terminate-after`, the watchdog downgrades to warn-only.

--- a/scripts/test-watchdog.sh
+++ b/scripts/test-watchdog.sh
@@ -17,8 +17,8 @@
 #   4. Assert the run completed in ~30s (not 90s) — i.e., the test
 #      was actually killed, not allowed to finish.
 #
-# Runs in < 35 seconds. Gated in CI as an advisory job; promote to
-# required once main branch protection is updated. See
+# Runs in < 35 seconds. Invoked inline from the required `test`
+# CI job — if this script fails, the PR is blocked. See
 # `.github/workflows/ci.yml` and docs/testing.md.
 
 set -euo pipefail

--- a/scripts/test-watchdog.sh
+++ b/scripts/test-watchdog.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Test-watchdog regression test.
+#
+# Proves that `.config/nextest.toml`'s `slow-timeout = { period = "…",
+# terminate-after = 1 }` actually kills a runaway test and reports it
+# as failed. Without this script, a future refactor could silently
+# drop `terminate-after` and downgrade the watchdog to a warning-
+# only mode; CI would stay green and the timeout policy would rot.
+#
+# How it works:
+#   1. Invoke `cargo nextest run --run-ignored only` scoped to the
+#      `watchdog_kill_smoke` test in `crates/mango` (which sleeps
+#      90s — past the 30s unit-class budget).
+#   2. Assert the nextest run exits non-zero.
+#   3. Assert the output contains `TIMEOUT` (nextest's kill-marker
+#      token — empirically verified against cargo-nextest 0.9.x).
+#   4. Assert the run completed in ~30s (not 90s) — i.e., the test
+#      was actually killed, not allowed to finish.
+#
+# Runs in < 35 seconds. Gated in CI as an advisory job; promote to
+# required once main branch protection is updated. See
+# `.github/workflows/ci.yml` and docs/testing.md.
+
+set -euo pipefail
+
+# Locate the repo root so this script is callable from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+if ! command -v cargo-nextest >/dev/null 2>&1; then
+  echo "test-watchdog: cargo-nextest is not installed. Install with:"
+  echo "  cargo install cargo-nextest --locked"
+  exit 2
+fi
+
+OUT_FILE="$(mktemp -t mango-watchdog-XXXXXX.log)"
+trap 'rm -f "${OUT_FILE}"' EXIT
+
+echo "test-watchdog: running watchdog_kill_smoke under --profile ci"
+START_TS=$(date +%s)
+set +e
+cargo nextest run \
+  --profile ci \
+  --run-ignored only \
+  --locked \
+  -E 'test(~watchdog_kill_smoke)' \
+  -p mango \
+  >"${OUT_FILE}" 2>&1
+NEXTEST_EXIT=$?
+set -e
+END_TS=$(date +%s)
+ELAPSED=$((END_TS - START_TS))
+
+echo "test-watchdog: nextest exited with ${NEXTEST_EXIT} after ${ELAPSED}s"
+
+# Assertion 1: non-zero exit (the test was recorded as failed).
+if [ "${NEXTEST_EXIT}" = "0" ]; then
+  echo "test-watchdog: FAIL — nextest exit code was 0 (expected non-zero)."
+  echo "test-watchdog: the watchdog did NOT kill the runaway test."
+  echo "--- nextest output ---"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+
+# Assertion 2: TIMEOUT token present (nextest's kill marker).
+if ! grep -q 'TIMEOUT' "${OUT_FILE}"; then
+  echo "test-watchdog: FAIL — 'TIMEOUT' marker not found in nextest output."
+  echo "test-watchdog: this likely means terminate-after was dropped from"
+  echo "               .config/nextest.toml, downgrading kills to warnings."
+  echo "--- nextest output ---"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+
+# Assertion 3: the run was killed within a bounded window, not after
+# the full 90s sleep. Allow generous headroom for slow CI runners
+# (compile/link overhead before the test starts) — 60s is the ceiling;
+# anything below that proves a kill rather than a natural exit.
+if [ "${ELAPSED}" -ge 60 ]; then
+  echo "test-watchdog: FAIL — elapsed ${ELAPSED}s exceeds 60s ceiling."
+  echo "test-watchdog: the test likely ran to natural completion (90s)"
+  echo "               instead of being killed at 30s."
+  echo "--- nextest output ---"
+  cat "${OUT_FILE}"
+  exit 1
+fi
+
+echo "test-watchdog: PASS — watchdog killed the runaway test at ~30s."


### PR DESCRIPTION
## Summary

Ships ROADMAP item 0.5.1 — test watchdog via `cargo-nextest` — with per-test-class hard timeouts (unit=30s, integration=5m, loom=30m, chaos=24h) and a committed regression smoke that proves the watchdog actually kills wedged tests.

## Classification

- [x] **Plumbing** (#1) — no north-star axis moves.
      Verification strategy: `cargo nextest run --workspace --all-targets --locked --profile ci` + `cargo test --doc --workspace --locked` + `bash scripts/test-watchdog.sh`; all three green locally (aarch64-apple-darwin + nextest 0.9.133). Watchdog smoke observed killing a 90s sleep at 30.003s, marker `TIMEOUT`, exit 100.

## What ships

- `.config/nextest.toml` — hard timeouts via `slow-timeout = { period = "…", terminate-after = 1 }` on every class override. Policy lives in `[profile.default]` so local runs enforce the same budgets as CI. `retries = 0` + `failure-output = "immediate-final"` per project test bar.
- `scripts/test-watchdog.sh` — regression smoke. Runs a `#[ignore]`d test (`watchdog_kill_smoke` in `crates/mango`) that sleeps 90s, asserts (1) non-zero exit, (2) `TIMEOUT` marker in output, (3) elapsed <60s. Catches "someone later drops `terminate-after` from the config, downgrading the watchdog to warn-only."
- `.github/workflows/ci.yml` — `test` job now installs `cargo-nextest` via `taiki-e/install-action@5f57d6cb…  # v2` (SHA-pinned per repo convention), runs `cargo nextest run --profile ci`, runs `cargo test --doc` separately (nextest doesn't cover doctests), and runs the watchdog smoke inline.
- `docs/testing.md` — the policy doc. Classes, budgets, process-per-test footguns, local-install instructions, how to add a new class, escape hatches for intentionally long tests, forward refs to madsim and Miri.
- `CONTRIBUTING.md` §8 updated to the exact CI command list (nextest + doctest + watchdog smoke); working rule in the rules section updated to reference both.
- `.github/pull_request_template.md` Test plan checkbox split to match.

## What's deferred

The roadmap item has three sub-goals; this PR ships #1 and #2 but defers #3 (per-test 10×-baseline regression detection). Rationale: nextest has no native 10× feature and a wrapper script over `--message-format libtest-json` is not productive with 2 tests in the workspace today. Will file a follow-up roadmap bullet; ship when the suite has ~50+ tests and CI history to sample from.

## Process

Plan at `.planning/0-5-1-nextest.plan.md`. rust-expert v1 returned REVISE (wrong filter-expression class mapping; `slow-timeout` without `terminate-after` is warn-only not kill; `retries=2` conflicts with the no-flake stance; `failure-output=final` hides first failures). Plan v2 fixed all four and rust-expert returned APPROVE_WITH_NITS — the only nit (bare `cargo nextest show-config` doesn't exist) was addressed in the plan before implementation.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo nextest run --workspace --all-targets --locked --profile ci` (2 tests pass, 1 skipped ignored)
- [x] `cargo test --doc --workspace --locked` (0 doctests today)
- [x] `bash scripts/test-watchdog.sh` (PASS — killed at 30s)
- [x] `cargo doc --workspace --no-deps` (clean)
- [x] `cargo deny check` (advisories/bans/licenses/sources ok)
- [ ] `cargo audit` (local network sometimes blocks; CI runs it)
- [x] `bash scripts/verify-contributing-refs.sh`
- [x] No new `TODO` / `FIXME` / `unimplemented!` introduced
- [ ] rust-expert adversarial review on final diff (final gate)

## Rollback

Revert the merge commit. Restores `cargo test --no-fail-fast` as the CI runner, removes `nextest.toml`, docs, and smoke. No dep graph change, no lockfile churn. The two existing tests still pass under `cargo test`.

## Refs

- `ROADMAP.md:794` — the item being shipped
- `.planning/0-5-1-nextest.plan.md` — final plan (v2)
- [nextest filterset docs](https://nexte.st/docs/filtersets/reference/)
- [nextest slow-tests docs](https://nexte.st/docs/configuration/slow-tests/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
