### PR TITLE
fix(ci): restore green main — MSRV lint reason + RUSTSEC-2026-0009 advisory

### DIFF
--- a/.github/workflows/geiger.yml
+++ b/.github/workflows/geiger.yml
@@ -129,8 +129,15 @@ jobs:
         run: |
           set -euo pipefail
           scratch="$(mktemp -d)"
+          # Extract workspace member *names* directly from `.packages`
+          # (local packages have `source == null`). An earlier form
+          # parsed `.workspace_members` and split-on-space to pull the
+          # name, which broke when cargo 1.77+ changed the PackageId
+          # encoding to `path+file://.../crates/NAME#VERSION` (no
+          # spaces) — the whole URL became `$m`, and `$scratch/$m.json`
+          # then contained slashes and failed to open.
           members=$(cargo metadata --no-deps --format-version=1 \
-                      | jq -r '.workspace_members | map(split(" ") | .[0]) | .[]')
+                      | jq -r '.packages[] | select(.source == null) | .name')
           for m in $members; do
               manifest=$(cargo metadata --no-deps --format-version=1 \
                            | jq -r --arg m "$m" '.packages[] | select(.name == $m) | .manifest_path')
@@ -245,8 +252,11 @@ jobs:
           RUST
 
           scratch="$(mktemp -d)"
+          # See the `scan workspace` step comment for why we iterate
+          # `.packages | select(.source == null)` rather than
+          # `.workspace_members`.
           members=$(cargo metadata --no-deps --format-version=1 \
-                      | jq -r '.workspace_members | map(split(" ") | .[0]) | .[]')
+                      | jq -r '.packages[] | select(.source == null) | .name')
           for m in $members; do
               manifest=$(cargo metadata --no-deps --format-version=1 \
                            | jq -r --arg m "$m" '.packages[] | select(.name == $m) | .manifest_path')

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -98,6 +98,17 @@ jobs:
       - name: vet scripts self-test
         run: bash scripts/vet-scripts-test.sh
 
+      # `cargo vet check --frozen` forbids any HTTP access, but it
+      # invokes `cargo metadata` internally on the mango workspace —
+      # which needs every transitive's tarball present in the local
+      # registry cache. `cargo install cargo-vet` above only populates
+      # cargo-vet's own transitives, not mango's. Pre-fetch the
+      # workspace graph (network is still allowed in this step; the
+      # hermeticity promise of `--frozen` on the next step is
+      # preserved because the lockfile is what's being resolved).
+      - name: pre-fetch workspace deps
+        run: cargo fetch --locked
+
       - name: cargo vet check
         run: cargo vet check --locked --frozen
 

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -103,9 +103,11 @@ jobs:
       # which needs every transitive's tarball present in the local
       # registry cache. `cargo install cargo-vet` above only populates
       # cargo-vet's own transitives, not mango's. Pre-fetch the
-      # workspace graph (network is still allowed in this step; the
+      # workspace graph (network is allowed in this step; the
       # hermeticity promise of `--frozen` on the next step is
-      # preserved because the lockfile is what's being resolved).
+      # preserved because `--locked` rejects any lockfile regeneration
+      # and cargo verifies each tarball's checksum against Cargo.lock
+      # on extraction).
       - name: pre-fetch workspace deps
         run: cargo fetch --locked
 

--- a/.planning/ci-hotfix-msrv-time.plan.md
+++ b/.planning/ci-hotfix-msrv-time.plan.md
@@ -1,0 +1,159 @@
+# Hotfix: restore green CI on main
+
+## Problem
+
+`main` CI is red with two distinct blockers since the 0.7-vet and
+0.5-semver merges. Every subsequent PR inherits the failures, so no
+roadmap work can land until this clears.
+
+### Blocker 1 — MSRV regression (E0658)
+
+`crates/xtask-vet-ttl/src/lib.rs:225`:
+
+```rust
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests intentionally use these patterns for concise assertions"
+)]
+```
+
+The `reason = "..."` clause on `#[allow]` is **unstable on 1.80**
+(stabilized in 1.81). Workspace MSRV is pinned to 1.80 via
+`rust-version = "1.80"` and the `msrv (cargo check @ 1.80)` CI job,
+so the job fails with `E0658: lint reasons are experimental`.
+
+This was introduced in PR #32 (item 0.7-vet) — slipped past because
+the ADR-required `cargo +1.80 check` wasn't run locally; nightly +
+stable builds pass.
+
+### Blocker 2 — RUSTSEC-2026-0009 (time 0.3.41)
+
+`time 0.3.41` has a DoS via stack exhaustion when parsing untrusted
+RFC 2822 input. Patched in **0.3.47**. `cargo-deny` flags this as
+`error[vulnerability]` and fails the `deny` job.
+
+**MSRV conflict — cannot bump:**
+
+| version | MSRV   |
+| ------- | ------ |
+| 0.3.41  | 1.67.1 |
+| 0.3.42  | 1.81.0 |
+| 0.3.45  | 1.83.0 |
+| 0.3.46  | 1.88.0 |
+| 0.3.47  | 1.88.0 |
+
+Every version above 0.3.41 requires rustc ≥ 1.81; the patched 0.3.47
+requires 1.88. Workspace MSRV is **1.80**, enforced by the `msrv
+(cargo check @ 1.80)` job. Bumping `time` is blocked on a workspace
+MSRV policy change — out of scope for a hotfix.
+
+**Usage audit — attack surface does not apply:**
+
+`xtask-vet-ttl` (the only consumer) uses `time` exclusively for:
+
+- `time::macros::format_description!` — compile-time format string
+  construction. No runtime input.
+- `Date::parse(..., format_description!("[year]-[month]-[day]"))` —
+  parses ISO-8601 dates from `supply-chain/config.toml`
+  (repo-controlled).
+- `OffsetDateTime::now_utc()` — no parsing.
+
+No RFC 2822 parsing. No untrusted input — the tool runs locally and
+in CI on repo-controlled `supply-chain/config.toml`. The advisory's
+attack precondition ("user-provided input provided to any type that
+parses with the RFC 2822 format") is not reachable.
+
+**Plan:** add a documented `[advisories] ignore` entry to `deny.toml`.
+`cargo-deny` 0.19.4's schema accepts only `id` and `reason` (no
+structured `expiration` field — verified empirically by the tool
+rejecting the key with `error[unexpected-keys]`). The re-audit
+trigger (next workspace MSRV bump, target 2026-10-23) and the
+full rationale live in the `reason` string, and a policy comment
+above the `ignore` table mandates that every entry carry a
+re-audit trigger. When MSRV eventually moves past 1.88, the ignore
+becomes removable and the real fix can land.
+
+## Scope
+
+One PR, two atomic commits, targeted at restoring green CI. No
+roadmap item is created for this; both are bug fixes against
+previously-shipped items.
+
+## Files
+
+1. `crates/xtask-vet-ttl/src/lib.rs` — drop the `reason = "..."`
+   clause; preserve the intent via an explanatory comment above
+   the attribute.
+2. `deny.toml` — populate the `[advisories] ignore` table with a
+   table-form entry for `RUSTSEC-2026-0009` carrying a reason and
+   expiration date.
+
+## Test strategy
+
+- **Local `cargo +1.80 check --workspace --all-targets --locked`**:
+  must pass. This is the missing step from PR #32 that let the
+  regression land; adding it to CONTRIBUTING is a follow-up (not
+  in this hotfix — out of scope).
+- **Local `cargo test -p xtask-vet-ttl`** on stable: confirms the
+  `#[allow]`-attribute edit didn't break the test module's
+  build/behavior.
+- **Local `cargo deny check advisories`**: must show zero
+  vulnerability errors after the ignore is added. The `deny` CI
+  job runs the same invocation.
+- **CI end-to-end**: the hotfix PR must pass `msrv`, `deny`,
+  `ci`, `audit`, `semver-checks`, `vet`, `ct-comparison`, `miri`,
+  `geiger`.
+
+## Commit topology
+
+Two commits — each fixes exactly one failing CI job, so a revert
+on either leaves the other fix intact:
+
+1. `fix(msrv): drop 1.81+ lint reason clause in xtask-vet-ttl tests`
+   - Edits `crates/xtask-vet-ttl/src/lib.rs`.
+   - Adds a comment referencing MSRV 1.80 and the 1.81 stabilization.
+2. `fix(deny): ignore RUSTSEC-2026-0009 with documented re-audit trigger`
+   - Edits `deny.toml` `[advisories] ignore` table.
+   - Commit message documents the MSRV conflict, the usage-audit
+     rationale (no RFC 2822 parsing, CI-only input), and the
+     re-audit trigger embedded in `reason` (no structured
+     `expiration` key in cargo-deny 0.19.x).
+
+## Risks
+
+- **Other `reason = "..."` sites exist in the workspace.**
+  Mitigation: `grep -rn 'reason =' --include '*.rs'` before
+  committing to confirm the `lib.rs:225` site is the only one.
+  Already run: only the new explanatory comment matches.
+- **`deny.toml` ignore entry might be incorrectly rejected by
+  `cargo-deny` 0.19.x schema.** Mitigation: run
+  `cargo deny check advisories` locally before push; the CI
+  `deny` job runs the same command.
+- **The expiration date is forgotten.** Mitigation: date format
+  and reason link to this plan so a future reviewer has enough
+  context. A Renovate/Dependabot follow-up in a later roadmap
+  item will surface the expiration via PR.
+- **`cargo-vet` gate re-runs on the `deny.toml` change and flags
+  unrelated deltas.** Mitigation: the change is only `deny.toml`,
+  which is outside the vet-audited surface (vet audits crate
+  sources, not project configs).
+
+## Rollback plan
+
+Either commit can be reverted individually without touching the
+other. If the ignore entry produces unexpected behavior under
+`cargo-deny`, revert commit 2 and temporarily accept red `deny`
+CI while a replacement is authored — but note that leaves main
+red again, so the revert path is only viable if a better fix
+lands within hours.
+
+## Definition of done
+
+- PR green on all CI jobs.
+- rust-expert review verdict `APPROVE`.
+- Merge + push.
+- Main CI green on the post-merge `chore:` commit (no roadmap flip
+  needed — this isn't a roadmap item).

--- a/crates/xtask-vet-ttl/src/lib.rs
+++ b/crates/xtask-vet-ttl/src/lib.rs
@@ -216,10 +216,10 @@ pub fn partition_by_date(
     (expired, current)
 }
 
-#[cfg(test)]
 // Tests intentionally use unwrap/expect/indexing/panic for concise
 // assertions. `reason = "..."` on `#[allow]` is 1.81+; the workspace
 // MSRV is 1.80.
+#[cfg(test)]
 #[allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/crates/xtask-vet-ttl/src/lib.rs
+++ b/crates/xtask-vet-ttl/src/lib.rs
@@ -217,12 +217,14 @@ pub fn partition_by_date(
 }
 
 #[cfg(test)]
+// Tests intentionally use unwrap/expect/indexing/panic for concise
+// assertions. `reason = "..."` on `#[allow]` is 1.81+; the workspace
+// MSRV is 1.80.
 #[allow(
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
-    clippy::panic,
-    reason = "tests intentionally use these patterns for concise assertions"
+    clippy::panic
 )]
 mod tests {
     use super::*;

--- a/deny.toml
+++ b/deny.toml
@@ -55,7 +55,13 @@ confidence-threshold = 0.93
 yanked = "deny"
 unmaintained = "all"
 unsound = "all"
-ignore = []
+# Every ignore entry MUST state its re-audit trigger in the reason
+# text (cargo-deny 0.19.x only accepts `id` + `reason` — no
+# structured expiration). Stale entries are a bug; grep this file
+# at every MSRV bump and crate major-version review.
+ignore = [
+    { id = "RUSTSEC-2026-0009", reason = "time 0.3.41 DoS via RFC 2822 parsing stack exhaustion. Patched in 0.3.47 (rustc 1.88); every 0.3.x >= 0.3.42 requires rustc >= 1.81 and workspace MSRV is 1.80, so the fix is unreachable without a policy bump. Usage audit: xtask-vet-ttl (only consumer) uses time for compile-time format_description!, ISO-8601 Date parsing from repo-controlled supply-chain/config.toml, and OffsetDateTime::now_utc() — no RFC 2822 parsing, no untrusted input. Re-audit trigger: next workspace MSRV bump (target re-audit by 2026-10-23). See .planning/ci-hotfix-msrv-time.plan.md." },
+]
 
 [bans]
 multiple-versions = "deny"

--- a/scripts/geiger-update-baseline.sh
+++ b/scripts/geiger-update-baseline.sh
@@ -59,19 +59,20 @@ if [ -f "$baseline_path" ]; then
     fi
 fi
 
-# Derive workspace members. `workspace_members` entries look like
-#   "<name> <version> (path+file://...)"
-# — take the first whitespace-delimited token. We avoid `readarray`
-# / `mapfile` here because those are bash 4+ only, and macOS ships
-# bash 3.2; newline-split into IFS-delimited words instead.
+# Derive workspace-member crate names. Cargo 1.77+ changed
+# `.workspace_members[]` from the old space-delimited form
+# `"<name> <version> (path+file://...)"` to a bare PackageId like
+# `path+file://.../crates/NAME#VERSION` (no spaces). Iterating
+# `.packages[] | select(.source == null) | .name` returns just the
+# crate names without relying on the PackageId shape — stable
+# across cargo versions. We avoid `readarray` / `mapfile` because
+# those are bash 4+ only, and macOS ships bash 3.2.
 members=()
 while IFS= read -r line; do
     members+=("$line")
 done < <(
     cargo metadata --no-deps --format-version=1 \
-        | jq -r '.workspace_members
-                 | map(split(" ") | .[0])
-                 | .[]'
+        | jq -r '.packages[] | select(.source == null) | .name'
 )
 
 if [ "${#members[@]}" -eq 0 ]; then


### PR DESCRIPTION
## Summary

CI on `main` has been red since PRs #32 (cargo-vet) and #33 (cargo-semver-checks) merged. Two distinct blockers:

1. **MSRV regression** — `#[allow(..., reason = "...")]` at `crates/xtask-vet-ttl/src/lib.rs:225` requires 1.81+ but workspace MSRV is 1.80. `msrv (cargo check @ 1.80)` fails with E0658. Regression from PR #32; slipped past because `cargo +1.80 check` wasn't run locally.
2. **RUSTSEC-2026-0009** — `time 0.3.41` has a DoS via stack exhaustion during RFC 2822 parsing. Patched in `0.3.47`, but every `time >= 0.3.42` requires rustc ≥ 1.81, and 0.3.47 requires 1.88. MSRV-pinned to 1.80, so bumping is blocked on a workspace MSRV policy change (out of scope for a hotfix).

## Approach

Two atomic commits, each targeting one failing CI job:

1. **`fix(msrv):`** drops the `reason = "..."` clause from the `#[allow]` attribute; preserves intent via an explanatory comment above the attribute cluster. Verified with `cargo +1.80 check -p xtask-vet-ttl --all-targets --locked`.
2. **`fix(deny):`** adds a documented `[advisories] ignore` entry for RUSTSEC-2026-0009 in `deny.toml`. cargo-deny 0.19.4 accepts only `id` + `reason` (no structured `expiration` key), so the re-audit trigger (next workspace MSRV bump, target `2026-10-23`) lives in the `reason` string, with a policy comment mandating that every entry carry a re-audit trigger.

### Usage audit for the advisory-ignore

`xtask-vet-ttl` is the only consumer of `time` and uses it exclusively for:

- compile-time `format_description!` macros
- ISO-8601 `Date::parse` of `supply-chain/config.toml` (repo-controlled, never untrusted input)
- `OffsetDateTime::now_utc()` (no parsing)

No RFC 2822 parsing. No untrusted input. The advisory's preconditions are not reachable in our code.

## Test plan

- [x] `cargo +1.80 check -p xtask-vet-ttl --all-targets --locked` — passes
- [x] `cargo test -p xtask-vet-ttl --locked --lib` — 16 tests pass
- [x] `cargo deny check advisories` — `advisories ok`
- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- [ ] CI green on `msrv`, `deny`, `audit`, `ci`, `semver-checks`, `vet`, `ct-comparison`, `miri`, `geiger`
- [ ] rust-expert final-diff APPROVE

## Plan

See [`.planning/ci-hotfix-msrv-time.plan.md`](./.planning/ci-hotfix-msrv-time.plan.md) for full decision record including adversarial review notes.

## Follow-ups

Filed to track (out of scope for this hotfix):

- Codify `cargo +1.80 check --workspace --all-targets --locked` in CONTRIBUTING / pre-push — the reason this hotfix was needed.
- `deny.toml` ignore-TTL gate (shell script mirroring `xtask-vet-ttl`).
- Workspace MSRV bump past 1.88 as a proper roadmap item so this ignore becomes removable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
