### PR TITLE
ci: grep-based CT-compare gate + fixtures (0.7)

### DIFF
--- a/.ct-comparison-ignore
+++ b/.ct-comparison-ignore
@@ -1,0 +1,24 @@
+# .ct-comparison-ignore — file-level exemptions for the
+# constant-time comparison gate (scripts/ct-comparison-check.sh,
+# docs/ct-comparison-policy.md).
+#
+# Use this file for whole-file false positives where the P1-P5 grep
+# signatures fire on code that is definitively not a secret compare —
+# the motivating case is name collisions like `token_bucket.rs`
+# (scope-word "token" in the filename, but the module is about rate
+# limiting, not authentication tokens).
+#
+# Per-line exemptions belong at the call site as a `// ct-allow: <reason>`
+# annotation, not here. File-level exemption is the blunt instrument;
+# prefer line-level where possible.
+#
+# Format:
+#   - one repo-relative path per line
+#   - `#` starts a comment; trailing comments are stripped
+#   - blank lines ignored
+#   - each path MUST exist at check time; a missing file aborts the
+#     gate with exit code 3 (prevents stale entries from silently
+#     disabling coverage)
+#
+# Example (commented out — uncomment with a real path when needed):
+# crates/mango-ratelimit/src/token_bucket.rs  # rate-limit, not auth

--- a/.github/workflows/ct-comparison.yml
+++ b/.github/workflows/ct-comparison.yml
@@ -1,0 +1,81 @@
+# Mango constant-time comparison gate
+#
+# Runs the scoped grep gate in scripts/ct-comparison-check.sh against
+# `auth*` / `crypto*` / `token*` / `hash_chain*` source files under
+# `crates/*/src/`. The gate enforces five signatures (P1-P5) that are
+# timing-oracle-prone byte compares; see docs/ct-comparison-policy.md.
+#
+# Escape hatch: a `// ct-allow: <reason>` on the same line as a match
+# exempts it. Adding a new annotation in a PR requires the
+# `ct-allow-approved` label (set-difference computed via git — rustfmt
+# reflows do not trigger false readings).
+#
+# Two steps:
+#
+#   harness  — fast smoke test of the gate logic itself
+#              (scripts/ct-comparison-scripts-test.sh, 18 scenarios).
+#              Fails the job if the gate regresses before we run it
+#              on real code.
+#
+#   gate     — the real enforcement. Exit codes:
+#              0 PASS, 1 violations, 2 missing label,
+#              3 stale .ct-comparison-ignore entry.
+#
+# Security: every `github.event.*` value flows through step-level
+# `env:` and is read as a shell variable in `run:`. No direct
+# interpolation into shell. Matches the pattern in geiger.yml /
+# miri.yml / loom.yml.
+
+name: ct-comparison
+
+on:
+  pull_request:
+    paths:
+      - "crates/**"
+      - ".ct-comparison-ignore"
+      - "docs/ct-comparison-policy.md"
+      - ".github/workflows/ct-comparison.yml"
+      - "scripts/ct-comparison-*.sh"
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - ".ct-comparison-ignore"
+      - "docs/ct-comparison-policy.md"
+      - ".github/workflows/ct-comparison.yml"
+      - "scripts/ct-comparison-*.sh"
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  ct-comparison:
+    name: ct-comparison (grep gate)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      # fetch-depth: 0 is required so the gate can read
+      # origin/$GITHUB_BASE_REF:<file> for the base-tree annotation
+      # set-difference. Shallower clones make the PR label gate a no-op.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      # Fail fast if check logic regressed before running on real code.
+      - name: ct-comparison scripts self-test
+        run: bash scripts/ct-comparison-scripts-test.sh
+
+      - name: ct-comparison gate
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          # toJson(null) yields "null"; branch on event_name to feed
+          # a real JSON array only on pull_request. Matches the
+          # PR_LABELS pattern in geiger.yml.
+          PR_LABELS: ${{ github.event_name == 'pull_request' && toJson(github.event.pull_request.labels.*.name) || '[]' }}
+        run: bash scripts/ct-comparison-check.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,20 @@ with worked examples: [`docs/arithmetic-policy.md`][arith].
   Complements `unsafe_code = "forbid"` (compile-time) and Miri
   (runtime UB). Full policy:
   [`docs/unsafe-policy.md`](./docs/unsafe-policy.md).
+- **Constant-time comparison.** Byte-compare timing oracles are
+  banned in modules matching `auth*` / `crypto*` / `token*` /
+  `hash_chain*` under `crates/*/src/`. Use
+  `subtle::ConstantTimeEq::ct_eq` for any `&[u8]` / `Vec<u8>` compare
+  that involves a secret (MAC tag, HMAC, token, hash digest, signature,
+  etc.). Enforced at PR time by the scoped grep gate in
+  `.github/workflows/ct-comparison.yml`; a complementary
+  `clippy::disallowed_methods` advisory layer flags byte-slice
+  `PartialEq::eq/ne` workspace-wide. Escape hatch: a `// ct-allow:
+<reason>` on the match line, gated by the `ct-allow-approved` PR
+  label; whole-file exemptions for name collisions (e.g.,
+  `token_bucket.rs`) go in
+  [`.ct-comparison-ignore`](./.ct-comparison-ignore). Full policy:
+  [`docs/ct-comparison-policy.md`](./docs/ct-comparison-policy.md).
 - **Monotonic clock.** All protocol-relevant time math uses
   `std::time::Instant` (monotonic). `SystemTime` is only for
   human-facing display (logs, lease-TTL rendering). Full policy:
@@ -337,6 +351,16 @@ cargo install --locked cargo-geiger --version 0.13.0   # once
 bash scripts/geiger-update-baseline.sh --dry-run       # preview
 bash scripts/geiger-update-baseline.sh                 # write
 bash scripts/geiger-scripts-test.sh                    # 15 scenarios
+```
+
+Run the constant-time comparison gate locally — same gate that
+blocks PRs in `.github/workflows/ct-comparison.yml`, and the
+self-test that proves the gate's own logic is sound:
+
+```bash
+bash scripts/ct-comparison-check.sh              # scans scoped files, exits 0/1/2/3
+bash scripts/ct-comparison-check.sh --list-scope # debug: dump the scope set
+bash scripts/ct-comparison-scripts-test.sh       # 18 harness scenarios
 ```
 
 Notes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,18 @@ crates = ["mango-loom-demo"]
 # procedure.
 [workspace.dependencies]
 loom = "=0.7.2"
+# Constant-time comparison primitives for secret byte compares in
+# `auth*` / `crypto*` / `token*` / `hash_chain*` modules. Enforced
+# by `scripts/ct-comparison-check.sh` per `docs/ct-comparison-policy.md`.
+# `default-features = false` drops the `std` feature (subtle is
+# no_std-capable; nothing in the trait surface needs std).
+# `const-generics` enables `ConstantTimeEq` on `[T; N]` arrays —
+# what fixed-size MAC tags / hashes want.
+# Forward-declared here so the first crate that needs it just writes
+# `subtle.workspace = true`; no crate uses it yet.
+subtle = { version = "2.6", default-features = false, features = [
+    "const-generics",
+] }
 
 [workspace.package]
 version = "0.1.0"
@@ -72,6 +84,16 @@ print_stderr = { level = "deny", priority = 1 }
 await_holding_lock = { level = "deny", priority = 1 }
 await_holding_refcell_ref = { level = "deny", priority = 1 }
 disallowed_types = { level = "deny", priority = 1 }
+# Advisory layer for the constant-time comparison policy
+# (docs/ct-comparison-policy.md). Pairs with `disallowed-methods`
+# in clippy.toml — without this line the config in clippy.toml is
+# inert. Kept at `warn` (not `deny`) because:
+#   (a) the scoped grep gate `scripts/ct-comparison-check.sh` is
+#       the CI-blocking enforcement layer, and
+#   (b) clippy's trait-method path resolution is flaky enough that
+#       silent no-op is a real risk; `warn` surfaces hits without
+#       blocking PRs if resolution regresses.
+disallowed_methods = { level = "warn", priority = 1 }
 # Pairs with `msrv = "1.80"` in clippy.toml: flags any stdlib API
 # call newer than MSRV at PR time, complementing the `cargo check
 # @ 1.80` job that catches it at compile time.

--- a/clippy.toml
+++ b/clippy.toml
@@ -18,6 +18,26 @@ disallowed-types = [
     { path = "std::sync::RwLock", reason = "use parking_lot::RwLock or tokio::sync::RwLock for the same reason" },
 ]
 
+# Constant-time comparison — complementary advisory layer to the
+# scoped grep gate (scripts/ct-comparison-check.sh +
+# docs/ct-comparison-policy.md). The grep gate is the CI-blocking
+# enforcement; this list is workspace-wide warn-level and catches
+# cross-file indirection the scoped grep misses (e.g. a helper
+# `fn eq(a: &[u8], b: &[u8]) -> bool { a == b }` in an unscoped
+# file, called from scoped code). `bytes::Bytes` is the specific
+# case that P1-P5 cannot catch from source text alone.
+#
+# Path resolution for these trait-method paths has historically been
+# flaky in clippy; if a path silently fails to resolve, the layer
+# becomes a no-op. Verify with `cargo clippy --workspace` after
+# editing. Bytes lives in `bytes::bytes::Bytes`; if clippy cannot
+# resolve the path, drop that entry and rely on the scoped grep.
+disallowed-methods = [
+    { path = "<[u8] as core::cmp::PartialEq>::eq", reason = "byte-slice == is timing-sensitive; use subtle::ConstantTimeEq::ct_eq. See docs/ct-comparison-policy.md." },
+    { path = "<[u8] as core::cmp::PartialEq>::ne", reason = "byte-slice != is timing-sensitive; use subtle::ConstantTimeEq::ct_eq. See docs/ct-comparison-policy.md." },
+    { path = "<alloc::vec::Vec<u8> as core::cmp::PartialEq>::eq", reason = "Vec<u8> == is timing-sensitive; use subtle::ConstantTimeEq::ct_eq on the slices. See docs/ct-comparison-policy.md." },
+]
+
 # Keep in sync with rust-version in Cargo.toml and the pinned
 # toolchain in .github/workflows/ci.yml's msrv job. Enables
 # clippy::incompatible_msrv (denied in Cargo.toml) to flag any

--- a/docs/ct-comparison-policy.md
+++ b/docs/ct-comparison-policy.md
@@ -1,0 +1,292 @@
+# Constant-time comparison policy
+
+Mango treats equality on secret byte sequences as a timing side
+channel, not a neutral operation. The machinery that enforces this is
+a scoped text gate — `scripts/ct-comparison-check.sh` — that runs on
+every PR and flags the specific source patterns that produce timing
+oracles in authentication, crypto, token, and hash-chain code.
+
+This doc is the policy. The CI enforcement is
+[`.github/workflows/ct-comparison.yml`](../.github/workflows/ct-comparison.yml);
+the check script is
+[`scripts/ct-comparison-check.sh`](../scripts/ct-comparison-check.sh);
+the ignore list is
+[`.ct-comparison-ignore`](../.ct-comparison-ignore).
+
+## Why this exists
+
+Comparing two byte sequences with `==` on most hardware short-circuits
+at the first differing byte. A remote attacker who can time the
+comparison learns one byte of a secret per failed probe — this is the
+classic HMAC-equals timing oracle (lucky-thirteen, HMAC tag
+verification CVEs, and the whole family they belong to). The fix is
+constant-time comparison: always walk the full length, always XOR and
+OR-accumulate.
+
+[`subtle::ConstantTimeEq`](https://docs.rs/subtle) is the canonical
+Rust crate for this. Its `ct_eq` returns a `subtle::Choice`, a
+wrapper around `u8` whose `From<Choice> for bool` conversion is
+always the final, branching step — by design, you have to explicitly
+decide when to leak.
+
+## Scope
+
+The gate scans files whose path matches any of:
+
+- `crates/*/src/**/auth*.rs`
+- `crates/*/src/**/crypto*.rs`
+- `crates/*/src/**/token*.rs`
+- `crates/*/src/**/hash_chain*.rs`
+- the directory variant: files under `crates/*/src/**/{auth,crypto,token,hash_chain}/**/*.rs`
+
+Exclusions (unconditional, applied before scope matching):
+
+- Any path containing `/tests/`.
+- Any file ending in `_test.rs` or `_tests.rs`.
+
+Rationale: test code routinely `assert_eq!` on byte slices. The gate
+is for production paths; test fixtures and `#[test]` modules in
+separate files stay out of scope by convention. Unit tests in the
+same file (`#[cfg(test)] mod tests`) are in scope and need the
+`// ct-allow: test` annotation — see Escape hatch below.
+
+### Naming collisions
+
+The `**/token*.rs` glob also matches `token_bucket.rs`,
+`token_stream.rs`, etc. — files that have nothing to do with auth
+tokens. The mitigation is [`.ct-comparison-ignore`](../.ct-comparison-ignore)
+at the repo root: one path per line, `#` comments allowed. Every
+entry must name a file that exists on disk; stale entries fail the
+gate with exit code 3. Entries carry a one-line justification as a
+trailing `#`-comment.
+
+## What is banned
+
+In a scoped file, the gate flags these five source-text patterns.
+All five require a `// ct-allow: <reason>` trailing-comment annotation
+to pass (see Escape hatch).
+
+- **P1 — byte-literal compare:** `== b"…"` or `!= b"…"` on either
+  operand. No ambiguity; the left or right side is literally a byte
+  string.
+
+- **P2 — secret-named receiver `.eq(` / `.ne(`:** `<ident>.eq(…)` or
+  `<ident>.ne(…)` where `<ident>` ends in `_hash`, `_hmac`, `_mac`,
+  `_tag`, `_token`, `_digest`, `_signature`, `_nonce`, `_secret`, or
+  `_key`. Also matches `.as_bytes().eq(` / `.as_bytes().ne(` and
+  `.eq(b"…")` / `.eq(&b"…")` forms regardless of receiver name.
+  _Not_ flagged: `role.eq(&Role::Admin)`, `path.eq(expected_path)`,
+  `opt.eq(&other)` — these are non-secret `.eq(` calls and must not
+  turn the gate into noise.
+
+- **P3 — `.as_bytes()` compare:** `.as_bytes() ==`, `== <expr>.as_bytes()`,
+  and the `!=` variants. Any `.as_bytes()` chain on either side of an
+  equality operator is flagged.
+
+- **P4 — secret-named type derives `PartialEq` or `Eq`:** a
+  `#[derive(...)]` attribute containing `PartialEq` or `Eq` followed
+  by a `struct` or `enum` declaration whose name matches
+  `Token | Hmac | Mac | Tag | Secret | Password | Key | Credential | Nonce | Digest | Signature`
+  (case-insensitive, whole-word). The detection spans multi-line
+  derives (`#[derive(\n    Debug,\n    PartialEq,\n)]` is flagged).
+  Types that must never derive `PartialEq`: anything that holds a
+  secret. The correct trait is `subtle::ConstantTimeEq`. Flagged only
+  in scoped files.
+
+- **P5 — secret-named identifier in `==` / `!=`:** `==` or `!=` where
+  either operand references an identifier whose name ends in one of
+  the P5 suffix words (same list as P2). Example: `session.token == received`,
+  `computed_hmac != stored`, `tag == expected_tag`. Both sides of the
+  operator are scanned.
+
+Patterns P1-P5 are deliberately narrow. Integer compares, enum
+matches, `Duration::ZERO` comparisons, `Ordering` compares — none
+match any pattern. The gate is not a blanket ban on `==`; it is a
+ban on five specific source-text shapes that reliably appear in
+secret-compare bugs.
+
+## What is required
+
+Use
+[`subtle::ConstantTimeEq::ct_eq`](https://docs.rs/subtle/latest/subtle/trait.ConstantTimeEq.html):
+
+```rust
+use subtle::ConstantTimeEq;
+
+// Compare two MAC tags. Both sides must be equal length.
+let choice = computed_hmac.ct_eq(&expected_hmac);
+if bool::from(choice) {
+    // equal — process the authenticated message
+} else {
+    // not equal — reject
+}
+```
+
+The final `bool::from(choice)` is the leak point. Everything before
+it is constant-time; the `if` diverges, which is the moment the
+secret becomes observable in timing. Put `bool::from` as close to the
+divergence as possible. Alternative equivalent form:
+
+```rust
+if choice.unwrap_u8() != 0 { … }
+```
+
+**Length caveat:** `ct_eq` requires equal-length inputs. If the
+inputs differ in length, `ct_eq` returns false immediately — which
+itself is a length oracle. If the length could be secret, pad to a
+fixed buffer before calling `ct_eq`, or use a length-aware wrapper.
+Most protocols treat tag length as public (HMAC-SHA256 tags are
+always 32 bytes); in those cases, the caller is responsible for
+enforcing the length contract.
+
+For fixed-size arrays (`[u8; 32]` for SHA-256 tags), `subtle` 2.6's
+`const-generics` feature gives you `ct_eq` on `[T; N]` directly.
+Mango's workspace declaration (`Cargo.toml`,
+`[workspace.dependencies]`) enables this feature.
+
+## Escape hatch
+
+A trailing-comment annotation on the offending line:
+
+```rust
+let equal_len = received.len() == expected.len(); // ct-allow: length comparison, not secret
+```
+
+The reason is free-form but must be specific. Reviewers look at every
+`// ct-allow:` and ask "is this genuinely out-of-scope for timing, or
+is the author punting?"
+
+**Label gate.** Every PR that adds a new `// ct-allow:` line needs
+the `ct-allow-approved` GitHub label. The gate detects new
+annotations via a set-difference between the base-ref tree and the
+HEAD tree, keyed on `(file-path, normalized-reason-text)` — so
+rustfmt reflows, line-number drift, and whitespace normalization
+don't trigger a false label-required prompt. Only genuinely new
+annotations count.
+
+Missing label on a PR that adds a new annotation: **exit code 2**.
+This mirrors the `unsafe-growth-approved` label flow documented in
+[`docs/unsafe-policy.md`](unsafe-policy.md).
+
+## Failure modes
+
+| exit | meaning       | trigger                                                                                                |
+| ---- | ------------- | ------------------------------------------------------------------------------------------------------ |
+| 0    | PASS          | no violations, or every violation is annotated, or new annotations carry the `ct-allow-approved` label |
+| 1    | violations    | unannotated P1-P5 match in a scoped file                                                               |
+| 2    | missing label | PR adds new `// ct-allow:` annotations without the `ct-allow-approved` label                           |
+| 3    | stale ignore  | `.ct-comparison-ignore` names a file that does not exist on disk                                       |
+
+`--list-scope` (local-debug flag) separately returns **0** if the
+scope set is non-empty, **2** if empty — CI does not care, this is
+only for contributors sanity-checking the glob.
+
+## Sanity-break recipe
+
+Verifies the gate would actually catch a regression. Mirrors the
+recipe in [`docs/unsafe-policy.md`](unsafe-policy.md).
+
+1. Create a temporary file at `crates/mango/src/auth_demo.rs` with:
+   ```rust
+   pub fn check(received: &[u8], expected: &[u8]) -> bool {
+       received == expected
+   }
+   ```
+2. Run `./scripts/ct-comparison-check.sh`. Expected: **exit 1**,
+   violation reported at `auth_demo.rs:2`.
+3. Rename the file to `crates/mango/src/unrelated.rs`. Re-run.
+   Expected: **exit 0** (file no longer matches the scope glob).
+4. Delete `crates/mango/src/unrelated.rs` before committing.
+
+If step 2 returns exit 0, the gate is broken or the scope glob is
+not matching the file — investigate before shipping.
+
+## Complementary layer — `clippy::disallowed_methods`
+
+`clippy.toml` at the repo root declares byte-slice `PartialEq::eq`
+as disallowed workspace-wide, as an **advisory** signal:
+
+```toml
+disallowed-methods = [
+  { path = "<[u8] as core::cmp::PartialEq>::eq", reason = "…" },
+  { path = "<alloc::vec::Vec<u8> as core::cmp::PartialEq>::eq", reason = "…" },
+  { path = "<bytes::Bytes as core::cmp::PartialEq>::eq", reason = "…" },
+]
+```
+
+Advisory because the scoped grep, not clippy, is the CI gate. Clippy
+fires warnings on `==` between byte slices _anywhere_ in the
+workspace — this catches the cross-file indirection the scoped grep
+misses (e.g., a helper `fn equal(a: &[u8], b: &[u8]) -> bool { a == b }`
+in an unscoped file, called from a scoped file). `bytes::Bytes`
+specifically is not catchable by P1-P5 alone because a `Bytes == Bytes`
+comparison has no byte-literal, no `.as_bytes()`, no P5 suffix
+identifier, and no derive. Clippy's `disallowed_methods` is the only
+layer that sees this shape.
+
+Clippy's path-resolution for trait-method paths has historically been
+flaky. If the paths above silently fail to resolve (no warnings fire
+where they should), the layer is documented as "attempted, not
+load-bearing" and the scoped grep remains the sole enforcement.
+
+## Known limitations
+
+- **No type resolution.** The gate is source-text only; it cannot see
+  that `let x: &[u8] = …; x == y` is a byte compare unless `x` has a
+  secret-suffix name. `subtle` adoption by hand and the
+  `disallowed_methods` layer are the backstops.
+
+- **Multi-line operators.** `foo\n    == bar` (one operand on a
+  separate line) is not flagged. Rustfmt's `binop_separator` default
+  keeps comparisons on a single line; banked on.
+
+- **Macro expansion.** `assert_eq!(token, expected)` expands to `==`
+  but the gate never sees the expansion. In test paths this is
+  exempted by the `/tests/` / `_test.rs` path rule; in scoped
+  non-test files, `assert_eq!` / `assert_ne!` / `debug_assert_eq!` /
+  `debug_assert_ne!` are a manual-review backstop. The policy is:
+  don't assert on secrets in production code.
+
+- **Cross-file indirection.** A byte compare hidden behind a helper
+  function call in an unscoped file is invisible to the scoped grep.
+  `clippy::disallowed_methods` is the workspace-wide signal; manual
+  review is the backstop.
+
+- **`bytes::Bytes == Bytes`.** Not caught by P1-P5. Caught by
+  `clippy::disallowed_methods` if clippy resolves the path.
+
+- **`token*` naming collision.** `**/token*.rs` matches
+  `token_bucket.rs` and friends. Mitigated by
+  [`.ct-comparison-ignore`](../.ct-comparison-ignore).
+
+- **MSRV.** `subtle` 2.6 supports Rust ≥1.41; workspace MSRV is 1.80
+  — no interaction.
+
+## When to upgrade to a dylint
+
+The roadmap item (ROADMAP.md:797) names `dylint` as the target
+mechanism; this grep gate is the interim enforcement the roadmap
+itself sanctions ("Until the dylint lands, the enforcement is a CI
+grep + manual review"). Upgrading makes sense when:
+
+- Real `auth/` / `crypto/` / `token/` / `hash_chain/` code has landed
+  in the workspace, giving the lint a real calibration target.
+- The grep gate's false-positive OR false-negative rate warrants
+  the heavier infrastructure (pinned nightly driver, HIR-level type
+  resolution).
+
+At dylint time, each `// ct-allow:` site translates to an
+`#[allow(mango::ct_comparison)]` attribute on the enclosing
+expression, statement, or item. Expression-level `#[allow]` requires
+Rust ≥1.81 (`stmt_expr_attributes` stabilization) and may inform
+dylint timing.
+
+## See also
+
+- [`docs/unsafe-policy.md`](unsafe-policy.md) — sibling gate, same
+  structure: monotonic growth + label-gated escape hatch.
+- [`docs/miri.md`](miri.md) — runtime UB gate on the curated subset.
+- [`docs/arithmetic-policy.md`](arithmetic-policy.md) — the fourth
+  security-relevant policy doc.
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) §7 (Other policies) and
+  §8 (Running the checks locally).

--- a/scripts/ct-comparison-check.sh
+++ b/scripts/ct-comparison-check.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# scripts/ct-comparison-check.sh
+#
+# Scan `auth*` / `crypto*` / `token*` / `hash_chain*` source files
+# for byte-compare patterns that produce timing oracles (P1-P5 in
+# docs/ct-comparison-policy.md), and enforce the label-gated escape
+# hatch for `// ct-allow:` annotations.
+#
+# Usage:
+#   bash scripts/ct-comparison-check.sh
+#   bash scripts/ct-comparison-check.sh --list-scope
+#
+# The script reads three environment variables to adapt to the CI
+# event context (set by `.github/workflows/ct-comparison.yml`):
+#
+#   GITHUB_EVENT_NAME   "pull_request" | "push" | "merge_group" | ""
+#   GITHUB_BASE_REF     PR base branch name (only meaningful on pull_request)
+#   PR_LABELS           JSON array of label names (set only on pull_request)
+#
+# All three are optional for local use.
+#
+# Exit codes:
+#   0  PASS — no violations, or every violation is annotated, or new
+#             annotations carry the `ct-allow-approved` label
+#   1  FAIL — unannotated P1-P5 match in a scoped file
+#   2  FAIL — PR adds new `// ct-allow:` annotations without the
+#             `ct-allow-approved` label
+#   3  FAIL — `.ct-comparison-ignore` names a file that does not exist
+#
+# Requires: bash, awk (POSIX), find, git (only on pull_request), jq.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+event="${GITHUB_EVENT_NAME:-}"
+base_ref="${GITHUB_BASE_REF:-}"
+pr_labels_raw="${PR_LABELS:-[]}"
+
+list_scope_only=0
+if [ "${1:-}" = "--list-scope" ]; then
+    list_scope_only=1
+elif [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    sed -n '2,/^set -/p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+elif [ -n "${1:-}" ]; then
+    printf 'error: unknown argument: %s\n' "$1" >&2
+    exit 64
+fi
+
+# ---------------------------------------------------------------------
+# 1. Validate .ct-comparison-ignore (if present)
+# ---------------------------------------------------------------------
+ignore_file=".ct-comparison-ignore"
+ignore_entries=""
+if [ -f "$ignore_file" ]; then
+    while IFS= read -r raw; do
+        # strip comments and whitespace
+        line="${raw%%#*}"
+        line="$(printf '%s' "$line" | awk '{$1=$1;print}')"
+        [ -z "$line" ] && continue
+        if [ ! -f "$line" ]; then
+            printf 'error: .ct-comparison-ignore references missing file: %s\n' "$line" >&2
+            printf '       either remove this entry, or restore the file.\n' >&2
+            exit 3
+        fi
+        ignore_entries="$ignore_entries $line"
+    done < "$ignore_file"
+fi
+
+# ---------------------------------------------------------------------
+# 2. Build scope set
+# ---------------------------------------------------------------------
+scope_re='(^|/)(auth|crypto|token|hash_chain)([^/]*\.rs$|[^/]*/)'
+
+# emit all *.rs under crates/, excluding test paths, then filter by
+# scope_re and subtract ignore entries.
+build_scope() {
+    find crates -type f -name '*.rs' 2>/dev/null \
+        | awk -v re="$scope_re" '
+            {
+                # exclude test paths
+                if ($0 ~ /\/tests\//) next
+                if ($0 ~ /_test\.rs$/) next
+                if ($0 ~ /_tests\.rs$/) next
+                # scope match: any path component after "crates/*/src/"
+                # starting with one of the 4 prefixes
+                if ($0 ~ re) print
+            }' \
+        | while IFS= read -r f; do
+            skip=0
+            for ig in $ignore_entries; do
+                if [ "$f" = "$ig" ]; then skip=1; break; fi
+            done
+            [ $skip -eq 0 ] && printf '%s\n' "$f"
+          done \
+        | sort -u
+}
+
+scope="$(build_scope || true)"
+
+if [ "$list_scope_only" -eq 1 ]; then
+    if [ -z "$scope" ]; then
+        printf 'scope is empty.\n'
+        exit 2
+    fi
+    printf '%s\n' "$scope"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------
+# 3. Scan each scoped file for P1-P5 patterns
+# ---------------------------------------------------------------------
+violations_tmp="$(mktemp)"
+trap 'rm -f "$violations_tmp"' EXIT
+
+scan_awk='
+BEGIN {
+    suffix_re = "_(hash|hmac|mac|tag|token|digest|signature|nonce|secret|key)"
+    sec_type_re = "^(Token|Hmac|Mac|Tag|Secret|Password|Key|Credential|Nonce|Digest|Signature)"
+    in_derive = 0
+    derive_buf = ""
+    derive_has_pe = 0
+    awaiting_type = 0
+    violations = 0
+}
+
+function find_comment_col(s,    i, L) {
+    L = length(s)
+    for (i = 1; i < L; i++) {
+        if (substr(s, i, 2) == "//") return i
+    }
+    return 0
+}
+
+function has_annotation(line,    c, comment) {
+    c = find_comment_col(line)
+    if (c == 0) return 0
+    comment = substr(line, c)
+    if (match(comment, /\/\/[[:space:]]*ct-allow:/)) return 1
+    return 0
+}
+
+function code_portion(line,    c) {
+    c = find_comment_col(line)
+    if (c == 0) return line
+    return substr(line, 1, c - 1)
+}
+
+function emit(lineno, tag, origline) {
+    printf "%s:%d: [%s] %s\n", FILENAME, lineno, tag, origline
+    violations++
+}
+
+{
+    origline = $0
+    ann = has_annotation(origline)
+    code = code_portion(origline)
+
+    # ---- P4: multi-line derive state machine ----
+    if (in_derive) {
+        derive_buf = derive_buf " " code
+        if (index(code, ")]") > 0) {
+            if (match(derive_buf, /PartialEq/) \
+                || match(derive_buf, /(^|[^A-Za-z0-9_])Eq([^A-Za-z0-9_]|$)/)) {
+                derive_has_pe = 1
+            } else {
+                derive_has_pe = 0
+            }
+            in_derive = 0
+            awaiting_type = derive_has_pe
+            derive_buf = ""
+        }
+        next
+    }
+
+    if (match(code, /#\[derive\(/)) {
+        in_derive = 1
+        derive_buf = code
+        if (index(code, ")]") > 0) {
+            if (match(derive_buf, /PartialEq/) \
+                || match(derive_buf, /(^|[^A-Za-z0-9_])Eq([^A-Za-z0-9_]|$)/)) {
+                derive_has_pe = 1
+            } else {
+                derive_has_pe = 0
+            }
+            in_derive = 0
+            awaiting_type = derive_has_pe
+            derive_buf = ""
+        }
+        next
+    }
+
+    if (awaiting_type) {
+        if (match(code, /(struct|enum)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*/)) {
+            decl = substr(code, RSTART, RLENGTH)
+            sub(/^(struct|enum)[[:space:]]+/, "", decl)
+            if (match(decl, sec_type_re)) {
+                tname = substr(decl, RSTART, RLENGTH)
+                if (!ann) {
+                    emit(NR, "P4 derive(PartialEq)/Eq on secret-named type " tname, origline)
+                }
+            }
+            awaiting_type = 0
+        }
+    }
+
+    # ---- P1: byte-literal compare ----
+    if (match(code, /(==|!=)[[:space:]]*b"/) \
+        || match(code, /b"[^"]*"[[:space:]]*(==|!=)/)) {
+        if (!ann) { emit(NR, "P1 byte-literal compare", origline); next }
+    }
+
+    # ---- P2: method-form byte compare ----
+    # P2a: <secret-suffix-ident>.eq(  /  .ne(
+    # P2b: .as_bytes().eq(  /  .ne(
+    # P2c: .eq(b"…")  /  .ne(b"…")  /  .eq(&b"…")
+    if (match(code, "[A-Za-z_][A-Za-z0-9_]*" suffix_re "\\.(eq|ne)\\(") \
+        || match(code, /\.as_bytes\(\)\.(eq|ne)\(/) \
+        || match(code, /\.(eq|ne)\([[:space:]]*&?[[:space:]]*b"/)) {
+        if (!ann) { emit(NR, "P2 method-form byte compare", origline); next }
+    }
+
+    # ---- P3: .as_bytes() in a compare ----
+    if (match(code, /\.as_bytes\(\)/) && match(code, /(==|!=)/)) {
+        if (!ann) { emit(NR, "P3 .as_bytes() compare", origline); next }
+    }
+
+    # ---- P5: secret-suffix identifier in ==/!= ----
+    # Requires both the operator and a secret-suffix word in the code.
+    if (match(code, /(==|!=)/) \
+        && match(code, "[A-Za-z_][A-Za-z0-9_]*" suffix_re "([^A-Za-z0-9_]|$)")) {
+        if (!ann) { emit(NR, "P5 secret-named identifier in compare", origline); next }
+    }
+}
+
+END {
+    exit (violations > 0) ? 1 : 0
+}
+'
+
+total_violations=0
+scanned_files=0
+if [ -n "$scope" ]; then
+    # iterate files (one per line in $scope)
+    OLDIFS="$IFS"
+    IFS='
+'
+    for f in $scope; do
+        scanned_files=$((scanned_files + 1))
+        awk "$scan_awk" "$f" >> "$violations_tmp" || true
+    done
+    IFS="$OLDIFS"
+fi
+
+total_violations="$(wc -l < "$violations_tmp" | awk '{print $1}')"
+
+# ---------------------------------------------------------------------
+# 4. PR-mode new-annotation label check
+# ---------------------------------------------------------------------
+# Detect new `// ct-allow:` annotations added in this PR (vs base),
+# using set-difference on (file, normalized-reason) keys. Rustfmt
+# reflows and line-number drift don't trigger false "new annotation"
+# readings.
+#
+# Only run on pull_request events with a base_ref we can resolve.
+new_annotations_count=0
+new_annotations_tmp="$(mktemp)"
+trap 'rm -f "$violations_tmp" "$new_annotations_tmp"' EXIT
+
+extract_annotations_from_tree() {
+    # $1 = git tree-ish ("HEAD" or "origin/$base_ref") or "__worktree__"
+    # Outputs: one line per annotation: "file|normalized-reason"
+    local treeish="$1"
+    local files
+    if [ "$treeish" = "__worktree__" ]; then
+        # Use scope as-is from working tree.
+        files="$scope"
+        for f in $files; do
+            awk -v F="$f" '
+                {
+                    # only lines that contain the annotation marker
+                    if (match($0, /\/\/[[:space:]]*ct-allow:[[:space:]]*(.*)$/)) {
+                        reason = substr($0, RSTART, RLENGTH)
+                        sub(/^\/\/[[:space:]]*ct-allow:[[:space:]]*/, "", reason)
+                        gsub(/[[:space:]]+/, " ", reason)
+                        sub(/[[:space:]]+$/, "", reason)
+                        printf "%s|%s\n", F, reason
+                    }
+                }' "$f" 2>/dev/null || true
+        done
+    else
+        # List files in the tree matching our scope set and extract.
+        # Use git ls-tree for the tree, re-apply scope filter, use
+        # `git show treeish:file` to read contents.
+        local tree_files
+        tree_files="$(git ls-tree -r --name-only "$treeish" -- 'crates/' 2>/dev/null \
+            | awk -v re="$scope_re" '
+                { if ($0 ~ /\/tests\//) next
+                  if ($0 ~ /_test\.rs$/) next
+                  if ($0 ~ /_tests\.rs$/) next
+                  if ($0 !~ /\.rs$/) next
+                  if ($0 ~ re) print }' \
+            | sort -u)"
+        local f
+        for f in $tree_files; do
+            # skip ignored
+            local skip=0
+            for ig in $ignore_entries; do
+                if [ "$f" = "$ig" ]; then skip=1; break; fi
+            done
+            [ "$skip" -eq 1 ] && continue
+            git show "$treeish:$f" 2>/dev/null \
+                | awk -v F="$f" '
+                    {
+                        if (match($0, /\/\/[[:space:]]*ct-allow:[[:space:]]*(.*)$/)) {
+                            reason = substr($0, RSTART, RLENGTH)
+                            sub(/^\/\/[[:space:]]*ct-allow:[[:space:]]*/, "", reason)
+                            gsub(/[[:space:]]+/, " ", reason)
+                            sub(/[[:space:]]+$/, "", reason)
+                            printf "%s|%s\n", F, reason
+                        }
+                    }' || true
+        done
+    fi
+}
+
+do_pr_check=0
+if [ "$event" = "pull_request" ] && [ -n "$base_ref" ]; then
+    if git rev-parse --verify "origin/$base_ref" >/dev/null 2>&1; then
+        do_pr_check=1
+    fi
+fi
+
+if [ "$do_pr_check" -eq 1 ]; then
+    head_anns="$(mktemp)"
+    base_anns="$(mktemp)"
+    trap 'rm -f "$violations_tmp" "$new_annotations_tmp" "$head_anns" "$base_anns"' EXIT
+
+    extract_annotations_from_tree "__worktree__" | sort -u > "$head_anns"
+    extract_annotations_from_tree "origin/$base_ref" | sort -u > "$base_anns"
+
+    # Set difference: lines in HEAD not in BASE
+    comm -23 "$head_anns" "$base_anns" > "$new_annotations_tmp"
+    new_annotations_count="$(wc -l < "$new_annotations_tmp" | awk '{print $1}')"
+fi
+
+# ---------------------------------------------------------------------
+# 5. Decide outcome
+# ---------------------------------------------------------------------
+printf '=== ct-comparison gate ===\n'
+printf 'scope: %d scoped files\n' "$scanned_files"
+printf 'violations: %d\n' "$total_violations"
+
+if [ "$total_violations" -gt 0 ]; then
+    printf '\nunannotated violations:\n'
+    cat "$violations_tmp"
+    printf '\nsee docs/ct-comparison-policy.md for remediation.\n'
+    summary_write() {
+        [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+        {
+            printf '### ct-comparison: FAIL\n\n'
+            printf '%d violation(s) in scoped files.\n\n' "$total_violations"
+            printf '```\n'
+            cat "$violations_tmp"
+            printf '```\n'
+        } >> "$GITHUB_STEP_SUMMARY"
+    }
+    summary_write
+    exit 1
+fi
+
+if [ "$new_annotations_count" -gt 0 ]; then
+    # Parse PR labels from JSON array
+    has_label=0
+    if printf '%s' "$pr_labels_raw" | jq -e 'if type == "array" then any(. == "ct-allow-approved") else false end' >/dev/null 2>&1; then
+        has_label=1
+    fi
+    if [ "$has_label" -eq 0 ]; then
+        printf '\nnew ct-allow annotations added without `ct-allow-approved` label:\n'
+        awk -F'|' '{ printf "  %s: %s\n", $1, $2 }' "$new_annotations_tmp"
+        printf '\nadd the `ct-allow-approved` label to the PR if the annotations are justified.\n'
+        if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            {
+                printf '### ct-comparison: FAIL (missing label)\n\n'
+                printf '%d new ct-allow annotation(s) without `ct-allow-approved` label.\n\n' "$new_annotations_count"
+            } >> "$GITHUB_STEP_SUMMARY"
+        fi
+        exit 2
+    fi
+    printf '\nnew ct-allow annotations approved via `ct-allow-approved` label (%d).\n' "$new_annotations_count"
+fi
+
+printf 'PASS\n'
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+        printf '### ct-comparison: PASS\n\n'
+        printf '| metric | value |\n|---|---|\n'
+        printf '| scoped files | %d |\n' "$scanned_files"
+        printf '| violations | 0 |\n'
+        printf '| new annotations | %d |\n' "$new_annotations_count"
+    } >> "$GITHUB_STEP_SUMMARY"
+fi
+exit 0

--- a/scripts/ct-comparison-scripts-test.sh
+++ b/scripts/ct-comparison-scripts-test.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+# scripts/ct-comparison-scripts-test.sh
+#
+# Test harness for scripts/ct-comparison-check.sh.
+#
+# Each scenario sets up a synthetic repo in a mktemp'd dir, copies
+# the check script in, writes fixture files inline via heredocs,
+# invokes the script, and asserts exit code + stdout substring.
+#
+# The fixtures live inline so there is no separate fixture tree to
+# drift out of sync — the test IS the fixture specification.
+#
+# Scenarios cover P1-P5 detection, annotation-accept, commented-out
+# code skip, negative cases (enum/Duration compares that must NOT
+# flag), scope exclusions, PR-mode label flow, and
+# .ct-comparison-ignore drift.
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+check_script="$repo_root/scripts/ct-comparison-check.sh"
+
+if [ ! -f "$check_script" ]; then
+    printf 'error: check script not found at %s\n' "$check_script" >&2
+    exit 2
+fi
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+# ---------------------------------------------------------------------
+# assertion helpers
+# ---------------------------------------------------------------------
+# usage: run_check <workdir> [env-setup]
+#   Runs the check script in <workdir> (cd first).
+#   Captures stdout+stderr in $RUN_OUT and exit in $RUN_EXIT.
+RUN_OUT=""
+RUN_EXIT=0
+run_check() {
+    local workdir="$1"
+    shift
+    local out
+    out="$(cd "$workdir" && env "$@" bash "$workdir/scripts/ct-comparison-check.sh" 2>&1)"
+    RUN_EXIT=$?
+    RUN_OUT="$out"
+}
+
+# same but with --list-scope
+run_check_list_scope() {
+    local workdir="$1"
+    local out
+    out="$(cd "$workdir" && bash "$workdir/scripts/ct-comparison-check.sh" --list-scope 2>&1)"
+    RUN_EXIT=$?
+    RUN_OUT="$out"
+}
+
+assert_exit() {
+    local scenario="$1" want="$2"
+    if [ "$RUN_EXIT" -ne "$want" ]; then
+        printf '  FAIL [exit %d, want %d]\n' "$RUN_EXIT" "$want"
+        printf '  --- output:\n%s\n  ---\n' "$RUN_OUT"
+        fail_count=$((fail_count + 1))
+        return 1
+    fi
+    return 0
+}
+
+assert_contains() {
+    local scenario="$1" needle="$2"
+    if ! printf '%s' "$RUN_OUT" | grep -qF -- "$needle"; then
+        printf '  FAIL [stdout missing: %s]\n' "$needle"
+        printf '  --- output:\n%s\n  ---\n' "$RUN_OUT"
+        fail_count=$((fail_count + 1))
+        return 1
+    fi
+    return 0
+}
+
+pass() {
+    printf '  PASS\n'
+    pass_count=$((pass_count + 1))
+}
+
+setup_workdir() {
+    local d
+    d="$(mktemp -d -t ct-cmp-test.XXXXXX)"
+    mkdir -p "$d/scripts"
+    cp "$check_script" "$d/scripts/ct-comparison-check.sh"
+    chmod +x "$d/scripts/ct-comparison-check.sh"
+    printf '%s' "$d"
+}
+
+cleanup_workdir() {
+    local d="$1"
+    [ -n "$d" ] && [ -d "$d" ] && rm -rf "$d"
+}
+
+# Set up a synthetic git repo with origin/main as the base.
+# Call AFTER writing the base tree; this commits it to origin/main.
+# Then further edits land on a feature branch.
+setup_pr_repo() {
+    local d="$1"
+    (cd "$d" \
+        && git init -q \
+        && git config user.email 'ct@mango.test' \
+        && git config user.name 'ct-test' \
+        && git checkout -q -b main \
+        && git add -A \
+        && git commit -q -m 'base' \
+        && git clone -q --bare . .bare.git >/dev/null 2>&1 \
+        && git remote add origin ./.bare.git \
+        && git fetch -q origin \
+        && git checkout -q -b feature
+    ) >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------
+# scenario 1: empty scope (no scoped files under crates/)
+# ---------------------------------------------------------------------
+printf 'scenario 01: empty scope -> PASS\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/lib.rs" <<'EOF'
+pub fn add(a: u32, b: u32) -> u32 { a.wrapping_add(b) }
+EOF
+run_check "$d"
+assert_exit 01 0 && assert_contains 01 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 2: scoped file using ct_eq only -> PASS
+# ---------------------------------------------------------------------
+printf 'scenario 02: clean ct_eq -> PASS\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+use subtle::ConstantTimeEq;
+pub fn verify(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    bool::from(a.ct_eq(b))
+}
+EOF
+run_check "$d"
+assert_exit 02 0 && assert_contains 02 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 3: P1 byte-literal compare -> FAIL exit 1
+# ---------------------------------------------------------------------
+printf 'scenario 03: P1 byte-literal -> FAIL 1\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn is_admin(name: &[u8]) -> bool {
+    name == b"admin"
+}
+EOF
+run_check "$d"
+assert_exit 03 1 && assert_contains 03 "P1 byte-literal" && assert_contains 03 "auth.rs:2" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 4: P1 annotated with ct-allow -> PASS
+# ---------------------------------------------------------------------
+printf 'scenario 04: P1 annotated -> PASS\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn is_admin_literal(name: &[u8]) -> bool {
+    name == b"admin" // ct-allow: role-name compare, not a secret
+}
+EOF
+run_check "$d"
+assert_exit 04 0 && assert_contains 04 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 5: P2 secret-suffix receiver .eq( -> FAIL 1
+# ---------------------------------------------------------------------
+printf 'scenario 05: P2 suffix-receiver .eq -> FAIL 1\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/crypto.rs" <<'EOF'
+pub fn check(session_hmac: &[u8], expected: &[u8]) -> bool {
+    session_hmac.eq(expected)
+}
+EOF
+run_check "$d"
+assert_exit 05 1 && assert_contains 05 "P2 method-form" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 6: P3 .as_bytes() compare -> FAIL 1
+# ---------------------------------------------------------------------
+printf 'scenario 06: P3 as_bytes compare -> FAIL 1\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/token.rs" <<'EOF'
+pub fn matches(tok: &str, expected: &[u8]) -> bool {
+    tok.as_bytes() == expected
+}
+EOF
+run_check "$d"
+assert_exit 06 1 && assert_contains 06 "P3 .as_bytes" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 7: P4 multi-line derive(PartialEq) on Token -> FAIL 1
+# ---------------------------------------------------------------------
+printf 'scenario 07: P4 multiline-derive -> FAIL 1\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+)]
+pub struct TokenTag {
+    pub bytes: [u8; 32],
+}
+EOF
+run_check "$d"
+assert_exit 07 1 && assert_contains 07 "P4 derive" && assert_contains 07 "TokenTag" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 8: P5 secret-suffix identifier in == -> FAIL 1
+# ---------------------------------------------------------------------
+printf 'scenario 08: P5 suffix-ident in == -> FAIL 1\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/hash_chain.rs" <<'EOF'
+pub fn matches(prev: &[u8], computed_hash: &[u8]) -> bool {
+    computed_hash == prev
+}
+EOF
+run_check "$d"
+assert_exit 08 1 && assert_contains 08 "P5" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 9: commented-out code "// foo == bar" -> PASS (not flagged)
+# ---------------------------------------------------------------------
+printf 'scenario 09: commented-out == -> PASS\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn dummy() -> u32 {
+    // old: let x = secret_hmac == received;
+    42
+}
+EOF
+run_check "$d"
+assert_exit 09 0 && assert_contains 09 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 10: negative — role.eq(&Role::Admin) in scoped file -> PASS
+# ---------------------------------------------------------------------
+printf 'scenario 10: negative role.eq -> PASS\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+#[derive(Debug, PartialEq)]
+pub enum Role { Admin, User }
+
+pub fn is_admin(role: &Role) -> bool {
+    role.eq(&Role::Admin)
+}
+EOF
+run_check "$d"
+assert_exit 10 0 && assert_contains 10 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 11: negative — enum/Duration compare in scoped file -> PASS
+# ---------------------------------------------------------------------
+printf 'scenario 11: negative enum/duration == -> PASS\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/token.rs" <<'EOF'
+use std::time::Duration;
+
+pub enum Color { Red, Blue }
+
+pub fn pick(c: Color, d: Duration) -> u32 {
+    if matches!(c, Color::Red) && d == Duration::ZERO {
+        1
+    } else if d != Duration::from_secs(30) {
+        2
+    } else {
+        3
+    }
+}
+EOF
+run_check "$d"
+assert_exit 11 0 && assert_contains 11 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 12: --list-scope on non-empty scope -> exit 0, files listed
+# ---------------------------------------------------------------------
+printf 'scenario 12: --list-scope non-empty -> 0\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn stub() -> u32 { 0 }
+EOF
+cat > "$d/crates/mango/src/not_scoped.rs" <<'EOF'
+pub fn stub() -> u32 { 0 }
+EOF
+run_check_list_scope "$d"
+assert_exit 12 0 && assert_contains 12 "auth.rs" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 13: non-scoped file with P1 patterns -> PASS (out of scope)
+# ---------------------------------------------------------------------
+printf 'scenario 13: non-scoped file has ==b"" -> PASS\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/unrelated.rs" <<'EOF'
+pub fn is_admin(name: &[u8]) -> bool {
+    let computed_hmac = name;
+    name == b"admin" && computed_hmac != b""
+}
+EOF
+run_check "$d"
+assert_exit 13 0 && assert_contains 13 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 14: PR mode — new ct-allow annotation without label -> exit 2
+# ---------------------------------------------------------------------
+printf 'scenario 14: PR new-annot no label -> 2\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn stub() -> u32 { 0 }
+EOF
+setup_pr_repo "$d"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn is_admin(name: &[u8]) -> bool {
+    name == b"admin" // ct-allow: role-name compare, not a secret
+}
+EOF
+run_check "$d" GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main PR_LABELS='[]'
+assert_exit 14 2 && assert_contains 14 "ct-allow-approved" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 15: PR mode — new ct-allow annotation WITH label -> 0
+# ---------------------------------------------------------------------
+printf 'scenario 15: PR new-annot with label -> 0\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn stub() -> u32 { 0 }
+EOF
+setup_pr_repo "$d"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn is_admin(name: &[u8]) -> bool {
+    name == b"admin" // ct-allow: role-name compare, not a secret
+}
+EOF
+run_check "$d" GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main PR_LABELS='["ct-allow-approved"]'
+assert_exit 15 0 && assert_contains 15 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 16: PR mode — reformatted (not new) ct-allow -> 0
+# BASE has `x == y // ct-allow: reason-a`; HEAD has same annotation
+# but line-moved within file and whitespace-normalized. No label.
+# Must NOT trip the new-annotation check.
+# ---------------------------------------------------------------------
+printf 'scenario 16: PR reformatted annot no label -> 0\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn a() -> bool {
+    let x = b"a";
+    let y = b"b";
+    x == y // ct-allow: literal compare for scenario 16 test
+}
+EOF
+setup_pr_repo "$d"
+# HEAD: insert a blank line before, and double-space before the comment
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn a() -> bool {
+
+    let x = b"a";
+    let y = b"b";
+    x == y  // ct-allow: literal compare for scenario 16 test
+}
+EOF
+run_check "$d" GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main PR_LABELS='[]'
+assert_exit 16 0 && assert_contains 16 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 17: .ct-comparison-ignore references missing file -> exit 3
+# ---------------------------------------------------------------------
+printf 'scenario 17: stale .ct-comparison-ignore -> 3\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth.rs" <<'EOF'
+pub fn stub() -> u32 { 0 }
+EOF
+cat > "$d/.ct-comparison-ignore" <<'EOF'
+# Stale entry — this file does not exist
+crates/mango/src/does_not_exist.rs
+EOF
+run_check "$d"
+assert_exit 17 3 && assert_contains 17 "references missing file" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# scenario 18: test-path exemption — file ends in _test.rs, not scoped
+# ---------------------------------------------------------------------
+printf 'scenario 18: _test.rs path exemption -> PASS\n'
+d="$(setup_workdir)"
+mkdir -p "$d/crates/mango/src"
+cat > "$d/crates/mango/src/auth_test.rs" <<'EOF'
+pub fn check() -> bool {
+    let secret_key = b"abc";
+    secret_key == b"abc"
+}
+EOF
+run_check "$d"
+assert_exit 18 0 && assert_contains 18 "PASS" && pass
+cleanup_workdir "$d"
+
+# ---------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------
+printf '\n====================\n'
+printf 'PASS: %d   FAIL: %d   SKIP: %d\n' "$pass_count" "$fail_count" "$skip_count"
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Ships the interim mechanism for ROADMAP item 0.7 — **constant-time comparison enforcement**. The roadmap entry names `dylint` as the long-term target but explicitly sanctions an interim CI-grep + manual-review mechanism: that's what lands here. Dylint remains as a future roadmap item.

- **Policy doc** at `docs/ct-comparison-policy.md` — scope, P1-P5 signatures, escape hatch, failure modes, sanity-break recipe, known limitations, complementary clippy layer.
- **Scoped grep gate** at `scripts/ct-comparison-check.sh` — flags five shapes (byte-literal compare, secret-suffix `.eq`/`.ne`, `.as_bytes()` compare, multi-line `derive(PartialEq/Eq)` on secret-named types, secret-suffix identifier in `==`/`!=`) in `auth*` / `crypto*` / `token*` / `hash_chain*` under `crates/*/src/`. Test paths and `.ct-comparison-ignore` entries excluded.
- **Escape hatch** — `// ct-allow: <reason>` on the match line; new annotations in a PR require the `ct-allow-approved` label. Label check uses git set-difference on `(file, normalized-reason)` so rustfmt reflows don't trigger false readings.
- **18-scenario harness** at `scripts/ct-comparison-scripts-test.sh` — positive + negative cases for every signature, label-gate flow, reformatted-annotation pass-through (the key RISK), `.ct-comparison-ignore` validation, test-path exemption. All 18 PASS.
- **Dedicated workflow** `ct-comparison.yml` mirrors `geiger.yml` (pull_request + push:main + merge_group; SHA-pinned checkout; step-level `env:` for every `github.event.*` value).
- **Complementary clippy layer** — `clippy::disallowed_methods` at workspace `warn` level; paired config added to `clippy.toml` for byte-slice `PartialEq::eq/ne` and `Vec<u8>::eq`. Advisory, not blocking — the grep gate is the hard enforcement.
- **`subtle` forward-declared** in `[workspace.dependencies]` with `default-features = false, features = ["const-generics"]` so the first crate that needs it just writes `subtle.workspace = true`.

Roadmap item: [ROADMAP.md:797](../blob/main/ROADMAP.md#L797).

## Classification

Plumbing — this PR adds a CI gate and policy doc. No runtime code changes, no north-star axis moved directly. Operationalizes the "Security side-channel" bar by establishing PR-time enforcement ahead of the dylint follow-up.

## Verification strategy

All commands green at every commit on this branch:

- [x] `bash scripts/ct-comparison-scripts-test.sh` — 18/18 PASS
- [x] `bash scripts/ct-comparison-check.sh` — PASS (0 scoped files currently under `crates/*/src/`)
- [x] `bash scripts/ct-comparison-check.sh --list-scope` — exit 2 (empty scope), as expected
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] Workflow YAML parses (python yaml.safe_load)

## Test plan

- [ ] CI ct-comparison workflow runs green on this PR
- [ ] CI ct-comparison workflow runs `scripts/ct-comparison-scripts-test.sh` as a self-test step
- [ ] `fetch-depth: 0` on checkout so the label set-difference can read `origin/$base_ref:<file>`
- [ ] Clippy CI green with `disallowed_methods = warn` active

## Rollback

Revert the PR. No crate code depends on the new `subtle` workspace-dependency entry yet; the gate scripts are self-contained; removing `.github/workflows/ct-comparison.yml` disables the gate. No schema, no on-disk state, no API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
