### PR TITLE
chore(vet): cargo-vet supply-chain audit gate (0.7-vet)

### DIFF
--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -1,0 +1,105 @@
+# Mango cargo-vet supply-chain gate.
+#
+# Security: every `github.event.*` value flows through step-level
+# `env:` and is read as a shell variable — never interpolated into
+# `run:` blocks directly. Matches the geiger.yml / miri.yml /
+# ct-comparison.yml hardening precedent.
+#
+# Triggers: pull_request (path-filtered), push:main, merge_group,
+# nightly schedule (imports.lock can rotate externally), and
+# workflow_dispatch (manual re-run after vet-pin bumps).
+#
+# Two gates per run:
+#   1. `cargo vet check --locked --frozen` — any transitive dep
+#      must be audited (via imports or [[audits]]) or exempted.
+#   2. `cargo run -q -p xtask-vet-ttl` — enforces a review-by:
+#      YYYY-MM-DD token in every [[exemptions.<crate>]] notes
+#      string. cargo-vet has no native TTL for exemptions; this
+#      binary (crate from commit A) fills the gap.
+#
+# Version pin: CARGO_VET_VERSION env below is the single source of
+# truth. Different vet versions can accept/reject the same audit
+# graph differently; the pin is exact (not caret). Bump procedure
+# lives in docs/supply-chain-policy.md (commit D).
+
+name: vet
+
+on:
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "supply-chain/**"
+      - "crates/xtask-vet-ttl/**"
+      - ".github/workflows/vet.yml"
+      - "scripts/vet-*.sh"
+  push:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "supply-chain/**"
+      - "crates/xtask-vet-ttl/**"
+      - ".github/workflows/vet.yml"
+      - "scripts/vet-*.sh"
+  merge_group:
+  schedule:
+    - cron: "17 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'schedule' || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_VET_VERSION: "0.10.2"
+
+jobs:
+  vet:
+    name: cargo-vet
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: cache cargo-vet binary
+        id: cache-vet
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: ~/.cargo/bin/cargo-vet
+          key: cargo-vet-${{ env.CARGO_VET_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: install cargo-vet
+        if: steps.cache-vet.outputs.cache-hit != 'true'
+        env:
+          CARGO_VET_VERSION: ${{ env.CARGO_VET_VERSION }}
+        run: |
+          set -euo pipefail
+          cargo install cargo-vet --version "${CARGO_VET_VERSION}" --locked
+
+      - name: vet version sanity
+        env:
+          CARGO_VET_VERSION: ${{ env.CARGO_VET_VERSION }}
+        run: |
+          set -euo pipefail
+          got="$(cargo vet --version | awk '{print $2}')"
+          if [ "$got" != "${CARGO_VET_VERSION}" ]; then
+              echo "error: cargo-vet version mismatch (want ${CARGO_VET_VERSION}, got ${got})" >&2
+              exit 1
+          fi
+
+      - name: vet scripts self-test
+        run: bash scripts/vet-scripts-test.sh
+
+      - name: cargo vet check
+        run: cargo vet check --locked --frozen
+
+      - name: xtask-vet-ttl (exemption review-by gate)
+        run: cargo run -q -p xtask-vet-ttl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,12 +253,21 @@ with worked examples: [`docs/arithmetic-policy.md`][arith].
 -D warnings` gates CI. Workspace lint table is in the workspace
   [`Cargo.toml`](./Cargo.toml); per-crate overrides in the local
   `clippy.toml`.
-- **Supply chain.** `cargo-deny` runs every PR against
-  [`deny.toml`](./deny.toml) (advisories, licenses, banned crates
-  including `openssl-sys`, duplicate-version policy). `cargo-audit`
-  runs on push, PR, and a nightly schedule. GitHub Actions are
-  SHA-pinned. Future additions tracked in Phase 0.5: `cargo-vet`,
-  SBOM via `cargo-cyclonedx`.
+- **Supply chain.** Three layered gates. `cargo-deny` runs every
+  PR against [`deny.toml`](./deny.toml) (advisories, licenses,
+  banned crates including `openssl-sys`, duplicate-version policy).
+  `cargo-audit` runs on push, PR, and a nightly schedule.
+  `cargo-vet` runs on every Cargo.toml / Cargo.lock / supply-chain/
+  change and enforces that every transitive dep has either a
+  first-party audit, a hit in an imported audit set (mozilla /
+  google / bytecode-alliance), or a TTL'd exemption in
+  [`supply-chain/config.toml`](./supply-chain/config.toml). The
+  exemption TTL is enforced by
+  [`crates/xtask-vet-ttl`](./crates/xtask-vet-ttl) (cargo-vet has
+  no native `end:` on `[[exemptions]]`). GitHub Actions are
+  SHA-pinned. Full policy:
+  [`docs/supply-chain-policy.md`](./docs/supply-chain-policy.md).
+  Future additions: SBOM via `cargo-cyclonedx`.
 - **MSRV.** Workspace MSRV is **1.80** (see
   `rust-version` in [`Cargo.toml`](./Cargo.toml) and the `msrv`
   CI job). MSRV bumps are deliberate, land in their own PR, and
@@ -361,6 +370,19 @@ self-test that proves the gate's own logic is sound:
 bash scripts/ct-comparison-check.sh              # scans scoped files, exits 0/1/2/3
 bash scripts/ct-comparison-check.sh --list-scope # debug: dump the scope set
 bash scripts/ct-comparison-scripts-test.sh       # 18 harness scenarios
+```
+
+Run the cargo-vet supply-chain gate locally after a dep bump — same
+gates that block PRs in `.github/workflows/vet.yml`. Full policy in
+[`docs/supply-chain-policy.md`](./docs/supply-chain-policy.md):
+
+```bash
+cargo install cargo-vet --version 0.10.2 --locked   # once; pin must match vet.yml
+bash scripts/vet-update.sh                          # refresh imports + run both gates
+cargo vet check --locked --frozen                   # audit-graph gate only
+cargo run -q -p xtask-vet-ttl                       # exemption review-by TTL gate only
+cargo run -q -p xtask-vet-ttl -- --list             # diagnostic listing of all tokens
+bash scripts/vet-scripts-test.sh                    # 8 harness scenarios
 ```
 
 Notes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +271,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -392,6 +419,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +509,78 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic-build"
@@ -560,7 +697,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "xtask-vet-ttl"
+version = "0.1.0"
+dependencies = [
+ "time",
+ "toml",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "2"
-members = ["crates/mango", "crates/mango-proto", "crates/mango-loom-demo"]
+members = [
+    "crates/mango",
+    "crates/mango-proto",
+    "crates/mango-loom-demo",
+    "crates/xtask-vet-ttl",
+]
 # tests/fixtures/geiger-toy-workspace is a self-contained workspace
 # used by scripts/geiger-scripts-test.sh as a real-cargo-geiger
 # oracle. Excluding it keeps Cargo from discovering its

--- a/crates/xtask-vet-ttl/Cargo.toml
+++ b/crates/xtask-vet-ttl/Cargo.toml
@@ -1,0 +1,51 @@
+# xtask-vet-ttl
+#
+# Bespoke TTL check for cargo-vet `[exemptions]` entries carrying a
+# `review-by: YYYY-MM-DD` token in their `notes` string. cargo-vet
+# natively supports `end:` on `[trusted]` and `[wildcard-audits]`
+# entries (covered by `cargo vet renew --expiring --dry-run`), but
+# NOT on `[exemptions]`. This crate fills that gap.
+#
+# Binary, not a library consumers depend on. Invoked by
+# `.github/workflows/vet.yml` and by local contributors via
+# `cargo run -q -p xtask-vet-ttl`. NOT published.
+#
+# Why a Rust crate instead of a shell script: the logic is date
+# arithmetic + TOML parsing, which is hairy to do portably in bash
+# (macOS `date -j` vs GNU `date -d`, bash 3.2 limits, awk dialect
+# drift). A project whose thesis is "from-scratch production Rust"
+# writes its own tooling in Rust.
+
+[package]
+name = "xtask-vet-ttl"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "TTL check for cargo-vet [exemptions] entries (supply-chain gate helper)."
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+# TOML parser for reading supply-chain/config.toml. `toml = 0.8` is
+# the current stable serde-backed parser; brings `toml_edit` and
+# `serde` transitively — both already in the workspace graph.
+toml = "0.8"
+# Date handling. `time` is no_std-capable with an opt-in `std`
+# feature that gives us `OffsetDateTime::now_utc` and conversion
+# from `SystemTime`. `macros` is the const-time format-string
+# parser, `parsing` + `formatting` are the runtime pair we use
+# for reading `review-by` tokens out of `notes` strings.
+time = { version = "0.3", default-features = false, features = [
+    "macros",
+    "parsing",
+    "formatting",
+    "std",
+] }
+
+[dev-dependencies]
+# No external dev-deps; unit tests are self-contained in src/lib.rs.

--- a/crates/xtask-vet-ttl/src/lib.rs
+++ b/crates/xtask-vet-ttl/src/lib.rs
@@ -93,8 +93,8 @@ impl From<toml::de::Error> for ParseError {
 /// date that follows is not a valid ISO-8601 `YYYY-MM-DD`.
 pub fn parse_review_by(notes: &str) -> Result<Option<Date>, time::error::Parse> {
     let Some(after_label) = notes.find(REVIEW_BY_LABEL).map(|i| {
-        // SAFETY-EQUIVALENT BOUND: `find` returns a valid UTF-8 index;
-        // adding the label's known-ASCII length stays within bounds.
+        // BOUND: `find` returns a valid UTF-8 index; adding the
+        // label's known-ASCII length stays within bounds.
         i.saturating_add(REVIEW_BY_LABEL.len())
     }) else {
         return Ok(None);
@@ -353,11 +353,15 @@ notes = "no ttl label at all"
         let (reviews, soft) = extract_exemption_reviews(cfg).unwrap();
         assert!(reviews.is_empty());
         assert_eq!(soft.len(), 1);
-        matches!(
+        // Variant classification is load-bearing: the xtask's exit
+        // codes depend on MissingReviewBy vs MalformedDate. A bare
+        // `matches!(...)` would type-check but discard the boolean;
+        // `assert!(matches!(...))` is what actually verifies.
+        assert!(matches!(
             soft[0],
             ParseError::MissingReviewBy { ref crate_name, .. }
                 if crate_name == "silent-crate"
-        );
+        ));
     }
 
     #[test]
@@ -371,11 +375,11 @@ notes = "review-by: 2026-13-40; oops"
         let (reviews, soft) = extract_exemption_reviews(cfg).unwrap();
         assert!(reviews.is_empty());
         assert_eq!(soft.len(), 1);
-        matches!(
+        assert!(matches!(
             soft[0],
             ParseError::MalformedDate { ref crate_name, .. }
                 if crate_name == "bad-date"
-        );
+        ));
     }
 
     #[test]

--- a/crates/xtask-vet-ttl/src/lib.rs
+++ b/crates/xtask-vet-ttl/src/lib.rs
@@ -1,0 +1,434 @@
+// Parse cargo-vet `supply-chain/config.toml` and extract TTL metadata
+// from `[[exemptions.<crate>]]` entries carrying a `review-by:
+// YYYY-MM-DD` token inside their `notes` string.
+//
+// See `docs/supply-chain-policy.md` for the convention. The parser is
+// intentionally lenient about surrounding text: contributors write
+// free-form rationale in `notes`, and we only pluck the ISO-8601 date
+// that follows a `review-by:` label.
+
+use std::fmt;
+
+use time::format_description::FormatItem;
+use time::macros::format_description;
+use time::Date;
+
+/// The single-source format for our TTL dates. ISO-8601 with
+/// zero-padded fields so that lex comparison and semantic
+/// comparison agree.
+pub const DATE_FORMAT: &[FormatItem<'_>] = format_description!("[year]-[month]-[day]");
+
+/// Literal tag that labels the TTL date inside an exemption's
+/// `notes` string.
+pub const REVIEW_BY_LABEL: &str = "review-by:";
+
+/// One exemption row carrying a TTL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExemptionReview {
+    pub crate_name: String,
+    pub version: String,
+    pub review_by: Date,
+}
+
+/// Failures surfaced to the CLI. Each variant maps to an exit code
+/// discipline documented in `main.rs`.
+#[derive(Debug)]
+pub enum ParseError {
+    /// The config file failed TOML syntax.
+    TomlSyntax(toml::de::Error),
+    /// `[exemptions]` was present but the shape did not match what
+    /// cargo-vet emits (array-of-tables keyed by crate name).
+    ShapeMismatch(String),
+    /// A `[[exemptions.<crate>]]` table lacks the `notes` string or
+    /// `notes` does not contain `review-by:`.
+    MissingReviewBy { crate_name: String, version: String },
+    /// `notes` contains `review-by:` but the date that follows is not
+    /// a syntactically valid `YYYY-MM-DD`.
+    MalformedDate {
+        crate_name: String,
+        version: String,
+        raw: String,
+    },
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TomlSyntax(e) => write!(f, "config.toml syntax error: {e}"),
+            Self::ShapeMismatch(s) => write!(f, "unexpected [exemptions] shape: {s}"),
+            Self::MissingReviewBy {
+                crate_name,
+                version,
+            } => write!(
+                f,
+                "exemption for `{crate_name}@{version}` has no `review-by:` in notes"
+            ),
+            Self::MalformedDate {
+                crate_name,
+                version,
+                raw,
+            } => write!(
+                f,
+                "exemption for `{crate_name}@{version}`: malformed review-by date `{raw}` (want YYYY-MM-DD)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+impl From<toml::de::Error> for ParseError {
+    fn from(e: toml::de::Error) -> Self {
+        Self::TomlSyntax(e)
+    }
+}
+
+/// Extract the `YYYY-MM-DD` that follows the first occurrence of
+/// `review-by:` in `notes`. Whitespace around the label and the date
+/// is tolerated; anything after the 10-character date is ignored (so
+/// `review-by: 2026-10-23; reason follows.` works).
+///
+/// Returns `Ok(None)` when the label is absent (caller decides if
+/// that's fatal). Returns `Err(..)` when the label is present but the
+/// date that follows is not a valid ISO-8601 `YYYY-MM-DD`.
+pub fn parse_review_by(notes: &str) -> Result<Option<Date>, time::error::Parse> {
+    let Some(after_label) = notes.find(REVIEW_BY_LABEL).map(|i| {
+        // SAFETY-EQUIVALENT BOUND: `find` returns a valid UTF-8 index;
+        // adding the label's known-ASCII length stays within bounds.
+        i.saturating_add(REVIEW_BY_LABEL.len())
+    }) else {
+        return Ok(None);
+    };
+    let tail = notes.get(after_label..).unwrap_or("").trim_start();
+    // Take exactly 10 chars `YYYY-MM-DD`. Anything shorter fails
+    // parsing; anything longer is ignored and the caller's free-form
+    // rationale text goes after.
+    let date_slice: String = tail.chars().take(10).collect();
+    let date = Date::parse(&date_slice, DATE_FORMAT)?;
+    Ok(Some(date))
+}
+
+/// Parse a full `supply-chain/config.toml` string and extract every
+/// `[[exemptions.<crate>]]` entry that carries a `review-by:` date.
+///
+/// Entries without any `notes` field, or with a `notes` field that
+/// lacks `review-by:`, are returned as `MissingReviewBy` errors in
+/// the second return vector. Callers decide whether missing dates are
+/// fatal — the workflow currently treats them as non-fatal warnings
+/// so contributors can add exemptions without an immediate TTL.
+///
+/// The split return is deliberate: the `Vec<ExemptionReview>` feeds
+/// the date-compare step, and the `Vec<ParseError>` surfaces the
+/// "present but unparseable" cases (malformed date) plus "present but
+/// no TTL" (missing review-by). Shape mismatches and TOML syntax
+/// errors are hard-fail and come back as `Err`.
+pub fn extract_exemption_reviews(
+    config_toml: &str,
+) -> Result<(Vec<ExemptionReview>, Vec<ParseError>), ParseError> {
+    let table: toml::Table = toml::from_str(config_toml)?;
+
+    let Some(exemptions) = table.get("exemptions") else {
+        // No [exemptions] block at all — empty result, not an error.
+        return Ok((Vec::new(), Vec::new()));
+    };
+
+    let exemptions_table = exemptions
+        .as_table()
+        .ok_or_else(|| ParseError::ShapeMismatch("`exemptions` is not a table".to_string()))?;
+
+    let mut reviews = Vec::new();
+    let mut soft_errors = Vec::new();
+
+    for (crate_name, entries_value) in exemptions_table {
+        let entries = entries_value.as_array().ok_or_else(|| {
+            ParseError::ShapeMismatch(format!("exemptions.{crate_name} is not an array of tables"))
+        })?;
+        for entry in entries {
+            let entry_table = entry.as_table().ok_or_else(|| {
+                ParseError::ShapeMismatch(format!(
+                    "exemptions.{crate_name}[..] element is not a table"
+                ))
+            })?;
+            let version = entry_table
+                .get("version")
+                .and_then(toml::Value::as_str)
+                .unwrap_or("<no-version>")
+                .to_string();
+            let notes = entry_table
+                .get("notes")
+                .and_then(toml::Value::as_str)
+                .unwrap_or("");
+            match parse_review_by(notes) {
+                Ok(Some(date)) => reviews.push(ExemptionReview {
+                    crate_name: crate_name.clone(),
+                    version,
+                    review_by: date,
+                }),
+                Ok(None) => soft_errors.push(ParseError::MissingReviewBy {
+                    crate_name: crate_name.clone(),
+                    version,
+                }),
+                Err(_) => {
+                    let raw = extract_raw_date_slice(notes);
+                    soft_errors.push(ParseError::MalformedDate {
+                        crate_name: crate_name.clone(),
+                        version,
+                        raw,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok((reviews, soft_errors))
+}
+
+/// Pull out the 10-char slice that `parse_review_by` tried to parse,
+/// for error reporting. Duplicates the slice extraction logic in
+/// `parse_review_by`; kept narrow so the happy path stays zero-copy.
+fn extract_raw_date_slice(notes: &str) -> String {
+    let Some(after_label) = notes
+        .find(REVIEW_BY_LABEL)
+        .map(|i| i.saturating_add(REVIEW_BY_LABEL.len()))
+    else {
+        return String::new();
+    };
+    let tail = notes.get(after_label..).unwrap_or("").trim_start();
+    tail.chars().take(10).collect()
+}
+
+/// Partition the reviews into `(expired, current)` relative to
+/// `today`. `expired` means `review_by < today`.
+#[must_use]
+pub fn partition_by_date(
+    reviews: Vec<ExemptionReview>,
+    today: Date,
+) -> (Vec<ExemptionReview>, Vec<ExemptionReview>) {
+    let mut expired = Vec::new();
+    let mut current = Vec::new();
+    for r in reviews {
+        if r.review_by < today {
+            expired.push(r);
+        } else {
+            current.push(r);
+        }
+    }
+    (expired, current)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests intentionally use these patterns for concise assertions"
+)]
+mod tests {
+    use super::*;
+    use time::macros::date;
+
+    #[test]
+    fn parse_review_by_simple() {
+        let got = parse_review_by("review-by: 2026-10-23").unwrap().unwrap();
+        assert_eq!(got, date!(2026 - 10 - 23));
+    }
+
+    #[test]
+    fn parse_review_by_with_trailing_rationale() {
+        let got = parse_review_by("review-by: 2026-10-23; no audit yet, small crate")
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, date!(2026 - 10 - 23));
+    }
+
+    #[test]
+    fn parse_review_by_with_leading_text() {
+        let got = parse_review_by("TBD audit. review-by: 2027-01-01 will bump when ring lands")
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, date!(2027 - 01 - 01));
+    }
+
+    #[test]
+    fn parse_review_by_extra_whitespace() {
+        let got = parse_review_by("review-by:    2026-12-31")
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, date!(2026 - 12 - 31));
+    }
+
+    #[test]
+    fn parse_review_by_absent_returns_none() {
+        let got = parse_review_by("no ttl here, just rationale").unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn parse_review_by_empty_returns_none() {
+        let got = parse_review_by("").unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn parse_review_by_malformed_errors() {
+        assert!(
+            parse_review_by("review-by: 2026-13-01").is_err(),
+            "bad month"
+        );
+        assert!(
+            parse_review_by("review-by: 2026/10/23").is_err(),
+            "wrong separator"
+        );
+        assert!(
+            parse_review_by("review-by: not-a-date").is_err(),
+            "not numeric"
+        );
+        assert!(parse_review_by("review-by: 2026-10").is_err(), "too short");
+    }
+
+    #[test]
+    fn extract_empty_config() {
+        let (reviews, soft) = extract_exemption_reviews("").unwrap();
+        assert!(reviews.is_empty());
+        assert!(soft.is_empty());
+    }
+
+    #[test]
+    fn extract_no_exemptions_section() {
+        let cfg = r#"
+[cargo-vet]
+version = "0.10.2"
+"#;
+        let (reviews, soft) = extract_exemption_reviews(cfg).unwrap();
+        assert!(reviews.is_empty());
+        assert!(soft.is_empty());
+    }
+
+    #[test]
+    fn extract_single_exemption_happy() {
+        let cfg = r#"
+[[exemptions.some-crate]]
+version = "1.2.3"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23; no audit yet"
+"#;
+        let (reviews, soft) = extract_exemption_reviews(cfg).unwrap();
+        assert_eq!(reviews.len(), 1);
+        assert_eq!(reviews[0].crate_name, "some-crate");
+        assert_eq!(reviews[0].version, "1.2.3");
+        assert_eq!(reviews[0].review_by, date!(2026 - 10 - 23));
+        assert!(soft.is_empty());
+    }
+
+    #[test]
+    fn extract_multiple_versions_same_crate() {
+        let cfg = r#"
+[[exemptions.dual-ver]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23"
+
+[[exemptions.dual-ver]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-11-30"
+"#;
+        let (reviews, soft) = extract_exemption_reviews(cfg).unwrap();
+        assert_eq!(reviews.len(), 2);
+        assert!(soft.is_empty());
+        let versions: Vec<&str> = reviews.iter().map(|r| r.version.as_str()).collect();
+        assert!(versions.contains(&"1.0.0"));
+        assert!(versions.contains(&"2.0.0"));
+    }
+
+    #[test]
+    fn extract_missing_review_by_becomes_soft_error() {
+        let cfg = r#"
+[[exemptions.silent-crate]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+notes = "no ttl label at all"
+"#;
+        let (reviews, soft) = extract_exemption_reviews(cfg).unwrap();
+        assert!(reviews.is_empty());
+        assert_eq!(soft.len(), 1);
+        matches!(
+            soft[0],
+            ParseError::MissingReviewBy { ref crate_name, .. }
+                if crate_name == "silent-crate"
+        );
+    }
+
+    #[test]
+    fn extract_malformed_date_becomes_soft_error() {
+        let cfg = r#"
+[[exemptions.bad-date]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-13-40; oops"
+"#;
+        let (reviews, soft) = extract_exemption_reviews(cfg).unwrap();
+        assert!(reviews.is_empty());
+        assert_eq!(soft.len(), 1);
+        matches!(
+            soft[0],
+            ParseError::MalformedDate { ref crate_name, .. }
+                if crate_name == "bad-date"
+        );
+    }
+
+    #[test]
+    fn extract_shape_mismatch_is_hard_fail() {
+        let cfg = r#"
+[exemptions]
+not-an-array = "scalar"
+"#;
+        let res = extract_exemption_reviews(cfg);
+        assert!(
+            res.is_err(),
+            "scalar under [exemptions.<crate>] must be rejected"
+        );
+    }
+
+    #[test]
+    fn extract_no_notes_field_becomes_soft_error() {
+        let cfg = r#"
+[[exemptions.bare]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+"#;
+        let (reviews, soft) = extract_exemption_reviews(cfg).unwrap();
+        assert!(reviews.is_empty());
+        assert_eq!(soft.len(), 1);
+    }
+
+    #[test]
+    fn partition_by_date_splits_correctly() {
+        let reviews = vec![
+            ExemptionReview {
+                crate_name: "past".into(),
+                version: "1.0".into(),
+                review_by: date!(2020 - 01 - 01),
+            },
+            ExemptionReview {
+                crate_name: "future".into(),
+                version: "1.0".into(),
+                review_by: date!(2099 - 01 - 01),
+            },
+            ExemptionReview {
+                crate_name: "today".into(),
+                version: "1.0".into(),
+                review_by: date!(2026 - 04 - 23),
+            },
+        ];
+        let today = date!(2026 - 04 - 23);
+        let (expired, current) = partition_by_date(reviews, today);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].crate_name, "past");
+        assert_eq!(current.len(), 2);
+        // Today's date is treated as NOT expired (boundary: >= today).
+        assert!(current.iter().any(|r| r.crate_name == "today"));
+        assert!(current.iter().any(|r| r.crate_name == "future"));
+    }
+}

--- a/crates/xtask-vet-ttl/src/main.rs
+++ b/crates/xtask-vet-ttl/src/main.rs
@@ -1,0 +1,190 @@
+// Binary entry point for the cargo-vet `[exemptions]` TTL check.
+//
+// Reads `supply-chain/config.toml` (relative to the repo root that
+// `CARGO_MANIFEST_DIR/..` points at, or the CWD — workflow always
+// runs from the repo root). Parses every `[[exemptions.<crate>]]`
+// entry, extracts `review-by: YYYY-MM-DD` from `notes`, and fails if
+// any date is in the past. Complements `cargo vet renew --expiring`,
+// which handles the `[trusted]` side of the TTL story.
+//
+// This binary is a CLI tool; `println!` / `eprintln!` are how it
+// communicates to the contributor and to CI step summaries. The
+// workspace-wide ban on print macros does not apply here.
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+//
+// Exit codes:
+//   0  PASS — every exemption either has a future review-by or none
+//             at all (the latter is advisory-only; see --strict)
+//   1  FAIL — at least one exemption's review-by is in the past
+//   2  FAIL — a review-by date was present but malformed, or the
+//             config file failed TOML syntax
+//
+// Flags:
+//   --list     print every (crate, version, review-by) tuple and exit 0
+//   --strict   treat missing review-by tokens as hard errors (exit 1)
+//   --config <path>  read from <path> instead of ./supply-chain/config.toml
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use time::OffsetDateTime;
+
+use xtask_vet_ttl::{extract_exemption_reviews, partition_by_date, ParseError, DATE_FORMAT};
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("xtask-vet-ttl: error: {e}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+struct Args {
+    list: bool,
+    strict: bool,
+    config: PathBuf,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut args = Args {
+        list: false,
+        strict: false,
+        config: PathBuf::from("supply-chain/config.toml"),
+    };
+    let mut iter = std::env::args().skip(1);
+    while let Some(a) = iter.next() {
+        match a.as_str() {
+            "--list" => args.list = true,
+            "--strict" => args.strict = true,
+            "--config" => {
+                let v = iter
+                    .next()
+                    .ok_or_else(|| "--config requires a path".to_string())?;
+                args.config = PathBuf::from(v);
+            }
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    Ok(args)
+}
+
+fn print_help() {
+    println!(
+        "xtask-vet-ttl — TTL check for cargo-vet [exemptions] entries\n\
+         \n\
+         USAGE:\n    \
+             cargo run -q -p xtask-vet-ttl -- [OPTIONS]\n\
+         \n\
+         OPTIONS:\n    \
+             --list           print every (crate, version, review-by) and exit 0\n    \
+             --strict         treat missing review-by as a failure (exit 1)\n    \
+             --config <path>  read <path> instead of supply-chain/config.toml\n    \
+             -h, --help       show this message\n\
+         \n\
+         EXIT CODES:\n    \
+             0  PASS\n    \
+             1  at least one review-by is in the past (or missing with --strict)\n    \
+             2  malformed date or config.toml syntax error\n\
+         "
+    );
+}
+
+fn run() -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let args = parse_args().map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let raw = fs::read_to_string(&args.config)
+        .map_err(|e| format!("cannot read {}: {e}", args.config.display()))?;
+    let (reviews, soft_errors) = extract_exemption_reviews(&raw)?;
+
+    // Any malformed-date soft error is always a hard fail — the
+    // contributor wrote a TTL token but we couldn't parse it, which
+    // means the intent exists and we shouldn't silently pass.
+    let malformed: Vec<&ParseError> = soft_errors
+        .iter()
+        .filter(|e| matches!(e, ParseError::MalformedDate { .. }))
+        .collect();
+    let missing: Vec<&ParseError> = soft_errors
+        .iter()
+        .filter(|e| matches!(e, ParseError::MissingReviewBy { .. }))
+        .collect();
+
+    if args.list {
+        println!("=== cargo-vet [exemptions] TTL check — listing ===");
+        println!("config: {}", args.config.display());
+        println!("entries with review-by: {}", reviews.len());
+        for r in &reviews {
+            let formatted = r
+                .review_by
+                .format(DATE_FORMAT)
+                .unwrap_or_else(|_| "<unformattable>".to_string());
+            println!("  {} @ {} -> {}", r.crate_name, r.version, formatted);
+        }
+        println!("entries missing review-by: {}", missing.len());
+        for e in &missing {
+            println!("  {e}");
+        }
+        println!("entries with malformed review-by: {}", malformed.len());
+        for e in &malformed {
+            println!("  {e}");
+        }
+        return Ok(ExitCode::from(0));
+    }
+
+    if !malformed.is_empty() {
+        eprintln!("xtask-vet-ttl: malformed review-by date(s):");
+        for e in &malformed {
+            eprintln!("  {e}");
+        }
+        return Ok(ExitCode::from(2));
+    }
+
+    let today = OffsetDateTime::now_utc().date();
+    let (expired, current) = partition_by_date(reviews, today);
+
+    if !expired.is_empty() {
+        let today_fmt = today.format(DATE_FORMAT).unwrap_or_else(|_| "???".into());
+        eprintln!(
+            "xtask-vet-ttl: {} exemption(s) past review-by (today = {}):",
+            expired.len(),
+            today_fmt
+        );
+        for r in &expired {
+            let fmt = r
+                .review_by
+                .format(DATE_FORMAT)
+                .unwrap_or_else(|_| "???".into());
+            eprintln!("  {} @ {} -> review-by {}", r.crate_name, r.version, fmt);
+        }
+        eprintln!("\nrenew via `cargo vet renew --expiring` for [trusted] entries,");
+        eprintln!("or bump the review-by date in supply-chain/config.toml for exemptions.");
+        eprintln!("see docs/supply-chain-policy.md.");
+        return Ok(ExitCode::from(1));
+    }
+
+    if args.strict && !missing.is_empty() {
+        eprintln!(
+            "xtask-vet-ttl: --strict: {} exemption(s) missing review-by:",
+            missing.len()
+        );
+        for e in &missing {
+            eprintln!("  {e}");
+        }
+        return Ok(ExitCode::from(1));
+    }
+
+    println!("xtask-vet-ttl: PASS");
+    let today_fmt = today.format(DATE_FORMAT).unwrap_or_else(|_| "???".into());
+    println!(
+        "  today = {today_fmt}; exemption TTLs OK ({} with review-by, {} without)",
+        current.len(),
+        missing.len()
+    );
+    Ok(ExitCode::from(0))
+}

--- a/crates/xtask-vet-ttl/src/main.rs
+++ b/crates/xtask-vet-ttl/src/main.rs
@@ -162,8 +162,8 @@ fn run() -> Result<ExitCode, Box<dyn std::error::Error>> {
                 .unwrap_or_else(|_| "???".into());
             eprintln!("  {} @ {} -> review-by {}", r.crate_name, r.version, fmt);
         }
-        eprintln!("\nrenew via `cargo vet renew --expiring` for [trusted] entries,");
-        eprintln!("or bump the review-by date in supply-chain/config.toml for exemptions.");
+        eprintln!("\nbump the review-by date in supply-chain/config.toml after re-eyeballing");
+        eprintln!("the crate, or replace the exemption with `cargo vet certify`.");
         eprintln!("see docs/supply-chain-policy.md.");
         return Ok(ExitCode::from(1));
     }

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -1,0 +1,276 @@
+# Supply-chain audit policy
+
+Mango treats every transitive dependency as code that will run with
+full process privileges. An unaudited dep is a supply-chain risk,
+not a neutral checkbox. The machinery that enforces this is three
+layered gates:
+
+- **`cargo-deny`** (advisory / license / banned-crate / duplicate
+  policy) — runs in `.github/workflows/ci.yml` against
+  [`deny.toml`](../deny.toml). Details at the bottom of this doc.
+- **`cargo-audit`** (RustSec advisory freshness) — runs in
+  [`.github/workflows/audit.yml`](../.github/workflows/audit.yml) on
+  push, PR, and a nightly cron.
+- **`cargo-vet`** (human-reviewed source audit graph) — the subject
+  of this document. Runs in
+  [`.github/workflows/vet.yml`](../.github/workflows/vet.yml).
+
+The three are not redundant. `cargo-deny` and `cargo-audit` react
+to metadata (licenses, CVEs); `cargo-vet` attests to the _source_
+of each crate version having been looked at by a human we trust.
+
+This doc is the policy. The CI enforcement is
+[`.github/workflows/vet.yml`](../.github/workflows/vet.yml); the
+contributor helper is
+[`scripts/vet-update.sh`](../scripts/vet-update.sh); the TTL binary
+is [`crates/xtask-vet-ttl`](../crates/xtask-vet-ttl); the audit
+graph itself is under [`supply-chain/`](../supply-chain/).
+
+## Why this exists
+
+Every `cargo build` compiles and runs code from dozens of upstream
+maintainers. `cargo-audit` catches _known_ vulnerabilities in that
+code, but known vulnerabilities are a small subset of "things a
+malicious maintainer can put in a dep." The 2024 `xz-utils`
+incident is the reference point: a multi-year social-engineering
+attack that landed a backdoor in a universally-linked library. No
+CVE database would have caught that on day zero.
+
+`cargo-vet` closes the gap by tracking, for every version of every
+crate in the dependency graph, a specific person who has looked at
+the source and attests that it matches a declared criterion (for
+us: `safe-to-deploy`). The audit graph is committed, reviewed, and
+fully auditable.
+
+Our `safe-to-deploy` bar: no obfuscation, no runtime code
+generation from network input, no calls into `unsafe` FFI that
+aren't documented and scoped, no behaviour at odds with the
+crate's public API contract. This is the Mozilla criterion — we
+deliberately reuse it instead of inventing a local one so that
+Mozilla's own audits transitively apply to crates we both depend
+on.
+
+## What the gate enforces
+
+On every PR that touches `Cargo.toml`, `Cargo.lock`,
+`supply-chain/**`, `crates/xtask-vet-ttl/**`,
+`.github/workflows/vet.yml`, or `scripts/vet-*.sh`, the workflow
+runs two gates.
+
+### Gate 1: `cargo vet check --locked --frozen`
+
+Walks the Cargo resolver output and, for every `(crate, version)`
+pair in the graph, demands one of:
+
+1. An entry in [`supply-chain/audits.toml`](../supply-chain/audits.toml)
+   — a first-party audit written by a mango contributor.
+2. An entry in an imported audit set (see Import sets below) that
+   covers this version.
+3. An entry in [`supply-chain/config.toml`](../supply-chain/config.toml)'s
+   `[[exemptions.<crate>]]` section — an escape hatch with a TTL
+   (see Gate 2).
+
+`--locked`: honour `Cargo.lock` exactly.
+`--frozen`: no network fetches. The imports feed is hydrated from
+[`supply-chain/imports.lock`](../supply-chain/imports.lock), which
+is committed. CI after the checkout step runs fully offline.
+
+Any new transitive dep that is neither audited nor exempted fails
+here with a readable diff.
+
+### Gate 2: `xtask-vet-ttl` (exemption TTLs)
+
+cargo-vet natively supports `end:` dates on `[[trusted]]` and
+`[[wildcard-audits]]` entries, and `cargo vet check` rejects any
+entry past its `end`. cargo-vet does **not** support `end:` on
+`[[exemptions]]` — which is the long tail of our supply-chain
+graph.
+
+[`crates/xtask-vet-ttl`](../crates/xtask-vet-ttl) is a small Rust
+binary that parses every `[[exemptions.<crate>]]` entry, extracts a
+`review-by: YYYY-MM-DD` token from its `notes` field, and fails CI
+if any date is in the past. Without this, an exemption added
+"temporarily" becomes permanent — review friction is how audits
+stay fresh.
+
+Exit codes:
+
+- `0` every exemption either has a future review-by or none (the
+  latter is advisory unless `--strict`).
+- `1` at least one exemption's `review-by` is past, or (with
+  `--strict`) at least one exemption is missing the token.
+- `2` a date token is present but malformed (e.g., `2026-13-01`),
+  or the config file is not syntactically valid TOML.
+
+The distinction between `1` (expired) and `2` (malformed) is
+deliberate: a typo in a new exemption should produce a different
+signal than a stale exemption that needs renewing.
+
+Run locally:
+
+```bash
+cargo run -q -p xtask-vet-ttl               # same gate CI runs
+cargo run -q -p xtask-vet-ttl -- --list     # diagnostic listing
+cargo run -q -p xtask-vet-ttl -- --strict   # treat missing tokens as failures
+```
+
+## Import sets
+
+`supply-chain/config.toml` imports three external audit feeds:
+
+| Set                 | URL                                                                                                                                                                            | Coverage                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `mozilla`           | [raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml](https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml)                                     | Large general-purpose Rust ecosystem, especially std-adjacent |
+| `google`            | [raw.githubusercontent.com/google/supply-chain/main/audits.toml](https://raw.githubusercontent.com/google/supply-chain/main/audits.toml)                                       | Broad, overlaps heavily with Mozilla; strong on gRPC / proto  |
+| `bytecode-alliance` | [raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml](https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml) | wasmtime-adjacent (`wit-bindgen`, prost ecosystem)            |
+
+URLs are canonical from the cargo-vet registry published by Mozilla:
+<https://raw.githubusercontent.com/mozilla/cargo-vet/main/registry.toml>.
+Verified HTTP 200 on 2026-04-23.
+
+The URLs in `config.toml` are the _source_; what actually gets
+checked is `supply-chain/imports.lock`, which is committed and
+updated by `cargo vet regenerate imports`. This makes CI
+deterministic: a feed rotating a key or moving a file does not
+break a merged PR until someone explicitly refreshes the lock.
+
+Adding a new import set is a no-op at the CI level (the lock only
+grows if the new set covers a crate in our graph). We keep the
+list small by policy — every import set is an additional trust
+relationship, and supply-chain risk compounds.
+
+## First-party policy entries
+
+Every workspace crate has an entry in `config.toml`:
+
+```toml
+[policy.mango]
+audit-as-crates-io = false
+criteria = "safe-to-deploy"
+```
+
+- `audit-as-crates-io = false` because our crates are not published.
+  Without this, cargo-vet tries to resolve them against crates.io
+  and fails.
+- `criteria = "safe-to-deploy"` pins the audit bar that transitive
+  deps must clear when pulled in by this crate.
+
+New workspace members MUST add a `[policy.<crate-name>]` block in
+the same PR that adds the crate, or CI fails.
+
+## Contributor workflow
+
+### When a dep bump lands
+
+```bash
+# from the repo root, after editing Cargo.toml / cargo update
+bash scripts/vet-update.sh
+```
+
+That script:
+
+1. Verifies your local `cargo-vet` version matches the CI pin.
+2. Runs `cargo vet regenerate imports` to refresh the lock.
+3. Runs `cargo vet check --locked --frozen` (same as CI).
+4. Runs `xtask-vet-ttl` (same as CI).
+5. Prints a diff of `supply-chain/` for you to commit.
+
+If the dep is covered by an existing imported audit, steps 2-4
+succeed and `config.toml`'s exemption list may shrink.
+
+If the dep is NOT covered, `cargo vet check` fails and lists the
+crate + version. You have three options:
+
+1. **Add an exemption** with a TTL. Edit `supply-chain/config.toml`:
+
+   ```toml
+   [[exemptions.new-crate]]
+   version = "1.2.3"
+   criteria = "safe-to-deploy"
+   notes = "review-by: 2026-10-23 — upstream maintainer, audit pending"
+   ```
+
+   The `review-by` date is six months from the day you add the
+   exemption. xtask-vet-ttl will fail CI on that date unless the
+   entry is renewed (push the date forward after another eyeball
+   pass) or replaced with a full audit.
+
+2. **Write a first-party audit.** After reading the crate source
+   and convincing yourself it meets `safe-to-deploy`:
+
+   ```bash
+   cargo vet certify new-crate 1.2.3
+   ```
+
+   This records you as the auditor in `supply-chain/audits.toml`.
+   Most small utility crates can be audited in one sitting.
+
+3. **Wait for the upstream import to cover it.** If the crate is
+   widely used, Mozilla / Google may have already audited it;
+   `cargo vet suggest` lists the specific import that would
+   eliminate the exemption.
+
+### When an exemption's `review-by` lapses
+
+A lapsed exemption turns CI red with a specific message:
+
+```
+xtask-vet-ttl: N exemption(s) past review-by (today = YYYY-MM-DD):
+  foo @ 1.2.3 -> review-by 2026-10-23
+```
+
+Do one of:
+
+- Re-eyeball the crate and push the date six months forward.
+- Replace the exemption with a full audit (`cargo vet certify`).
+- Check whether the crate is now covered by an import
+  (`bash scripts/vet-update.sh` then retry).
+
+## CI pin bump procedure
+
+`.github/workflows/vet.yml` pins the cargo-vet binary via
+`CARGO_VET_VERSION`. Different vet versions can accept/reject the
+same audit graph differently, so the pin is exact.
+
+To bump:
+
+1. Update `CARGO_VET_VERSION` in `vet.yml` to the new version.
+2. Locally:
+   ```bash
+   cargo install cargo-vet --version <new> --locked --force
+   cargo vet check --locked --frozen
+   cargo run -q -p xtask-vet-ttl
+   ```
+3. If `config.toml`'s `[cargo-vet] version` field needs bumping
+   (major.minor only — vet rejects x.y.z in this field), do it in
+   the same PR.
+4. Open a PR; rust-expert reviews for the same reasons it reviews
+   any security-sensitive config change.
+
+## What lives where
+
+| File                          | Role                        | Hand-edited?                         |
+| ----------------------------- | --------------------------- | ------------------------------------ |
+| `supply-chain/config.toml`    | imports, policy, exemptions | yes (exemption notes, policy blocks) |
+| `supply-chain/audits.toml`    | first-party audits          | via `cargo vet certify`              |
+| `supply-chain/imports.lock`   | resolved imports            | via `cargo vet regenerate imports`   |
+| `crates/xtask-vet-ttl/`       | exemption TTL binary        | yes                                  |
+| `.github/workflows/vet.yml`   | CI gate                     | yes                                  |
+| `scripts/vet-update.sh`       | contributor helper          | yes                                  |
+| `scripts/vet-scripts-test.sh` | harness self-test           | yes                                  |
+
+## Relationship to `cargo-deny` and `cargo-audit`
+
+- `cargo-deny` ([`deny.toml`](../deny.toml)) gates licenses,
+  duplicate versions, and banned crates (`openssl-sys`,
+  `openssl-src`). Runs in `ci.yml`. Its `advisories` section also
+  gates against the RustSec DB, with strict posture (yanked,
+  unmaintained, unsound all fail).
+- `cargo-audit` (`audit.yml`) gates RustSec advisories on push /
+  PR / nightly cron. Nightly is the differentiator — it surfaces
+  advisories published _after_ a PR merged.
+- `cargo-vet` (this doc) gates source-level audit attestations.
+  Slowest-moving, hardest to bypass, catches things the other two
+  cannot (like a backdoor in a package whose metadata looks clean).
+
+All three are required for `safe-to-deploy`.

--- a/scripts/vet-scripts-test.sh
+++ b/scripts/vet-scripts-test.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# scripts/vet-scripts-test.sh
+#
+# Smoke-test harness for the cargo-vet supply-chain gate.
+#
+# What this covers:
+#   - xtask-vet-ttl honours exit codes for synthetic configs
+#     (happy / expired / malformed / missing).
+#   - scripts/vet-update.sh rejects a wrong cargo-vet version when
+#     asked to (version-extraction regression guard).
+#   - .github/workflows/vet.yml and supply-chain/ both exist and
+#     are well-formed TOML/YAML at check time.
+#
+# What this does NOT cover:
+#   - Running `cargo vet check` itself. That runs as a dedicated
+#     workflow step after this harness — duplicating it here only
+#     doubles CI wall-clock.
+#   - The xtask parser's TOML-shape edge cases. Those are covered
+#     by the 16 unit tests inside crates/xtask-vet-ttl/src/lib.rs.
+#     This harness is the CLI-level oracle on top.
+#
+# Invocation:
+#   bash scripts/vet-scripts-test.sh
+#   (run from any CWD; script cd's to repo root)
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+pass_count=0
+fail_count=0
+
+# ---------------------------------------------------------------------
+# assertion helpers
+# ---------------------------------------------------------------------
+RUN_OUT=""
+RUN_EXIT=0
+run_ttl() {
+    local config_path="$1"
+    shift
+    # Capture $? immediately after $(); `|| true` would swallow the
+    # exit code the way `$?` is sampled post-substitution.
+    RUN_OUT="$(cargo run -q -p xtask-vet-ttl -- --config "$config_path" "$@" 2>&1)"
+    RUN_EXIT=$?
+}
+
+assert_exit() {
+    local scenario="$1" want="$2"
+    if [ "$RUN_EXIT" -ne "$want" ]; then
+        printf 'FAIL  %s: want exit %d, got %d\n' "$scenario" "$want" "$RUN_EXIT" >&2
+        printf '----- output -----\n%s\n------------------\n' "$RUN_OUT" >&2
+        fail_count=$((fail_count + 1))
+        return 1
+    fi
+    return 0
+}
+
+assert_contains() {
+    local scenario="$1" needle="$2"
+    if ! printf '%s' "$RUN_OUT" | grep -qF -- "$needle"; then
+        printf 'FAIL  %s: expected output to contain %q\n' "$scenario" "$needle" >&2
+        printf '----- output -----\n%s\n------------------\n' "$RUN_OUT" >&2
+        fail_count=$((fail_count + 1))
+        return 1
+    fi
+    return 0
+}
+
+pass() {
+    printf 'PASS  %s\n' "$1"
+    pass_count=$((pass_count + 1))
+}
+
+# tmpdir cleanup
+tmpdir="$(mktemp -d -t mango-vet-test.XXXXXX)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+# ---------------------------------------------------------------------
+# xtask-vet-ttl CLI scenarios
+# ---------------------------------------------------------------------
+
+# Scenario 1: happy path — one exemption with a future review-by.
+scenario="happy (future review-by -> exit 0)"
+cat >"$tmpdir/happy.toml" <<'TOML'
+[cargo-vet]
+version = "0.10"
+
+[[exemptions.foo]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2099-01-01 — distant future"
+TOML
+run_ttl "$tmpdir/happy.toml"
+assert_exit "$scenario" 0 && \
+    assert_contains "$scenario" "PASS" && \
+    pass "$scenario"
+
+# Scenario 2: expired — review-by in the past must exit 1.
+scenario="expired (past review-by -> exit 1)"
+cat >"$tmpdir/expired.toml" <<'TOML'
+[cargo-vet]
+version = "0.10"
+
+[[exemptions.foo]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2000-01-01 — long ago"
+TOML
+run_ttl "$tmpdir/expired.toml"
+assert_exit "$scenario" 1 && \
+    assert_contains "$scenario" "past review-by" && \
+    pass "$scenario"
+
+# Scenario 3: malformed date — must exit 2 (hard fail, distinct
+# from "expired" so contributors can tell a typo from a stale entry).
+scenario="malformed date (bad month -> exit 2)"
+cat >"$tmpdir/malformed.toml" <<'TOML'
+[cargo-vet]
+version = "0.10"
+
+[[exemptions.foo]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-13-01 — month 13"
+TOML
+run_ttl "$tmpdir/malformed.toml"
+assert_exit "$scenario" 2 && \
+    assert_contains "$scenario" "malformed" && \
+    pass "$scenario"
+
+# Scenario 4: missing review-by + --strict -> exit 1.
+scenario="missing review-by + --strict -> exit 1"
+cat >"$tmpdir/missing.toml" <<'TOML'
+[cargo-vet]
+version = "0.10"
+
+[[exemptions.foo]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+notes = "no token here"
+TOML
+run_ttl "$tmpdir/missing.toml" --strict
+assert_exit "$scenario" 1 && \
+    assert_contains "$scenario" "missing review-by" && \
+    pass "$scenario"
+
+# Scenario 5: missing review-by without --strict -> exit 0 (advisory).
+scenario="missing review-by no-strict -> exit 0 (advisory)"
+run_ttl "$tmpdir/missing.toml"
+assert_exit "$scenario" 0 && \
+    assert_contains "$scenario" "PASS" && \
+    pass "$scenario"
+
+# Scenario 6: --list prints a listing and exits 0 even if entries are
+# expired (diagnostic mode; must not double-fail contributors who are
+# investigating a red CI run).
+scenario="--list (expired entries -> exit 0)"
+run_ttl "$tmpdir/expired.toml" --list
+assert_exit "$scenario" 0 && \
+    assert_contains "$scenario" "listing" && \
+    pass "$scenario"
+
+# ---------------------------------------------------------------------
+# vet-update.sh version-extraction regression guard
+# ---------------------------------------------------------------------
+# The wrapper reads CARGO_VET_VERSION from .github/workflows/vet.yml.
+# If the extraction regex drifts (quoting, spacing), the wrapper
+# would silently accept any installed version. Verify a concrete
+# version line is extractable today.
+scenario="vet-update.sh: CARGO_VET_VERSION is parseable"
+if grep -qE '^\s*CARGO_VET_VERSION:\s*"[0-9]+\.[0-9]+\.[0-9]+"' .github/workflows/vet.yml; then
+    pass "$scenario"
+else
+    printf 'FAIL  %s: CARGO_VET_VERSION line not found or malformed in vet.yml\n' "$scenario" >&2
+    fail_count=$((fail_count + 1))
+fi
+
+# ---------------------------------------------------------------------
+# supply-chain/ presence
+# ---------------------------------------------------------------------
+scenario="supply-chain/ files exist"
+if [ -f supply-chain/config.toml ] \
+    && [ -f supply-chain/audits.toml ] \
+    && [ -f supply-chain/imports.lock ]; then
+    pass "$scenario"
+else
+    printf 'FAIL  %s: one of config.toml / audits.toml / imports.lock missing\n' "$scenario" >&2
+    fail_count=$((fail_count + 1))
+fi
+
+# ---------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
+if [ "$fail_count" -ne 0 ]; then
+    exit 1
+fi

--- a/scripts/vet-update.sh
+++ b/scripts/vet-update.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# scripts/vet-update.sh
+#
+# Contributor helper for the cargo-vet supply-chain audit gate.
+#
+# What it does, in order:
+#   1. Verifies the local cargo-vet binary matches the pin in
+#      .github/workflows/vet.yml (CARGO_VET_VERSION). CI is exact;
+#      there's no point running this with a different local
+#      version because the result will be non-deterministic.
+#   2. Runs `cargo vet regenerate imports` to refresh
+#      supply-chain/imports.lock from the three canonical feeds.
+#      This is the "pull in new audits" step — an audit that was
+#      not present when a contributor last ran this might now
+#      cover a previously-exempted crate, shrinking the diff.
+#   3. Runs `cargo vet check --locked --frozen` — the exact gate
+#      the CI workflow runs. Must pass before pushing.
+#   4. Runs xtask-vet-ttl to verify every exemption has a
+#      non-expired review-by token.
+#   5. Prints a diff summary so the contributor knows what
+#      supply-chain/ changes to commit.
+#
+# Usage (from the repo root):
+#   bash scripts/vet-update.sh
+#
+# Exit codes:
+#   0  everything clean, supply-chain/ may or may not have changed
+#   1  cargo-vet version mismatch, or a gate failed
+#
+# NOT for CI use. The workflow at .github/workflows/vet.yml runs
+# `cargo vet check` directly; this script is for human contributors
+# after editing Cargo.toml or touching supply-chain/.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+# Extract the pin from vet.yml. Single source of truth.
+workflow_file=".github/workflows/vet.yml"
+if [ ! -f "$workflow_file" ]; then
+    printf 'error: %s not found (run from repo root)\n' "$workflow_file" >&2
+    exit 1
+fi
+
+want_version="$(
+    grep -E '^\s*CARGO_VET_VERSION:\s*"[^"]+"' "$workflow_file" \
+        | head -n 1 \
+        | sed -E 's/.*"([^"]+)".*/\1/'
+)"
+if [ -z "${want_version:-}" ]; then
+    printf 'error: could not extract CARGO_VET_VERSION from %s\n' "$workflow_file" >&2
+    exit 1
+fi
+
+if ! command -v cargo-vet >/dev/null 2>&1; then
+    printf 'error: cargo-vet is not installed.\n  install with: cargo install cargo-vet --version %s --locked\n' "$want_version" >&2
+    exit 1
+fi
+
+got_version="$(cargo vet --version | awk '{print $2}')"
+if [ "$got_version" != "$want_version" ]; then
+    printf 'error: cargo-vet version mismatch.\n  want: %s (from %s)\n  got:  %s\n  bump with: cargo install cargo-vet --version %s --locked --force\n' \
+        "$want_version" "$workflow_file" "$got_version" "$want_version" >&2
+    exit 1
+fi
+
+printf '==> cargo vet regenerate imports\n'
+cargo vet regenerate imports
+
+printf '\n==> cargo vet check --locked --frozen\n'
+cargo vet check --locked --frozen
+
+printf '\n==> xtask-vet-ttl\n'
+cargo run -q -p xtask-vet-ttl
+
+printf '\n==> supply-chain/ diff vs HEAD\n'
+if git diff --quiet -- supply-chain/; then
+    printf '  (no changes)\n'
+else
+    git diff --stat -- supply-chain/
+    printf '\nReview the diff and commit:\n'
+    printf '  git add supply-chain/\n'
+    printf '  git commit -m "chore(supply-chain): refresh vet imports"\n'
+fi
+
+printf '\nAll gates PASS.\n'

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,0 +1,4 @@
+
+# cargo-vet audits file
+
+[audits]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,0 +1,325 @@
+
+# cargo-vet config file
+
+[cargo-vet]
+version = "0.10"
+
+[imports.bytecode-alliance]
+url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
+
+[imports.google]
+url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
+
+[imports.mozilla]
+url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
+
+[policy.mango]
+audit-as-crates-io = false
+criteria = "safe-to-deploy"
+
+[policy.mango-loom-demo]
+audit-as-crates-io = false
+criteria = "safe-to-deploy"
+
+[policy.mango-proto]
+audit-as-crates-io = false
+criteria = "safe-to-deploy"
+
+[policy.xtask-vet-ttl]
+audit-as-crates-io = false
+criteria = "safe-to-deploy"
+
+[[exemptions.aho-corasick]]
+version = "1.1.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — regex dep, BurntSushi, audit pending"
+
+[[exemptions.anyhow]]
+version = "1.0.102"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — error-handling, dtolnay, audit pending"
+
+[[exemptions.bytes]]
+version = "1.11.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tokio-rs, audit pending"
+
+[[exemptions.cc]]
+version = "1.2.60"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rust-lang/cc-rs, audit pending"
+
+[[exemptions.cfg-if]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rust-lang, audit pending"
+
+[[exemptions.errno]]
+version = "0.3.14"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rustix dep, lambda-fairy, audit pending"
+
+[[exemptions.fastrand]]
+version = "2.4.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — smol-rs, audit pending"
+
+[[exemptions.find-msvc-tools]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — cc dep, rust-lang, audit pending"
+
+[[exemptions.fixedbitset]]
+version = "0.5.7"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — petgraph dep, audit pending"
+
+[[exemptions.generator]]
+version = "0.8.8"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — loom dep, Xudong-Huang, audit pending"
+
+[[exemptions.getrandom]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rust-random, audit pending"
+
+[[exemptions.hashbrown]]
+version = "0.16.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rust-lang, audit pending"
+
+[[exemptions.itertools]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rust-itertools, audit pending"
+
+[[exemptions.itoa]]
+version = "1.0.18"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — dtolnay, audit pending"
+
+[[exemptions.libc]]
+version = "0.2.185"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rust-lang, audit pending"
+
+[[exemptions.linux-raw-sys]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rustix dep, sunfishcode, audit pending"
+
+[[exemptions.loom]]
+version = "0.7.2"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tokio-rs, exact-pinned for determinism"
+
+[[exemptions.memchr]]
+version = "2.8.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — BurntSushi, audit pending"
+
+[[exemptions.multimap]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — prost-build dep, havarnov, audit pending"
+
+[[exemptions.once_cell]]
+version = "1.21.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — matklad, audit pending"
+
+[[exemptions.petgraph]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — petgraph team, audit pending"
+
+[[exemptions.pin-project-lite]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — taiki-e, audit pending"
+
+[[exemptions.prettyplease]]
+version = "0.2.37"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — dtolnay, audit pending"
+
+[[exemptions.proc-macro2]]
+version = "1.0.106"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — dtolnay, audit pending"
+
+[[exemptions.prost]]
+version = "0.13.5"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tokio-rs prost, audit pending"
+
+[[exemptions.prost-build]]
+version = "0.13.5"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tokio-rs prost, audit pending"
+
+[[exemptions.prost-derive]]
+version = "0.13.5"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tokio-rs prost, audit pending"
+
+[[exemptions.prost-types]]
+version = "0.13.5"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tokio-rs prost, audit pending"
+
+[[exemptions.quote]]
+version = "1.0.45"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — dtolnay, audit pending"
+
+[[exemptions.r-efi]]
+version = "5.3.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — getrandom transitive, r-efi maintainers, audit pending"
+
+[[exemptions.regex]]
+version = "1.12.3"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rust-lang, audit pending"
+
+[[exemptions.regex-automata]]
+version = "0.4.14"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — BurntSushi, audit pending"
+
+[[exemptions.regex-syntax]]
+version = "0.8.10"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — rust-lang, audit pending"
+
+[[exemptions.rustix]]
+version = "1.1.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — bytecodealliance, audit pending"
+
+[[exemptions.rustversion]]
+version = "1.0.22"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — dtolnay, audit pending"
+
+[[exemptions.scoped-tls]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — alexcrichton, audit pending"
+
+[[exemptions.serde]]
+version = "1.0.228"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — serde-rs/dtolnay, audit pending"
+
+[[exemptions.serde_core]]
+version = "1.0.228"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — serde-rs/dtolnay, audit pending"
+
+[[exemptions.serde_derive]]
+version = "1.0.228"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — serde-rs/dtolnay, audit pending"
+
+[[exemptions.serde_spanned]]
+version = "0.6.9"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — toml dep, toml-rs team, audit pending"
+
+[[exemptions.syn]]
+version = "2.0.117"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — dtolnay, audit pending"
+
+[[exemptions.tempfile]]
+version = "3.27.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — Stebalien, audit pending"
+
+[[exemptions.thread_local]]
+version = "1.1.9"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — Amanieu, audit pending"
+
+[[exemptions.time]]
+version = "0.3.41"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — jhpratt, audit pending"
+
+[[exemptions.toml]]
+version = "0.8.23"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — toml-rs team, audit pending"
+
+[[exemptions.toml_datetime]]
+version = "0.6.11"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — toml-rs team, audit pending"
+
+[[exemptions.toml_edit]]
+version = "0.22.27"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — toml-rs team, audit pending"
+
+[[exemptions.toml_write]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — toml-rs team, audit pending"
+
+[[exemptions.tonic-build]]
+version = "0.12.3"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — hyperium, audit pending"
+
+[[exemptions.tracing]]
+version = "0.1.44"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tokio-rs tracing, audit pending"
+
+[[exemptions.tracing-core]]
+version = "0.1.36"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tokio-rs tracing, audit pending"
+
+[[exemptions.tracing-subscriber]]
+version = "0.3.23"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tokio-rs tracing, audit pending"
+
+[[exemptions.unicode-ident]]
+version = "1.0.24"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — dtolnay, audit pending"
+
+[[exemptions.valuable]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — tracing dep, rust-lang, audit pending"
+
+[[exemptions.windows-link]]
+version = "0.1.3"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — microsoft/windows-rs, audit pending"
+
+[[exemptions.windows-link]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — microsoft/windows-rs, audit pending"
+
+[[exemptions.windows-result]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — microsoft/windows-rs, audit pending"
+
+[[exemptions.windows-sys]]
+version = "0.61.2"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — microsoft/windows-rs, audit pending"
+
+[[exemptions.winnow]]
+version = "0.7.15"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — toml-rs team / epage, audit pending"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,0 +1,450 @@
+
+# cargo-vet imports lock
+
+[[publisher.wasip2]]
+version = "1.0.3+wasi-0.2.9"
+when = "2026-04-17"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen]]
+version = "0.57.1"
+when = "2026-04-17"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[audits.bytecode-alliance.wildcard-audits.wasip2]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2025-08-10"
+end = "2026-08-21"
+notes = """
+This is a Bytecode Alliance authored crate.
+"""
+
+[[audits.bytecode-alliance.wildcard-audits.wit-bindgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+start = "2025-08-13"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.bytecode-alliance.audits.bitflags]]
+who = "Jamey Sharp <jsharp@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.2.1"
+notes = """
+This version adds unsafe impls of traits from the bytemuck crate when built
+with that library enabled, but I believe the impls satisfy the documented
+safety requirements for bytemuck. The other changes are minor.
+"""
+
+[[audits.bytecode-alliance.audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.2 -> 2.3.3"
+notes = """
+Nothing outside the realm of what one would expect from a bitflags generator,
+all as expected.
+"""
+
+[[audits.bytecode-alliance.audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.1 -> 2.6.0"
+notes = """
+Changes in how macros are invoked and various bits and pieces of macro-fu.
+Otherwise no major changes and nothing dealing with `unsafe`.
+"""
+
+[[audits.bytecode-alliance.audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.7.0 -> 2.9.4"
+notes = "Tweaks to the macro, nothing out of order."
+
+[[audits.bytecode-alliance.audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.10.0 -> 2.11.1"
+notes = "Minor updates, nothing awry here."
+
+[[audits.bytecode-alliance.audits.heck]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.5.0"
+notes = "Minor changes for a `no_std` upgrade but otherwise everything looks as expected."
+
+[[audits.bytecode-alliance.audits.matchers]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.bytecode-alliance.audits.matchers]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Some unsafe code, but not more than before. Nothing awry."
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.46.0"
+notes = "one use of unsafe to call windows specific api to get console handle."
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.46.0 -> 0.50.1"
+notes = "Lots of stylistic/rust-related changes, plus new features, but nothing out of the ordrinary."
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.50.1 -> 0.50.3"
+notes = "CI changes, Rust changes, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.sharded-slab]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.4"
+notes = "I always really enjoy reading eliza's code, she left perfect comments at every use of unsafe."
+
+[[audits.bytecode-alliance.audits.shlex]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "Only minor `unsafe` code blocks which look valid and otherwise does what it says on the tin."
+
+[[audits.bytecode-alliance.audits.smallvec]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.13.2 -> 1.14.0"
+notes = "Minor new feature, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.tracing-log]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = """
+This is a standard adapter between the `log` ecosystem and the `tracing`
+ecosystem. There's one `unsafe` block in this crate and it's well-scoped.
+"""
+
+[[audits.bytecode-alliance.audits.tracing-log]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.2.0"
+notes = "Nothing out of the ordinary, a typical major version update and nothing awry."
+
+[[audits.google.audits.bitflags]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.3.2"
+notes = """
+Security review of earlier versions of the crate can be found at
+(Google-internal, sorry): go/image-crate-chromium-security-review
+
+The crate exposes a function marked as `unsafe`, but doesn't use any
+`unsafe` blocks (except for tests of the single `unsafe` function).  I
+think this justifies marking this crate as `ub-risk-1`.
+
+Additional review comments can be found at https://crrev.com/c/4723145/31
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.either]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.13.0"
+notes = "Unsafe code pertaining to wrapping Pin APIs. Mostly passes invariants down."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.either]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.13.0 -> 1.14.0"
+notes = """
+Inheriting ub-risk-1 from the baseline review of 1.13.0. While the delta has some diffs in unsafe code, they are either:
+- migrating code to use helper macros
+- migrating match patterns to take advantage of default bindings mode from RFC 2005
+Either way, the result is code that does exactly the same thing and does not change the risk of UB.
+
+See https://crrev.com/c/6323164 for more audit details.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.either]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.14.0 -> 1.15.0"
+notes = 'The delta in `lib.rs` only tweaks doc comments and `#[cfg(feature = "std")]`.'
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.equivalent]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.equivalent]]
+who = "Jonathan Hao <phao@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.1 -> 1.0.2"
+notes = "No changes to any .rs files or Rust code."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.heck]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
+notes = """
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'``, `'\bnet\b'``, `'\bunsafe\b'``
+and there were no hits.
+
+`heck` (version `0.3.3`) has been added to Chromium in
+https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24c97e7a8f4057
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "2.7.1"
+notes = '''
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`
+and there were no hits.
+
+There is a little bit of `unsafe` Rust code - the audit can be found at
+https://chromium-review.googlesource.com/c/chromium/src/+/6187726/2
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.7.1 -> 2.8.0"
+notes = """
+No `unsafe` introduced or affected in:
+* `indexmap_with_default!` and `indexset_with_default!` macros
+* New `PartialEq` implementations
+* `fn slice_eq` in `util.rs`
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.lazy_static]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.4.0"
+notes = '''
+I grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits.
+
+There are two places where `unsafe` is used.  Unsafe review notes can be found
+in https://crrev.com/c/5347418.
+
+This crate has been added to Chromium in https://crrev.com/c/3321895.
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.lazy_static]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.4.0 -> 1.5.0"
+notes = "Unsafe review notes: https://crrev.com/c/5650836"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.22"
+notes = """
+Unsafe review in https://docs.google.com/document/d/1IXQbD1GhTRqNHIGxq6yy7qHqxeO4CwN5noMFXnqyDIM/edit?usp=sharing
+
+Unsafety is generally very well-documented, with one exception, which we
+describe in the review doc.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.22 -> 0.4.25"
+notes = "No impact on `unsafe` usage in `lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.25 -> 0.4.26"
+notes = "Only trivial code and documentation changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.smallvec]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.13.2"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.3.2 -> 2.0.2"
+notes = "Removal of some unsafe code/methods. No changes to externals, just some refactoring (mostly internal)."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.2 -> 2.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.1 -> 2.3.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "2.3.3 -> 2.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.0 -> 2.4.1"
+notes = "Only allowing new clippy lints"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = [
+    "Teodor Tanasoaia <ttanasoaia@mozilla.com>",
+    "Erich Gubler <erichdongubler@gmail.com>",
+]
+criteria = "safe-to-deploy"
+delta = "2.6.0 -> 2.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.9.4 -> 2.10.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.deranged]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.11"
+notes = """
+This crate contains a decent bit of `unsafe` code, however all internal
+unsafety is verified with copious assertions (many are compile-time), and
+otherwise the unsafety is documented and left to the caller to verify.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.deranged]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.11 -> 0.4.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.indexmap]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.8.0 -> 2.11.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.26 -> 0.4.29"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+Very straightforward, simple crate. No dependencies, unsafe, extern,
+side-effectful std functions, etc.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.powerfmt]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = """
+A tiny bit of unsafe code to implement functionality that isn't in stable rust
+yet, but it's all valid. Otherwise it's a pretty simple crate.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.sharded-slab]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.7"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.shlex]]
+who = "Max Inden <mail@max-inden.de>"
+criteria = "safe-to-deploy"
+delta = "1.1.0 -> 1.3.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.smallvec]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.14.0 -> 1.15.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-macros]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-macros]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.6 -> 0.2.10"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-macros]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.10 -> 0.2.18"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-macros]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.18 -> 0.2.22"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"


### PR DESCRIPTION
## Summary

Ships item **0.7-vet** from `ROADMAP.md:798` — a `cargo-vet`
supply-chain audit gate on top of the existing `cargo-deny` +
`cargo-audit` stack. Every transitive dependency must now have
either a first-party audit, a hit in an imported audit set
(mozilla / google / bytecode-alliance), or a TTL'd exemption.
Missing audits fail CI.

### Four-commit topology

| # | Commit | What |
|---|---|---|
| A | `9a4e20f` | `crates/xtask-vet-ttl` — TTL binary for `[exemptions]` (`review-by:` token parser). 16 unit tests. |
| B | `b9a9e58` | `supply-chain/config.toml` + `imports.lock` + `audits.toml`. 3 imports, 4 policy blocks, 59 exemptions. |
| C | `75a63a7` | `.github/workflows/vet.yml` + `scripts/vet-update.sh` + `scripts/vet-scripts-test.sh` (8 harness scenarios). |
| D | `a462d4b` | `docs/supply-chain-policy.md` + CONTRIBUTING.md edits. |

### Design highlights

- **Hybrid TTL story.** cargo-vet natively supports `end:` dates
  on `[[trusted]]` / `[[wildcard-audits]]` (covered by
  `cargo vet check`). It does NOT support `end:` on
  `[[exemptions]]` — the long tail of our graph. The
  `xtask-vet-ttl` crate fills that gap: parses
  `notes = "review-by: YYYY-MM-DD …"` from each exemption and
  fails CI on a past date.
- **Rust, not shell.** Date arithmetic + TOML parsing is hairy to
  do portably in bash (macOS `date -j` vs GNU `date -d`, bash 3.2,
  awk drift). The project's thesis is from-scratch production
  Rust; the tooling follows suit.
- **Import URLs verified against the canonical registry**
  (`https://raw.githubusercontent.com/mozilla/cargo-vet/main/registry.toml`,
  2026-04-23). Imports stripped ~20 auto-exemptions from the
  initial `cargo vet init` output.
- **Exact CI pin** (`CARGO_VET_VERSION = "0.10.2"`) — different vet
  versions can accept/reject the same audit graph differently.
  Binary cached on the runner keyed on `(version, os, arch)`.
- **Workflow security hardening** — every `github.event.*` value
  flows through step-level `env:`; never interpolated into `run:`.
  Matches the ct-comparison / geiger / miri precedent.
- **No `cargo vet renew --expiring --dry-run` step**: vet 0.10.x
  has no `--dry-run` flag on `renew`, and there are zero
  `[[trusted]]` entries today. If one lands, `cargo vet check`
  itself fails on expired `end:` dates.

### Evidence

```
$ bash scripts/vet-scripts-test.sh
PASS  happy (future review-by -> exit 0)
PASS  expired (past review-by -> exit 1)
PASS  malformed date (bad month -> exit 2)
PASS  missing review-by + --strict -> exit 1
PASS  missing review-by no-strict -> exit 0 (advisory)
PASS  --list (expired entries -> exit 0)
PASS  vet-update.sh: CARGO_VET_VERSION is parseable
PASS  supply-chain/ files exist
8 passed, 0 failed

$ cargo vet check --locked --frozen
Vetting Succeeded (20 fully audited, 59 exempted)

$ cargo run -q -p xtask-vet-ttl
xtask-vet-ttl: PASS
  today = 2026-04-23; exemption TTLs OK (59 with review-by, 0 without)

$ cargo test -p xtask-vet-ttl
test result: ok. 16 passed; 0 failed; 0 ignored

$ bash scripts/verify-contributing-refs.sh
verify-contributing-refs.sh: all checks passed
```

## Test plan

- [x] `cargo test -p xtask-vet-ttl` — 16 unit tests cover the
      TOML shape + date-parser edge cases
- [x] `bash scripts/vet-scripts-test.sh` — 8 CLI-level smoke
      scenarios (happy / expired / malformed / missing /
      --strict / --list / version-regex / file-existence)
- [x] `cargo vet check --locked --frozen` — green locally against
      the committed `supply-chain/` state
- [x] `cargo run -q -p xtask-vet-ttl` — all 59 exemption TTLs
      future-dated (2026-10-23, 6 months out)
- [x] `bash scripts/vet-update.sh` — contributor wrapper
      end-to-end (extracts pin, regenerates imports, runs both
      gates)
- [x] `bash scripts/verify-contributing-refs.sh` — CONTRIBUTING.md
      link / anchor integrity after edits
- [x] `cargo check --workspace` — workspace builds with the new
      crate
- [x] `cargo clippy -p xtask-vet-ttl --all-targets -- -D warnings` —
      clean
- [x] Workflow security hardened — no direct `github.event.*`
      interpolation into `run:`

Refs `ROADMAP.md:798` (item 0.7-vet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
