### PR TITLE
feat(loom): workspace dev-dep + canonical mango-loom-demo template (0.5.2)

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -1,0 +1,108 @@
+# Mango loom workflow
+#
+# Runs loom model-checking in CI. Separate from ci.yml because the
+# loom build uses `RUSTFLAGS="--cfg loom"` which is ABI-incompatible
+# with the default build cache — sharing a Swatinem/rust-cache scope
+# would thrash. Separate job → separate cache prefix (`v0-loom`).
+#
+# Budget: the loom class in `.config/nextest.toml` sets
+# `slow-timeout = 30m` with `terminate-after = 1`. This job's
+# `timeout-minutes: 45` is the belt on top of that suspender — any
+# individual wedged model gets SIGTERM'd by nextest first; the
+# workflow kill fires only if the runner itself is hung.
+#
+# Action refs are SHA-pinned per ci.yml's convention.
+#
+# Path filter: this workflow only runs when loom-relevant files
+# change. A docs-only PR does not pay the loom tax. Required-check
+# policy (branch protection) should list "loom" with
+# `require_for_changed_paths` so the check stays green when the path
+# filter skips it.
+#
+# Security note: no `${{ github.event.* }}` interpolation inside
+# run: blocks. All inputs are static, and the only dynamic GITHUB_*
+# usage is in `concurrency.group` (ref name), which is sanitized by
+# GitHub before workflow dispatch.
+
+name: loom
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/mango-loom-demo/**"
+      - ".github/workflows/loom.yml"
+      - ".config/nextest.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    paths:
+      - "crates/mango-loom-demo/**"
+      - ".github/workflows/loom.yml"
+      - ".config/nextest.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+jobs:
+  loom:
+    name: loom
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          # Separate cache from ci.yml's clippy/test jobs. The loom
+          # build sets `--cfg loom` via RUSTFLAGS, which invalidates
+          # the default build cache anyway; giving it its own prefix
+          # makes the separation explicit and avoids alternation
+          # thrash when ci.yml runs on the same PR.
+          prefix-key: v0-loom
+          shared-key: ""
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458  # v2
+        with:
+          tool: cargo-nextest
+      - name: cargo fetch
+        run: cargo fetch --locked
+      - name: cargo nextest run (loom)
+        # Canonical loom invocation. Documented in docs/loom.md.
+        #
+        # --cfg loom: activates loom::* imports in the demo crate
+        #   (the ecosystem-standard idiom, not a Cargo feature).
+        # -C debug-assertions: loom's internal aliasing and causality
+        #   checks are gated on debug_assertions. Without this flag,
+        #   `--release` would silently neuter the model — tests would
+        #   still "pass" but never actually check anything.
+        # LOOM_MAX_PREEMPTIONS=2: tokio/crossbeam convention. 2 is
+        #   the canonical smoke-level preemption budget; higher
+        #   values explode the schedule space super-linearly.
+        # LOOM_MAX_BRANCHES=10000: caps exploration per model.
+        #   Protects against a runaway model; 10k is generous for the
+        #   demo (exploration finishes in <100 branches) and leaves
+        #   headroom for Phase 3+ models that are copied from this
+        #   template.
+        # --release: loom recommends release mode because Drop-order
+        #   and inlining can affect the model. `-C debug-assertions`
+        #   preserves the checks; see above.
+        # --profile ci: inherits the 30m per-test watchdog from the
+        #   [profile.default.overrides] filter='test(~loom)' entry in
+        #   .config/nextest.toml.
+        env:
+          RUSTFLAGS: "--cfg loom -C debug-assertions"
+          LOOM_MAX_PREEMPTIONS: "2"
+          LOOM_MAX_BRANCHES: "10000"
+        run: cargo nextest run --profile ci --release -p mango-loom-demo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,11 @@ with worked examples: [`docs/arithmetic-policy.md`][arith].
   `clippy::disallowed_types`; see [`clippy.toml`](./clippy.toml).
   Neither `parking_lot` nor `tokio::sync` poisons on panic, and
   neither holds its guard across `.await` (enforced by
-  `clippy::await_holding_lock`).
+  `clippy::await_holding_lock`). Any custom shared-state primitive
+  (atomic-based counter, lock-free queue, handwritten guard) must
+  ship with a `loom` model that exercises its ordering invariants;
+  see [`docs/loom.md`](./docs/loom.md) and the template crate
+  [`crates/mango-loom-demo`](./crates/mango-loom-demo/).
 - **Monotonic clock.** All protocol-relevant time math uses
   `std::time::Instant` (monotonic). `SystemTime` is only for
   human-facing display (logs, lease-TTL rendering). Full policy:
@@ -278,6 +282,16 @@ cargo deny check
 cargo audit
 rustup run 1.80 cargo check --workspace --all-targets --locked \
   --target x86_64-unknown-linux-gnu
+```
+
+Optional — run the loom model-checker suite locally. Not required on
+every PR, but mandatory for any PR that adds or modifies a
+shared-state primitive (see [`docs/loom.md`](./docs/loom.md)):
+
+```bash
+RUSTFLAGS="--cfg loom -C debug-assertions" \
+  LOOM_MAX_PREEMPTIONS=2 LOOM_MAX_BRANCHES=10000 \
+  cargo nextest run --profile ci --release -p mango-loom-demo
 ```
 
 Notes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,10 +74,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result",
+]
 
 [[package]]
 name = "getrandom"
@@ -113,6 +144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,8 +168,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mango"
 version = "0.1.0"
+
+[[package]]
+name = "mango-loom-demo"
+version = "0.1.0"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "mango-proto"
@@ -140,6 +197,15 @@ version = "0.1.0"
 dependencies = [
  "prost",
  "tonic-build",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -153,6 +219,15 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "once_cell"
@@ -169,6 +244,12 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
@@ -299,6 +380,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,10 +460,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasip2"
@@ -353,9 +531,24 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-sys"
@@ -363,7 +556,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,14 @@
 [workspace]
 resolver = "2"
-members = ["crates/mango", "crates/mango-proto"]
+members = ["crates/mango", "crates/mango-proto", "crates/mango-loom-demo"]
+
+# Exact-version pin for loom. Env-var semantics (LOOM_MAX_PREEMPTIONS,
+# LOOM_MAX_BRANCHES, etc.) and model behavior can drift between minor
+# versions; pinning exact prevents `cargo update` from silently
+# changing CI semantics. See docs/loom.md for the version-bump
+# procedure.
+[workspace.dependencies]
+loom = "=0.7.2"
 
 [workspace.package]
 version = "0.1.0"

--- a/crates/mango-loom-demo/Cargo.toml
+++ b/crates/mango-loom-demo/Cargo.toml
@@ -1,0 +1,63 @@
+[package]
+name = "mango-loom-demo"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Canonical loom-test template. Scaffolds the pattern Phase 3+ primitives copy. PEDAGOGICAL — not a dependency."
+publish = false
+
+# loom is a `cfg(loom)` dep, not a dev-dep. `src/lib.rs` references
+# `loom::thread` and `loom::sync::atomic::AtomicBool` directly under
+# `#[cfg(loom)]`, so loom must be linked into the library target, not
+# just tests/benches/examples. Dev-deps are scoped to non-lib targets
+# only, so they would compile the lib without `loom` in the crate
+# graph and fail on the `loom::...` paths. The tokio/crossbeam/bytes
+# idiom is a target-cfg dep gated on `cfg(loom)`:
+#   [target.'cfg(loom)'.dependencies]
+# The dep is only pulled in when `RUSTFLAGS="--cfg loom"` is set, so
+# default builds have zero loom overhead — same behavior as a
+# dev-dep for normal `cargo test`, correct behavior under `--cfg loom`.
+[target.'cfg(loom)'.dependencies]
+loom.workspace = true
+
+# Intentionally does NOT declare `[lints] workspace = true`.
+# Workspace policy sets `unsafe_code = "forbid"`, which `forbid`
+# semantics make non-overridable in any crate that inherits.
+# This demo crate needs unsafe for the cell shim and raw-pointer
+# dereferences in the spinlock guard, so it opts out of workspace
+# lint inheritance entirely and declares its own minimal policy
+# below. Workspace lints only apply to members with
+# `[lints] workspace = true`; omitting that line is the documented
+# escape hatch (Cargo reference, RFC 3389).
+#
+# Note: `missing_lints_inheritance` is a nightly-only Cargo lint
+# (gated on `-Zcargo-lints`, landed in cargo 1.95 Feb 2026) that
+# would flag non-inheriting crates. Our stable toolchain does not
+# emit it, so no `[lints.cargo]` allow is needed. Revisit if we
+# ever adopt `-Zcargo-lints` in CI.
+
+[lints.rust]
+unsafe_code = "allow"
+unreachable_pub = "warn"
+# `--cfg loom` is the ecosystem-standard activation mechanism
+# (see docs/loom.md). Declare the cfg here so rustc's
+# unexpected_cfgs lint doesn't warn on every `#[cfg(loom)]` /
+# `#[cfg(not(loom))]` gate under the default build.
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(loom)"] }
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+# Preserve hardening where reasonable — the demo still
+# shouldn't panic, slice-index blindly, or use unwrap/expect
+# outside tests.
+unwrap_used = { level = "deny", priority = 1 }
+expect_used = { level = "deny", priority = 1 }
+panic = { level = "deny", priority = 1 }
+unimplemented = { level = "deny", priority = 1 }
+todo = { level = "deny", priority = 1 }
+indexing_slicing = { level = "deny", priority = 1 }
+dbg_macro = { level = "deny", priority = 1 }

--- a/crates/mango-loom-demo/src/lib.rs
+++ b/crates/mango-loom-demo/src/lib.rs
@@ -1,0 +1,152 @@
+//! **PEDAGOGICAL DEMO ONLY.** This crate exercises the loom
+//! workspace scaffolding and serves as a template that Phase 3+
+//! primitives copy.
+//!
+//! Do NOT depend on `Spinlock` from any other crate. Spinlocks
+//! are almost always the wrong tool; when Phase 3+ lands real
+//! primitives, use those.
+//!
+//! Ordering discipline: `Ordering` is imported from `std` on
+//! both arms — loom re-exports the same type. The cfg split is
+//! for `AtomicBool` and the cell module only.
+
+use std::sync::atomic::Ordering;
+
+#[cfg(loom)]
+use loom::sync::atomic::AtomicBool;
+#[cfg(not(loom))]
+use std::sync::atomic::AtomicBool;
+
+// Cell shim. The non-loom arm wraps std::cell::UnsafeCell with
+// the SAME surface loom's UnsafeCell exposes (`new`, `with`,
+// `with_mut`) — no escape hatch to raw pointers beyond what
+// loom itself offers. This keeps the pattern loom-faithful:
+// Phase 3+ authors copying this file cannot write code that
+// "works under cargo test, broken under --cfg loom".
+#[cfg(not(loom))]
+mod cell {
+    pub(crate) struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
+
+    impl<T> UnsafeCell<T> {
+        pub(crate) const fn new(data: T) -> Self {
+            Self(std::cell::UnsafeCell::new(data))
+        }
+        pub(crate) fn with<R>(&self, f: impl FnOnce(*const T) -> R) -> R {
+            f(self.0.get())
+        }
+        pub(crate) fn with_mut<R>(&self, f: impl FnOnce(*mut T) -> R) -> R {
+            f(self.0.get())
+        }
+    }
+}
+
+#[cfg(loom)]
+mod cell {
+    pub(crate) use loom::cell::UnsafeCell;
+}
+
+use cell::UnsafeCell;
+
+#[doc(hidden)]
+pub struct Spinlock<T> {
+    locked: AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+// SAFETY: `locked` serializes access; the only path to `data`
+// goes through `lock`, which enforces mutual exclusion.
+// `T: Send` is required; `T: Sync` is not, because only one
+// thread reads/writes `data` at a time. Precedent: std's
+// `unsafe impl<T: ?Sized + Send> Sync for Mutex<T>`.
+unsafe impl<T: Send> Send for Spinlock<T> {}
+unsafe impl<T: Send> Sync for Spinlock<T> {}
+
+impl<T> Spinlock<T> {
+    pub fn new(data: T) -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock(&self) -> SpinlockGuard<'_, T> {
+        while self
+            .locked
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            #[cfg(loom)]
+            loom::thread::yield_now();
+            #[cfg(not(loom))]
+            std::hint::spin_loop();
+        }
+        SpinlockGuard { lock: self }
+    }
+}
+
+#[must_use = "SpinlockGuard holds the lock for its lifetime; a dropped guard immediately releases"]
+#[doc(hidden)]
+pub struct SpinlockGuard<'a, T> {
+    lock: &'a Spinlock<T>,
+}
+
+impl<T> SpinlockGuard<'_, T> {
+    /// Loom-aware read access. Prefer this in loom tests so the
+    /// access is observed by the model.
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        // SAFETY: guard's existence proves we hold the lock;
+        // the cell shim ensures loom sees the access on the
+        // loom arm.
+        self.lock.data.with(|p| unsafe { f(&*p) })
+    }
+
+    /// Loom-aware write access. Prefer this in loom tests.
+    pub fn with_mut<R>(&mut self, f: impl FnOnce(&mut T) -> R) -> R {
+        // SAFETY: guard's existence proves exclusive access.
+        self.lock.data.with_mut(|p| unsafe { f(&mut *p) })
+    }
+}
+
+// Deref/DerefMut on the non-loom arm are a convenience for
+// normal (non-loom) use. Under loom we suppress them so tests
+// are forced to use .with()/.with_mut(), which route through
+// loom's cell tracking. The non-loom impls ALSO route through
+// .with()/.with_mut() (via the shim) so the API shape is
+// congruent with loom's — no raw-pointer escape hatch.
+#[cfg(not(loom))]
+impl<T> std::ops::Deref for SpinlockGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        // SAFETY: by construction (`Spinlock::lock`), a
+        // `SpinlockGuard<'a, T>` exists only after a successful
+        // `compare_exchange_weak(false, true, Acquire, _)` on
+        // `self.lock.locked`, and `Drop` releases with
+        // `Ordering::Release`. While this guard lives, no other
+        // thread can obtain a second guard on the same Spinlock,
+        // so we hold exclusive access to `data`. The guard's 'a
+        // lifetime bounds the returned reference; the closure's
+        // return type unifies with `&T` so the pointer
+        // dereference is lifetime-bounded to `&self`. Precedent:
+        // std::sync::Mutex's `unsafe impl<T: ?Sized + Send> Sync
+        // for Mutex<T>` relies on the same construction-time
+        // invariant.
+        self.lock.data.with(|p| unsafe { &*p })
+    }
+}
+
+#[cfg(not(loom))]
+impl<T> std::ops::DerefMut for SpinlockGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: same guard-existence invariant as in `deref`,
+        // upgraded to exclusive access because we hold `&mut self`
+        // on the guard — no aliased `Deref` reference can be live
+        // concurrently with this `DerefMut` call.
+        self.lock.data.with_mut(|p| unsafe { &mut *p })
+    }
+}
+
+impl<T> Drop for SpinlockGuard<'_, T> {
+    fn drop(&mut self) {
+        self.lock.locked.store(false, Ordering::Release);
+    }
+}

--- a/crates/mango-loom-demo/tests/loom_spinlock.rs
+++ b/crates/mango-loom-demo/tests/loom_spinlock.rs
@@ -1,0 +1,29 @@
+#![cfg(loom)]
+
+use mango_loom_demo::Spinlock;
+use std::sync::Arc;
+
+#[test]
+fn mutual_exclusion() {
+    loom::model(|| {
+        let lock = Arc::new(Spinlock::new(0_u32));
+
+        let lock_a = Arc::clone(&lock);
+        let t1 = loom::thread::spawn(move || {
+            let mut g = lock_a.lock();
+            g.with_mut(|v| *v += 1);
+        });
+
+        let lock_b = Arc::clone(&lock);
+        let t2 = loom::thread::spawn(move || {
+            let mut g = lock_b.lock();
+            g.with_mut(|v| *v += 1);
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        let g = lock.lock();
+        g.with(|v| assert_eq!(*v, 2));
+    });
+}

--- a/crates/mango-loom-demo/tests/loom_spinlock.rs
+++ b/crates/mango-loom-demo/tests/loom_spinlock.rs
@@ -1,7 +1,7 @@
 #![cfg(loom)]
 
+use loom::sync::Arc;
 use mango_loom_demo::Spinlock;
-use std::sync::Arc;
 
 #[test]
 fn mutual_exclusion() {

--- a/docs/loom.md
+++ b/docs/loom.md
@@ -1,0 +1,227 @@
+# Loom policy
+
+[loom](https://github.com/tokio-rs/loom) is mango's concurrency
+model-checker. Any shared-state primitive that manipulates atomics,
+`UnsafeCell`, or lock-free data structures **must** ship with a loom
+model exercising its ordering invariants before it can land on a
+Phase 3+ branch.
+
+This doc is the policy. The canonical template lives at
+[`crates/mango-loom-demo/`](../crates/mango-loom-demo/); the CI
+enforcement is [`.github/workflows/loom.yml`](../.github/workflows/loom.yml).
+
+## Why loom
+
+Concurrent code passes `cargo test` by luck on x86. The TSO memory
+model of x86 hides a wide class of ordering bugs that only surface
+on weaker architectures (ARM, RISC-V, POWER) or under aggressive
+compiler reordering. loom is a sequentially-consistent model checker
+that _deliberately_ explores interleavings permitted by the C++20
+memory model — the same model `std::sync::atomic` compiles down to.
+
+Under `--cfg loom`:
+
+- `std::thread::spawn` is replaced by `loom::thread::spawn`, which
+  yields control to the model scheduler at every synchronization
+  primitive.
+- `std::sync::atomic::*` types are replaced by loom's, which track
+  happens-before chains and flag causality violations.
+- `std::cell::UnsafeCell` is replaced by `loom::cell::UnsafeCell`,
+  which records accesses and flags data races the compiler can't.
+
+If a loom model fails, it prints an interleaving that violates the
+property. Fix the ordering until the model passes under
+`LOOM_MAX_PREEMPTIONS=2`. This is the hard bar for merging any
+lock-free primitive.
+
+## Activation — `RUSTFLAGS`, not a Cargo feature
+
+Loom is activated with `RUSTFLAGS="--cfg loom"`, not a Cargo feature.
+This is the tokio / crossbeam / bytes convention. Cargo features
+unify across the dependency graph, which would be a disaster for
+loom — a downstream crate enabling `loom` would flip the activation
+for every dep that uses it, recompiling the world into the model
+layer even for builds that aren't loom runs.
+
+Cfg gates are local to the crate that declares them. The demo
+crate's `Cargo.toml` wires loom as a target-cfg dep so it's only
+linked when `--cfg loom` is set:
+
+```toml
+[target.'cfg(loom)'.dependencies]
+loom.workspace = true
+```
+
+Default builds pay zero loom cost. Under `--cfg loom`, loom is linked
+and the demo's `#[cfg(loom)]` imports resolve.
+
+## Canonical invocation
+
+```bash
+RUSTFLAGS="--cfg loom -C debug-assertions" \
+  LOOM_MAX_PREEMPTIONS=2 \
+  LOOM_MAX_BRANCHES=10000 \
+  cargo nextest run --profile ci --release -p mango-loom-demo
+```
+
+Every flag is load-bearing:
+
+| Flag                      | Why                                                                                                                                                                                                                   |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--cfg loom`              | Activates the `#[cfg(loom)]` gates in the crate. Without it, loom is not linked and the tests compile as ordinary threads — meaningless.                                                                              |
+| `-C debug-assertions`     | Loom's aliasing and causality checks are gated on `debug_assertions`. `--release` silently neuters them otherwise — tests "pass" without actually checking anything.                                                  |
+| `LOOM_MAX_PREEMPTIONS=2`  | Caps preemption points per model run. `2` is the tokio/crossbeam-standard smoke value — enough to catch realistic interleaving bugs without schedule-space explosion. Raise temporarily when chasing a suspected bug. |
+| `LOOM_MAX_BRANCHES=10000` | Caps total branches explored per `loom::model(…)` call. Protects against a runaway model.                                                                                                                             |
+| `--release`               | Loom itself recommends release mode; optimization can change Drop order and inlining, which can shift observable scheduling. `-C debug-assertions` keeps loom's internal assertions alive.                            |
+| `--profile ci`            | Inherits the `30m` per-test watchdog from the `test(~loom)` filter in [`.config/nextest.toml`](../.config/nextest.toml).                                                                                              |
+| `-p mango-loom-demo`      | Scopes to the demo crate. Phase 3+ additions will add more `-p <crate>` entries; the full-matrix invocation will eventually live in a Makefile recipe.                                                                |
+
+Do not edit any of these flags without updating this doc and
+[`.github/workflows/loom.yml`](../.github/workflows/loom.yml) in
+the same commit.
+
+## Loom environment variables (reference)
+
+These are loom's runtime knobs. The defaults in the canonical
+invocation above are tuned for CI; raise them during local debugging.
+
+| Var                        | Default        | Purpose                                                                                                                                  |
+| -------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `LOOM_MAX_PREEMPTIONS`     | `2` (ours)     | Max preemptions per model. Higher → more interleavings, super-linear blow-up.                                                            |
+| `LOOM_MAX_BRANCHES`        | `10000` (ours) | Hard cap on branches per `loom::model`. Aborts runaway models.                                                                           |
+| `LOOM_MAX_DURATION`        | unset          | Wall-clock budget for a single model run (seconds). Use when chasing combinatorial explosion.                                            |
+| `LOOM_MAX_PERMUTATIONS`    | unset          | Cap on permutations explored. Rarely needed.                                                                                             |
+| `LOOM_CHECKPOINT_FILE`     | unset          | Write-through checkpoint; resume a long model from where it crashed.                                                                     |
+| `LOOM_CHECKPOINT_INTERVAL` | unset          | Branches between checkpoint writes.                                                                                                      |
+| `LOOM_LOCATION`            | unset          | Emit source locations for atomic ops in the failure trace. Turn on when a model fails and you need to map the interleaving back to code. |
+| `LOOM_LOG`                 | unset          | Verbose scheduler trace (`trace`, `debug`, `info`). Loud; only use on a single failing test.                                             |
+
+Full reference: [loom `Builder` docs](https://docs.rs/loom/latest/loom/model/struct.Builder.html).
+
+## Writing a new loom test
+
+1. Copy the shape of [`crates/mango-loom-demo/src/lib.rs`](../crates/mango-loom-demo/src/lib.rs).
+   The pattern is: cfg-split imports, cfg-split `UnsafeCell` shim,
+   loom-aware `.with()/.with_mut()` accessors on any guard type.
+2. Put the test in `tests/loom_*.rs` with `#![cfg(loom)]` at the
+   file head. The `test(~loom)` filter in `.config/nextest.toml`
+   routes it into the 30-minute budget.
+3. Wrap each model in `loom::model(|| { … })`. Everything inside
+   the closure — `Arc::new`, `loom::thread::spawn`, `.join()` — runs
+   once _per interleaving_, not once.
+4. Use `loom::thread::spawn` (not `std::thread::spawn`) and
+   `loom::sync::Arc` (or `std::sync::Arc` — std's is Sync under
+   loom too, but the loom-native `Arc` integrates better).
+5. Drive the model through `loom::thread::yield_now()` in spin
+   loops. On the non-loom arm, use `std::hint::spin_loop()`.
+
+### The critical rule: no raw-pointer escape hatch
+
+Any code path that reaches `*ptr` on an `UnsafeCell`'s data must go
+through `.with()` / `.with_mut()`. On the loom arm these are the
+hooks loom uses to detect data races. A Deref impl that dereferences
+the cell's raw pointer directly will work on std but be invisible
+to loom — the exact "passes `cargo test`, broken under `--cfg loom`"
+footgun this template is designed to prevent.
+
+The demo's `Deref` / `DerefMut` impls are cfg-gated to the non-loom
+arm for this reason. Under loom, tests are forced to use
+`.with()` / `.with_mut()`.
+
+### Sanity-break every model
+
+Before merging, prove the model is actually checking something:
+flip each `Ordering::Acquire` to `Relaxed`, flip each
+`Ordering::Release` to `Relaxed`, run loom, and confirm the model
+**fails** with a causality violation. Restore the orderings. A model
+that passes under both strong and weak orderings is not checking
+what you think it's checking.
+
+The demo was sanity-broken in both directions during development:
+
+- `compare_exchange_weak(Acquire, Relaxed)` → `(Relaxed, Relaxed)`
+  → loom reports `Causality violation: Concurrent write accesses
+to UnsafeCell`.
+- `store(Release)` → `store(Relaxed)` → same violation.
+
+## Version-bump procedure
+
+`loom` is pinned exactly at the workspace level:
+
+```toml
+[workspace.dependencies]
+loom = "=0.7.2"
+```
+
+The exact pin is load-bearing. Loom's env-var semantics, model
+internals, and which interleavings are explored can drift between
+minor versions. A `cargo update` that silently bumps loom can
+change CI semantics without a diff anyone can review.
+
+To bump:
+
+1. Update the pin in the workspace `Cargo.toml`.
+2. Run `cargo update -p loom`.
+3. Re-run the canonical invocation locally and confirm the demo
+   still passes.
+4. **Sanity-break again.** New loom versions have occasionally
+   weakened the detection — if the sanity breaks no longer fail the
+   model, that's a red flag worth investigating before merging.
+5. Scan loom's CHANGELOG for env-var renames or default changes.
+   Update this doc and `.github/workflows/loom.yml` in the same
+   commit as the bump.
+6. PR review gate: the rust-expert agent must sign off on the
+   bump diff.
+
+## Debugging a failed model
+
+When loom reports a causality violation, the output is a schedule
+— a sequence of thread steps interleaved with atomic ops. The
+default output is terse. To make it readable:
+
+1. Set `LOOM_LOCATION=1` — annotates each step with the source
+   location of the atomic op or thread spawn. Essential for mapping
+   the schedule back to code.
+2. Drop `LOOM_MAX_BRANCHES` to `100` — loom explores in a
+   roughly-deterministic order, so the first failing schedule is
+   usually near the start of the exploration. A tight cap gets you
+   to it faster.
+3. Drop `LOOM_MAX_PREEMPTIONS` to `1` — if the model fails at 1
+   preemption, the bug is a _simpler_ violation than a 2-preemption
+   one. Fixing the 1-preemption case often fixes the 2-preemption
+   one.
+4. Run a single model: `cargo nextest run -E 'test(my_model)'`.
+
+If loom still reports a violation you don't understand, turn on
+`LOOM_LOG=trace` on a single model. The output is extremely verbose
+— capture it to a file.
+
+## Non-negotiables (pre-merge checklist)
+
+For any PR that adds or modifies a shared-state primitive:
+
+- [ ] A loom model exists and lives in `tests/loom_*.rs` or a
+      loom-named module.
+- [ ] The model passes under the canonical invocation
+      (`LOOM_MAX_PREEMPTIONS=2`).
+- [ ] The model has been sanity-broken at least once per ordering
+      it's supposed to verify.
+- [ ] Any `Ordering::Relaxed` has a comment justifying why weaker
+      than `Acquire`/`Release` is correct.
+- [ ] Any `UnsafeCell` access goes through `.with()` / `.with_mut()`.
+- [ ] The PR description links the loom job run (green) on the
+      final commit.
+
+A PR without these is not mergeable.
+
+## See also
+
+- [`docs/testing.md`](testing.md) — the `loom` test class (30-minute
+  watchdog) lives in the shared nextest policy.
+- [`CONTRIBUTING.md` §8](../CONTRIBUTING.md) — optional local loom
+  invocation.
+- [`ROADMAP.md` item 0.5.2](../ROADMAP.md) — where this policy was declared.
+- [loom — tokio-rs/loom](https://github.com/tokio-rs/loom)
+- [loom Builder env-var reference](https://docs.rs/loom/latest/loom/model/struct.Builder.html)
+- The blog post series that led to loom:
+  [_An Introduction to lock-free programming_ — Jeff Preshing](https://preshing.com/20120612/an-introduction-to-lock-free-programming/).

--- a/docs/loom.md
+++ b/docs/loom.md
@@ -140,8 +140,7 @@ what you think it's checking.
 The demo was sanity-broken in both directions during development:
 
 - `compare_exchange_weak(Acquire, Relaxed)` → `(Relaxed, Relaxed)`
-  → loom reports `Causality violation: Concurrent write accesses
-to UnsafeCell`.
+  → loom reports ``Causality violation: Concurrent write accesses to `UnsafeCell`.`` (backticks around `UnsafeCell` are loom's verbatim output).
 - `store(Release)` → `store(Relaxed)` → same violation.
 
 ## Version-bump procedure

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,12 +27,12 @@ test is [`scripts/test-watchdog.sh`](../scripts/test-watchdog.sh).
 
 ## Test classes and budgets
 
-| Class | Selector | Budget | Used for |
-|-------|----------|--------|----------|
-| `unit` | default (unclassified) | 30s | `#[cfg(test)] mod tests` in `src/`, pure function tests, codec round-trips |
-| `integration` | `kind(test)` | 5 min | `tests/*.rs` at each crate root; multi-module exercises |
-| `loom` | `test(~loom)` | 30 min | Concurrency model checking (Phase 5+) |
-| `chaos` | `test(~chaos)` | 24 h | Fault injection / crash-only recovery (Phase 14.5+) |
+| Class         | Selector               | Budget | Used for                                                                                         |
+| ------------- | ---------------------- | ------ | ------------------------------------------------------------------------------------------------ |
+| `unit`        | default (unclassified) | 30s    | `#[cfg(test)] mod tests` in `src/`, pure function tests, codec round-trips                       |
+| `integration` | `kind(test)`           | 5 min  | `tests/*.rs` at each crate root; multi-module exercises                                          |
+| `loom`        | `test(~loom)`          | 30 min | Concurrency model checking (see [`docs/loom.md`](loom.md); template in `crates/mango-loom-demo`) |
+| `chaos`       | `test(~chaos)`         | 24 h   | Fault injection / crash-only recovery (Phase 14.5+)                                              |
 
 The filter expressions live in
 [`.config/nextest.toml`](../.config/nextest.toml) under


### PR DESCRIPTION
## Summary

Ships ROADMAP item 0.5.2 — **`loom` as a workspace dev-dependency** — via a canonical pedagogical template that Phase 3+ shared-state primitives will copy.

- New crate `crates/mango-loom-demo` with a loom-faithful `Spinlock<T>` / `SpinlockGuard` demo. loom declared under `[target.'cfg(loom)'.dependencies]` (the tokio/crossbeam/bytes idiom) — zero overhead on default builds; only linked under `RUSTFLAGS="--cfg loom"`.
- Workspace-level exact pin `loom = "=0.7.2"` to freeze env-var semantics across `cargo update`.
- cfg-split `UnsafeCell` shim with a congruent `.with()/.with_mut()` surface on both arms, Deref/DerefMut gated to non-loom arm — removes the "passes `cargo test`, broken under `--cfg loom`" footgun by construction.
- Sanity-break verified both directions: flipping `Ordering::Acquire` → `Relaxed` on the CAS, and `Ordering::Release` → `Relaxed` on the unlock store, each trigger `loom`'s causality-violation detector. Restored in the final commit.
- `.github/workflows/loom.yml` runs the canonical invocation on every path-relevant PR. Separate Swatinem cache (`v0-loom`) to avoid thrashing the default build cache. `RUSTFLAGS` / `LOOM_*` passed as step env, not interpolated into `run:` (workflow-injection hardening).
- `docs/loom.md` (~180 lines): activation rationale, canonical invocation table, env-var reference, new-test recipe, critical no-raw-pointer-escape-hatch rule, sanity-break discipline, version-bump procedure, debugging recipe, pre-merge checklist.
- `CONTRIBUTING.md` §7 and §8 updated with the loom command and a pointer to `docs/loom.md`; `docs/testing.md` loom row points at `docs/loom.md` and the template crate.

Roadmap checkbox flip will land directly on `main` after merge per the convention in `CONTRIBUTING.md §3`.

Closes roadmap item: `ROADMAP.md:773` — `loom` as a workspace dev-dependency.

## North-star classification

**Plumbing.** This PR introduces no shared-state primitive of its own and moves no north-star axis directly; it lands the template and the CI gate that Phase 3+ concurrency work will use to meet Reviewer's Contract items #4 (concurrency) and #5 (unsafe) evidence requirements. The demo's `unsafe` is pedagogical and isolated to the non-workspace-inheriting crate; the workspace `unsafe_code = "forbid"` policy is unchanged.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean.
- [x] `cargo nextest run --workspace --all-targets --locked --profile ci` passes (2 existing tests, demo contributes 0 under default build — expected, `#![cfg(loom)]` gate).
- [x] `cargo test --doc --workspace --locked` passes.
- [x] `cargo deny check` clean (advisories ok, bans ok, licenses ok, sources ok).
- [x] **Canonical loom invocation passes locally:** `RUSTFLAGS="--cfg loom -C debug-assertions" LOOM_MAX_PREEMPTIONS=2 LOOM_MAX_BRANCHES=10000 cargo nextest run --profile ci --release -p mango-loom-demo` — 1 passed, 0 skipped in 19ms.
- [x] **Sanity break #1 (Acquire → Relaxed):** model reports `Causality violation: Concurrent write accesses to UnsafeCell`. Restored.
- [x] **Sanity break #2 (Release → Relaxed):** model reports the same causality violation. Restored.
- [x] `.github/workflows/loom.yml` runs via path filter on this PR and is expected to go green on the same canonical invocation.
- [x] Path-only verification: docs-only PRs won't trigger loom (path filter excludes everything outside `crates/mango-loom-demo/`, `.github/workflows/loom.yml`, `.config/nextest.toml`, `Cargo.toml`, `Cargo.lock`).

## Rollback

Revert both commits (`a8b5d62`, `5ad2013`). The workspace loses the `crates/mango-loom-demo` member and the workspace `loom` dep; the CI loom job stops being invoked because the workflow file is gone; the docs pointer from `docs/testing.md` becomes a dead link and is removed by the revert. No other mango code depends on any of these artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
