### PR TITLE
chore(semver): cargo-semver-checks advisory CI gate (0.5-semver)

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,139 @@
+# Mango cargo-semver-checks CI gate.
+#
+# Catches semver violations the API surface alone misses — e.g.,
+# tightening a trait bound, removing a #[derive(Clone)], adding a
+# required generic parameter. Complements cargo-public-api (future
+# ROADMAP:802); neither fully replaces the other.
+#
+# Mode: ADVISORY pre-Phase-6. The check runs, surfaces its findings,
+# but does not block merge. Flip to gating when Phase 6 opens
+# (first PR that introduces a stable public API on a `crates/mango-*`
+# crate). The flip procedure is in docs/semver-policy.md.
+#
+# Version pin: CARGO_SEMVER_CHECKS_VERSION below is the single source
+# of truth. Different tool versions can flag / miss different things;
+# the pin is exact. Bump procedure in docs/semver-policy.md.
+#
+# Security: every github event value flows through step-level env
+# and is read as a shell variable — never interpolated into run
+# blocks directly. Matches the vet.yml / geiger.yml precedent.
+
+name: semver-checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "crates/**/src/**"
+      - "crates/**/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/semver-checks.yml"
+      - "scripts/semver-scripts-test.sh"
+      - "docs/semver-policy.md"
+  # merge_group does not honour paths filters — GitHub Actions
+  # always dispatches merge-queue events. That's the correct
+  # behaviour for us (merge-queue is the last line of defense) and
+  # matches the vet.yml precedent.
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_SEMVER_CHECKS_VERSION: "0.47.0"
+
+jobs:
+  semver-checks:
+    name: cargo-semver-checks (advisory)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # baseline-rev <sha> needs the commit present locally;
+          # actions/checkout@v4 defaults to depth 1.
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        # cargo-semver-checks invokes cargo rustdoc, which needs a
+        # functioning toolchain. Unlike cargo-vet (prebuilt binary),
+        # this gate cannot skip toolchain setup.
+
+      - name: cache cargo-semver-checks binary
+        id: cache-semver-checks
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: ~/.cargo/bin/cargo-semver-checks
+          key: cargo-semver-checks-${{ env.CARGO_SEMVER_CHECKS_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: install cargo-semver-checks
+        if: steps.cache-semver-checks.outputs.cache-hit != 'true'
+        env:
+          CARGO_SEMVER_CHECKS_VERSION: ${{ env.CARGO_SEMVER_CHECKS_VERSION }}
+        run: |
+          set -euo pipefail
+          cargo install cargo-semver-checks --version "${CARGO_SEMVER_CHECKS_VERSION}" --locked
+
+      - name: semver-checks version sanity
+        env:
+          CARGO_SEMVER_CHECKS_VERSION: ${{ env.CARGO_SEMVER_CHECKS_VERSION }}
+        run: |
+          set -euo pipefail
+          got="$(cargo semver-checks --version | awk '{print $2}')"
+          if [ "$got" != "${CARGO_SEMVER_CHECKS_VERSION}" ]; then
+              echo "error: cargo-semver-checks version mismatch (want ${CARGO_SEMVER_CHECKS_VERSION}, got ${got})" >&2
+              exit 1
+          fi
+
+      - name: semver-checks scripts self-test
+        run: bash scripts/semver-scripts-test.sh
+
+      - name: resolve baseline sha
+        id: base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          set -euo pipefail
+          # Prefer the GitHub-provided base SHA (attacker-uncontrollable,
+          # set by the maintainer's base-branch choice for PRs, or by
+          # the merge queue for merge_group). Fall back to
+          # git merge-base HEAD origin/main for workflow_dispatch,
+          # which has no base-sha event field.
+          if [ -n "${PR_BASE_SHA:-}" ]; then
+              base="${PR_BASE_SHA}"
+          elif [ -n "${MERGE_GROUP_BASE_SHA:-}" ]; then
+              base="${MERGE_GROUP_BASE_SHA}"
+          else
+              base="$(git merge-base HEAD origin/main)"
+          fi
+          echo "sha=${base}" >> "$GITHUB_OUTPUT"
+          echo "baseline sha: ${base}"
+
+      # SEMVER-CHECKS-MODE: advisory
+      # Single-line sentinel above. scripts/semver-scripts-test.sh
+      # asserts this sentinel stays in sync with the
+      # continue-on-error flag on the next step. When Phase 6 opens,
+      # flip BOTH together (sentinel -> gating, continue-on-error
+      # -> false). See docs/semver-policy.md.
+      - name: cargo semver-checks
+        id: semver-check
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          set -euo pipefail
+          cargo semver-checks --workspace --baseline-rev "${BASE_SHA}"
+
+      - name: surface advisory failure as warning
+        if: steps.semver-check.outcome == 'failure'
+        run: |
+          echo "::warning title=semver-checks advisory::cargo-semver-checks reported violations. See job log above and docs/semver-policy.md."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,6 +268,13 @@ with worked examples: [`docs/arithmetic-policy.md`][arith].
   SHA-pinned. Full policy:
   [`docs/supply-chain-policy.md`](./docs/supply-chain-policy.md).
   Future additions: SBOM via `cargo-cyclonedx`.
+- **Semver compatibility.** `cargo-semver-checks` runs on every PR
+  that touches `crates/**/src/**`, `crates/**/Cargo.toml`, the root
+  `Cargo.toml`, or `Cargo.lock`. **Advisory** today — a violation
+  produces a visible `::warning::` annotation but does not block
+  merge. **Gating from Phase 6** (first stable public API). Full
+  policy, including the advisory→gating flip procedure:
+  [`docs/semver-policy.md`](./docs/semver-policy.md).
 - **MSRV.** Workspace MSRV is **1.80** (see
   `rust-version` in [`Cargo.toml`](./Cargo.toml) and the `msrv`
   CI job). MSRV bumps are deliberate, land in their own PR, and
@@ -383,6 +390,18 @@ cargo vet check --locked --frozen                   # audit-graph gate only
 cargo run -q -p xtask-vet-ttl                       # exemption review-by TTL gate only
 cargo run -q -p xtask-vet-ttl -- --list             # diagnostic listing of all tokens
 bash scripts/vet-scripts-test.sh                    # 8 harness scenarios
+```
+
+Run the cargo-semver-checks gate locally before opening a PR that
+touches a crate's public surface — same gate CI runs. `git fetch`
+first so the baseline isn't stale. Full policy in
+[`docs/semver-policy.md`](./docs/semver-policy.md):
+
+```bash
+cargo install cargo-semver-checks --version 0.47.0 --locked  # once; match semver-checks.yml
+git fetch origin main                                        # refresh baseline
+cargo semver-checks --workspace --baseline-rev origin/main   # the gate
+bash scripts/semver-scripts-test.sh                          # workflow self-test
 ```
 
 Notes:

--- a/docs/semver-policy.md
+++ b/docs/semver-policy.md
@@ -1,0 +1,228 @@
+# Semver compatibility policy
+
+Mango commits to semantic versioning on every `pub` item in every
+published `crates/mango-*` crate. Today no crate is published; when
+Phase 6 opens (first stable public API), the rules here become
+merge-blocking.
+
+The machinery behind this policy:
+
+- **`cargo-semver-checks`** — this doc's subject. Runs in
+  [`.github/workflows/semver-checks.yml`](../.github/workflows/semver-checks.yml)
+  on every PR that touches a crate's source or manifest.
+- **`cargo-public-api`** (future, ROADMAP:802) — complementary
+  surface-level diff tool. Not shipped yet.
+
+`cargo-semver-checks` catches violations the public-API surface alone
+doesn't reveal: tightening a trait bound, removing a
+`#[derive(Clone)]`, adding a required generic parameter, flipping
+`#[non_exhaustive]`. It compiles `cargo rustdoc` JSON for both the
+working tree and a git baseline, and runs a library of lints over the
+delta.
+
+## Mode: advisory (pre-Phase-6), gating (Phase 6+)
+
+The gate is **advisory today**. A semver violation in a PR:
+
+- Shows up as a `::warning::` annotation in the PR's **Files** view
+  (not buried in the Actions log), and
+- Does **not** block merge.
+
+Phase 6 flips both: the annotation becomes a hard failure, and
+merge is blocked until the PR either fixes the violation or
+documents it as an intentional break with a major version bump.
+
+Why run advisory-now instead of waiting for Phase 6:
+
+1. **Exercise the machinery before it's load-bearing.** Contributors
+   hitting the gate for the first time on a Phase-6 PR have a worse
+   experience if the gate has never run before.
+2. **Signal is still useful today.** A refactor that accidentally
+   makes a placeholder type non-`Clone` is worth flagging even when
+   the type isn't published yet — it's exactly the kind of
+   regression that's easy to introduce silently and painful to fix
+   after a `1.0`.
+3. **Install + cache + pin is the same work.** Flipping to blocking
+   is a single-digit-line PR (see §"Flipping to blocking" below).
+
+## What the gate runs
+
+On every PR that touches `crates/**/src/**`, `crates/**/Cargo.toml`,
+`Cargo.toml` (workspace root), `Cargo.lock`, the workflow itself,
+the harness script, or this policy doc, the workflow:
+
+1. Installs the pinned `cargo-semver-checks` binary (version in
+   `CARGO_SEMVER_CHECKS_VERSION`, cached by `(version, os, arch)`).
+2. Runs `scripts/semver-scripts-test.sh` — a structural self-test of
+   the workflow file itself (see §"Harness").
+3. Resolves a baseline SHA from the event (PR base / merge_group
+   base / workflow_dispatch fallback to `git merge-base HEAD
+origin/main`).
+4. Runs `cargo semver-checks --workspace --baseline-rev <base>`.
+5. If the check reports violations, emits a loud `::warning::`
+   annotation pointing to this doc.
+
+The `merge_group` trigger has no `paths:` filter — GitHub Actions
+doesn't support one on merge-queue events. That's intentional
+(merge-queue is the last line of defense).
+
+The `Cargo.toml` (root) filter catches both `[workspace.dependencies]`
+bumps (which CAN flip re-exported public surface) and
+`[workspace.lints]` tweaks (which cannot). We accept the
+false-positive on lint-only PRs — the check is advisory today and
+cheap.
+
+## Responding to a warning
+
+If `cargo-semver-checks` flags a violation on your PR:
+
+1. **Read the tool output.** Each lint includes a specific reason
+   and a link to its reference page.
+2. **Decide whether the break is intentional.**
+   - **Unintentional** (common): a refactor slipped; fix the code.
+     For example, if a type lost a `Clone` impl because an inner
+     field stopped being `Clone`, either add `Clone` back to the
+     field or make the outer type `Clone` via an explicit impl.
+   - **Intentional** (rare, Phase 6+): the change is a deliberate
+     breaking change that warrants a major-version bump. Document
+     the rationale in the PR description. Pre-Phase-6, there's no
+     `semver_exemptions` table yet; just proceed — the gate is
+     advisory. When the table lands in Phase 6, intentional breaks
+     will be listed there.
+3. **Push a fix** (if unintentional) and the annotation goes away.
+
+## Running locally
+
+```bash
+git fetch origin main
+cargo install --locked cargo-semver-checks --version <pin>
+cargo semver-checks --workspace --baseline-rev origin/main
+```
+
+The `git fetch` is load-bearing — a stale local `origin/main`
+produces spurious deltas. Use the pin from
+[`.github/workflows/semver-checks.yml`](../.github/workflows/semver-checks.yml)
+(the `CARGO_SEMVER_CHECKS_VERSION` env var).
+
+**Toolchain channel**: `cargo-semver-checks` uses `cargo rustdoc`,
+which emits an unstable JSON format. The tool is pinned to a specific
+format version, and CI runs on **stable**. Running locally on
+**nightly** may produce different results; CI is authoritative.
+
+## Bumping the pin
+
+1. Update `CARGO_SEMVER_CHECKS_VERSION` in
+   [`.github/workflows/semver-checks.yml`](../.github/workflows/semver-checks.yml).
+2. Locally:
+   ```bash
+   cargo install --locked cargo-semver-checks --version <new> --force
+   cargo semver-checks --workspace --baseline-rev origin/main
+   bash scripts/semver-scripts-test.sh
+   ```
+3. Open a PR. rust-expert reviews per the normal workflow — new
+   lint rules can surface legitimate regressions on the same PR that
+   bumps the pin, which is fine (fix them or open a follow-up).
+
+## Flipping to blocking (Phase 6 procedure)
+
+When the first `crates/mango-*` crate gains a stable public API
+(Phase 6), flip the gate in a dedicated PR:
+
+1. In [`.github/workflows/semver-checks.yml`](../.github/workflows/semver-checks.yml):
+   - Change the sentinel comment from
+     `# SEMVER-CHECKS-MODE: advisory`
+     to
+     `# SEMVER-CHECKS-MODE: gating`.
+   - Change `continue-on-error: true` to `continue-on-error: false`
+     on the same step.
+2. Update this doc's first section to read "gating" throughout.
+3. If breaking changes are ever intentional, add a
+   `[workspace.metadata.mango.semver_exemptions]` table to the
+   workspace `Cargo.toml` with a documented entry per break. The
+   harness will need a corresponding check. Design that when we get
+   there, not now.
+
+The harness asserts the sentinel and the `continue-on-error` flag
+stay in sync. Flipping one without the other fails CI — this is the
+guard against "sentinel says gating but gate still doesn't block"
+drift.
+
+## Verifying the gate works
+
+To confirm the workflow is wired up correctly end-to-end (do this
+once after shipping, and after any pin bump):
+
+1. On a scratch branch, introduce a deliberate breaking change to
+   `crates/mango/src/lib.rs` — e.g., remove `#[derive(Clone)]` from
+   a public type, or tighten a trait bound.
+2. Open a PR against `main` and wait for the `semver-checks`
+   workflow to complete.
+3. Confirm the PR's **Files** view shows the `::warning::`
+   annotation (pre-Phase-6) or a red X on the check (Phase 6+).
+4. **Close the scratch PR without merging. Delete the branch.** Do
+   NOT squash-merge — the entire point is to avoid landing a break.
+
+## Known caveats
+
+- **Workspace strict lints**: `unsafe_code = "forbid"`,
+  `arithmetic_side_effects = deny`, and similar
+  workspace-deny lints apply when the tool rustdoc-compiles a
+  _baseline_ commit. If a lint rejects code that passed `cargo
+check` at the time the baseline commit was made (possible after a
+  lint tightening), the baseline compile fails — producing a
+  failure unrelated to semver. The tool mitigates this by passing
+  `--cap-lints=warn` via rustdoc by default on recent versions. If
+  you hit a lint failure on the baseline specifically, add
+  `RUSTFLAGS="--cap-lints=warn"` to the `cargo semver-checks` step
+  env as a last resort.
+- **`publish = false` members are skipped** automatically by
+  `--workspace`. Today that's `mango-proto`, `mango-loom-demo`, and
+  `xtask-vet-ttl`. Verified on `cargo-semver-checks 0.47.0`.
+- **Nothing is published**, so `--baseline-registry` is unusable;
+  we rely exclusively on `--baseline-rev <sha>`.
+- **Baseline build cost** compounds as the workspace grows. Today
+  it's one placeholder crate; once Phase 1–6 land real crates, the
+  gate will rustdoc-compile every publishable member for the
+  baseline tree on every PR. If CI wall-clock becomes a problem,
+  cache rustdoc JSON via `--baseline-rustdoc` and an `actions/cache`
+  keyed on the baseline SHA. On deck, not implemented.
+
+## Harness
+
+[`scripts/semver-scripts-test.sh`](../scripts/semver-scripts-test.sh)
+is the self-test for the workflow file. It asserts:
+
+- Workflow file exists.
+- `CARGO_SEMVER_CHECKS_VERSION` is declared as `x.y.z`.
+- Checkout step sets `fetch-depth: 0`.
+- `SEMVER-CHECKS-MODE` sentinel is present and consistent with
+  `continue-on-error`.
+- The `::warning::` annotation step exists.
+- Required path filters are present.
+- The deprecated `check-release` subcommand is NOT in use.
+- This policy doc exists (so the workflow's links aren't broken).
+
+It runs as a step in the workflow and can be run locally:
+
+```bash
+bash scripts/semver-scripts-test.sh
+```
+
+## File inventory
+
+| File                                  | Role               | Hand-edited? |
+| ------------------------------------- | ------------------ | ------------ |
+| `.github/workflows/semver-checks.yml` | CI gate            | yes          |
+| `scripts/semver-scripts-test.sh`      | workflow self-test | yes          |
+| `docs/semver-policy.md`               | this doc           | yes          |
+
+## Relationship to `cargo-public-api`
+
+`cargo-public-api` (future ROADMAP:802) prints a human-readable diff
+of a crate's public surface. It's great for PR-review triage but is
+syntactic — it doesn't reason about trait-bound tightening or
+semver implications. `cargo-semver-checks` is the tool that actually
+**judges** whether a diff is a semver violation.
+
+Both ship as advisory-now, gating-at-Phase-6. They're complementary,
+not redundant.

--- a/scripts/semver-scripts-test.sh
+++ b/scripts/semver-scripts-test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# scripts/semver-scripts-test.sh
+#
+# Smoke-test harness for the cargo-semver-checks CI gate.
+#
+# What this covers:
+#   - .github/workflows/semver-checks.yml exists and has the
+#     structural invariants the CI gate depends on (version pin
+#     format, fetch-depth, sentinel + continue-on-error consistency,
+#     loud-warning step, path filters).
+#   - docs/semver-policy.md exists (workflow comments link to it;
+#     broken links turn a runtime failure into a tooling-trust
+#     failure).
+#
+# What this does NOT cover:
+#   - Running `cargo semver-checks` itself. That runs as a dedicated
+#     workflow step after this harness — duplicating it here only
+#     doubles CI wall-clock.
+#   - The tool's own lint logic. cargo-semver-checks has its own
+#     extensive test suite upstream; we gain nothing by reimplementing.
+#
+# Invocation:
+#   bash scripts/semver-scripts-test.sh
+#   (run from any CWD; script cd's to repo root)
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+pass_count=0
+fail_count=0
+
+pass() {
+    printf 'PASS  %s\n' "$1"
+    pass_count=$((pass_count + 1))
+}
+
+fail() {
+    printf 'FAIL  %s\n' "$1" >&2
+    fail_count=$((fail_count + 1))
+}
+
+workflow=".github/workflows/semver-checks.yml"
+policy_doc="docs/semver-policy.md"
+
+# ---------------------------------------------------------------------
+# workflow presence
+# ---------------------------------------------------------------------
+scenario="workflow file exists"
+if [ -f "$workflow" ]; then
+    pass "$scenario"
+else
+    fail "$scenario: $workflow missing"
+    printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------
+# version pin parseability
+# ---------------------------------------------------------------------
+# The install step reads this env var verbatim. If the regex drifts,
+# contributors would install a version different from the pin, and
+# the `semver-checks version sanity` step in the workflow would catch
+# it — but this harness fails FIRST, at commit time, with a clearer
+# message.
+scenario="CARGO_SEMVER_CHECKS_VERSION is parseable as x.y.z"
+if grep -qE '^\s*CARGO_SEMVER_CHECKS_VERSION:\s*"[0-9]+\.[0-9]+\.[0-9]+"' "$workflow"; then
+    pass "$scenario"
+else
+    fail "$scenario: CARGO_SEMVER_CHECKS_VERSION line not found or malformed in $workflow"
+fi
+
+# ---------------------------------------------------------------------
+# fetch-depth on checkout
+# ---------------------------------------------------------------------
+# --baseline-rev <sha> needs the commit locally. actions/checkout
+# defaults to depth 1. Missing fetch-depth: 0 produces runtime
+# failures that look unrelated to the gate.
+scenario="checkout step sets fetch-depth: 0"
+if grep -qE '^\s*fetch-depth:\s*0\s*$' "$workflow"; then
+    pass "$scenario"
+else
+    fail "$scenario: fetch-depth: 0 not found in $workflow"
+fi
+
+# ---------------------------------------------------------------------
+# advisory/gating sentinel + continue-on-error consistency
+# ---------------------------------------------------------------------
+# Single-line sentinel `# SEMVER-CHECKS-MODE: <mode>` sits above the
+# check step. Phase 6 flip must update BOTH the sentinel AND the
+# continue-on-error flag, so this harness asserts they're in sync.
+# If the sentinel says `advisory`, continue-on-error must be true.
+# If it says `gating`, continue-on-error must be false.
+
+# Normalize whitespace via tr -s so reflows / rebases don't break us.
+normalized="$(tr -s ' \t' ' ' < "$workflow")"
+
+mode_line="$(printf '%s\n' "$normalized" | grep -E '# SEMVER-CHECKS-MODE: (advisory|gating)' | head -n 1 || true)"
+scenario="SEMVER-CHECKS-MODE sentinel is present"
+if [ -n "$mode_line" ]; then
+    pass "$scenario"
+
+    mode="$(printf '%s' "$mode_line" | sed -E 's/.*SEMVER-CHECKS-MODE: ([a-z]+).*/\1/')"
+
+    # Find the continue-on-error line that follows the sentinel
+    # within the same step.
+    coe_line="$(printf '%s\n' "$normalized" | grep -E '^ *continue-on-error: (true|false)' | head -n 1 || true)"
+    scenario="continue-on-error matches sentinel (mode=$mode)"
+    if [ -z "$coe_line" ]; then
+        fail "$scenario: no continue-on-error line found"
+    elif [ "$mode" = "advisory" ] && printf '%s' "$coe_line" | grep -q 'true'; then
+        pass "$scenario"
+    elif [ "$mode" = "gating" ] && printf '%s' "$coe_line" | grep -q 'false'; then
+        pass "$scenario"
+    else
+        fail "$scenario: mode=$mode but continue-on-error line was: $coe_line"
+    fi
+else
+    fail "$scenario: '# SEMVER-CHECKS-MODE: advisory|gating' not found in $workflow"
+fi
+
+# ---------------------------------------------------------------------
+# loud-warning step: advisory mode without a visible signal is worse
+# than no gate (classic "nobody reads the warnings" failure mode).
+# The workflow must emit a ::warning:: annotation when the check fails.
+# ---------------------------------------------------------------------
+scenario="advisory failure is surfaced as ::warning:: annotation"
+if grep -qF '::warning title=semver-checks advisory::' "$workflow"; then
+    pass "$scenario"
+else
+    fail "$scenario: no ::warning title=semver-checks advisory:: line in $workflow"
+fi
+
+# ---------------------------------------------------------------------
+# path filters: the load-bearing paths must be present on pull_request.
+# Missing any of these means PRs that should trigger the gate would
+# silently skip it.
+# ---------------------------------------------------------------------
+scenario="pull_request paths include the load-bearing entries"
+# Disable shell globbing around the loop so ** patterns are matched
+# as literal strings, not expanded against the local filesystem.
+set -f
+missing=""
+for p in 'crates/**/src/**' 'crates/**/Cargo.toml' 'Cargo.toml' 'Cargo.lock'; do
+    # Escape the ** / * literals for regex, then match either single-
+    # or double-quoted YAML list form.
+    pattern_escaped="${p//\*/\\*}"
+    if ! grep -qE "^\s*-\s*[\"']${pattern_escaped}[\"']\s*$" "$workflow"; then
+        missing="$missing $p"
+    fi
+done
+set +f
+if [ -z "$missing" ]; then
+    pass "$scenario"
+else
+    fail "$scenario: missing path filter entries:$missing"
+fi
+
+# ---------------------------------------------------------------------
+# bare subcommand — not the deprecated `check-release` alias.
+# Modern cargo-semver-checks uses `cargo semver-checks` without a
+# subcommand. The workflow must not embed the deprecated form.
+# ---------------------------------------------------------------------
+scenario="workflow uses bare 'cargo semver-checks' (not deprecated check-release)"
+if grep -qE 'cargo semver-checks\s+check-release' "$workflow"; then
+    fail "$scenario: deprecated 'cargo semver-checks check-release' still present"
+else
+    pass "$scenario"
+fi
+
+# ---------------------------------------------------------------------
+# policy doc presence — workflow comments link to it.
+# ---------------------------------------------------------------------
+scenario="policy doc exists"
+if [ -f "$policy_doc" ]; then
+    pass "$scenario"
+else
+    fail "$scenario: $policy_doc missing"
+fi
+
+# ---------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "$pass_count" "$fail_count"
+if [ "$fail_count" -ne 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Ships ROADMAP item at [`ROADMAP.md:799`](../blob/main/ROADMAP.md#L799) — `cargo-semver-checks` as an advisory CI gate. Advisory-now; flips to blocking when Phase 6 opens (first stable public API).

- `.github/workflows/semver-checks.yml` pins cargo-semver-checks 0.47.0, runs `cargo semver-checks --workspace --baseline-rev <sha>` on PRs that touch crate sources or manifests.
- `scripts/semver-scripts-test.sh` (9 scenarios) asserts the workflow's structural invariants: version pin format, `fetch-depth: 0`, `SEMVER-CHECKS-MODE` sentinel ↔ `continue-on-error` consistency, `::warning::` annotation presence, required path filters, no deprecated `check-release` subcommand.
- `docs/semver-policy.md` — what the tool checks, advisory→gating flip procedure, running locally (with `git fetch origin main` prefix), toolchain channel caveats, strict-lint interaction escape hatch, known caveats.
- `CONTRIBUTING.md` — §7 policy bullet + §9 local-run block.

## Commits

1. `3d3e1ab` — `docs(semver): policy doc + CONTRIBUTING.md wiring (0-5-semver A/2)`
2. `933734f` — `ci(semver): cargo-semver-checks advisory CI gate (0-5-semver B/2)`

## Key design decisions

- **Advisory via `continue-on-error: true` + `::warning::` annotation in `if: failure()` step.** Plain `continue-on-error` produces a green check with output buried in Actions — contributors miss it. The extra annotation step surfaces the signal in the PR's Files view so the "nobody reads the advisory" drift is harder.
- **Single-line sentinel `# SEMVER-CHECKS-MODE: advisory`** keyed by the harness to the `continue-on-error` flag. Phase 6 flip must update both together; drift fails CI.
- **Baseline SHA from GitHub-provided event fields** (`pull_request.base.sha` / `merge_group.base_sha`), passed through step-level `env:`, never interpolated into `run:`.
- **`fetch-depth: 0` on checkout** — `--baseline-rev <sha>` needs the commit locally.
- **No `--exclude` list needed**: smoke-tested locally; `--workspace` auto-skips `publish = false` members (mango-proto, mango-loom-demo, xtask-vet-ttl).
- **Bare `cargo semver-checks` (not `check-release`)** — the deprecated alias works today but the harness asserts the bare form so upstream alias removal fails at harness time, not runtime.

## Test plan

- [x] `bash scripts/semver-scripts-test.sh` — 9 PASS / 0 FAIL
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/semver-checks.yml'))"` — YAML parses
- [x] `cargo semver-checks --workspace --baseline-rev origin/main` locally — "no semver update required" (expected; mango is a placeholder with no public API yet)
- [x] Confirmed `--workspace` auto-skips `publish = false` members — only `mango` is processed
- [x] Confirmed workspace strict lints don't break baseline rustdoc

Pre-commit smoke test is documented in commit B/2's message; full rationale in `.planning/0-5-semver-checks.plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)