### PR TITLE
ci(doc): rustdoc gate + missing_docs (ROADMAP.md:801)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,10 +227,14 @@ jobs:
           shared-key: ""
       - name: install protoc
         # tonic-build 0.12 + prost-build 0.13 do not vendor protoc;
-        # mango-proto's build script needs it. Same convention as
-        # the clippy/test/msrv jobs.
+        # mango-proto's build script needs it. protoc ships on the
+        # GitHub-hosted runner image — same convention as the
+        # clippy/test/msrv jobs.
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: cargo fetch
+        # Strictly redundant with cargo doc's own fetch, but mirrors
+        # the clippy/test/msrv step shape and gives a clean log
+        # boundary if the network flakes on the lockfile resolve.
         run: cargo fetch --locked
       - name: cargo doc (gate)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,62 @@ jobs:
           command: check
           arguments: --all-features
 
+  doc:
+    # Rustdoc gate. Two layers, one job:
+    #
+    #   1. RUSTDOCFLAGS="-D warnings" — every rustdoc lint becomes
+    #      a hard error. Catches rustdoc::broken_intra_doc_links
+    #      (the common regression after a rename), invalid HTML,
+    #      bare URLs, etc. We do NOT enumerate a specific lint
+    #      allowlist — new rustdoc lints land every few releases,
+    #      and an allowlist rots silently. Broad deny plus per-
+    #      module `#![allow(...)]` for known-noisy generated code
+    #      (crates/mango-proto/src/lib.rs for prost output) is the
+    #      correct shape.
+    #
+    #   2. `#![deny(missing_docs)]` on every crates/mango-*/src/lib.rs
+    #      root — source-side contract that every `pub` item has at
+    #      least one line of prose. The attribute survives CI-flag
+    #      rearrangement; -D warnings alone would silently drop
+    #      missing_docs enforcement if someone pulled the flag.
+    #
+    # Doctest *execution* stays in the `test` job below (it runs
+    # `cargo test --doc`). This job is link/warn-only — compiles
+    # doc pages but does not execute code blocks. See
+    # docs/documentation-policy.md for the full policy.
+    #
+    # Why a job in ci.yml and not a dedicated doc.yml: cargo doc
+    # is stable-toolchain + protoc (already warm from the clippy
+    # job's cache) + a few seconds of compile. Dedicated file
+    # would split the "core compile/lint/doc" cluster for no win.
+    name: doc
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          # Distinct cache scope — cargo doc's artifacts are not
+          # interchangeable with clippy/test/msrv. Sharing would
+          # silently invalidate other jobs on every alternation.
+          prefix-key: v0-doc
+          shared-key: ""
+      - name: install protoc
+        # tonic-build 0.12 + prost-build 0.13 do not vendor protoc;
+        # mango-proto's build script needs it. Same convention as
+        # the clippy/test/msrv jobs.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: cargo fetch
+        run: cargo fetch --locked
+      - name: cargo doc (gate)
+        env:
+          # `-D warnings` turns rustdoc lints into errors. See
+          # docs/documentation-policy.md for the rationale and the
+          # local reproducer command.
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --document-private-items --workspace --locked
+
   bench-harness:
     # Bench-harness scaffold smoke tests. No Rust toolchain, no cache —
     # the scaffold is pure shell (etcd oracle fetch-and-verify, hardware

--- a/crates/mango-loom-demo/src/lib.rs
+++ b/crates/mango-loom-demo/src/lib.rs
@@ -16,6 +16,8 @@
 //! the Miri CI workflow has a non-vacuous surface to exercise.
 //! See `docs/miri.md`.
 
+#![deny(missing_docs)]
+
 use std::sync::atomic::Ordering;
 
 #[cfg(loom)]

--- a/crates/mango-proto/src/lib.rs
+++ b/crates/mango-proto/src/lib.rs
@@ -7,7 +7,15 @@
 //! It is **not** wire-stable and will be deleted when the first
 //! real `mango.*.v1` proto lands.
 
+#![deny(missing_docs)]
+
+/// Namespace root for `mango.hello.*` protobuf services. Phase-0
+/// smoke surface only; real versioned namespaces (`mango.kv.v1`,
+/// `mango.raft.v1`, …) land in Phase 6+.
 pub mod hello {
+    /// Version 0 of the hello service. `v0` is a pipeline smoke
+    /// test, NOT a wire-stable surface — it will be deleted when
+    /// the first real `mango.*.v1` service lands.
     pub mod v0 {
         // Generated code is foreign — we do not own the style. Every
         // workspace-denied lint that prost's expansion could plausibly
@@ -18,6 +26,14 @@ pub mod hello {
         // priority-0 allow, so the individual denies MUST be listed
         // explicitly — the group allows are kept only for
         // future-proofing against new lints in those groups.
+        //
+        // The `rustdoc::bare_urls` and `rustdoc::broken_intra_doc_links`
+        // allows guard against future prost-build versions embedding
+        // `.proto` comment URLs or cross-references. The outer
+        // `-D warnings` in the doc gate does NOT silence those two
+        // from inside this module without the explicit allow — a
+        // dep bump would otherwise red the `doc` job with no source
+        // change from us.
         #![allow(
             clippy::all,
             clippy::pedantic,
@@ -39,7 +55,9 @@ pub mod hello {
             clippy::await_holding_lock,
             clippy::await_holding_refcell_ref,
             unreachable_pub,
-            missing_docs
+            missing_docs,
+            rustdoc::bare_urls,
+            rustdoc::broken_intra_doc_links
         )]
         include!(concat!(env!("OUT_DIR"), "/mango.hello.v0.rs"));
     }

--- a/crates/mango/src/lib.rs
+++ b/crates/mango/src/lib.rs
@@ -3,6 +3,12 @@
 //! This crate is currently a placeholder. Real functionality lands per the
 //! phases described in `ROADMAP.md` at the workspace root.
 
+#![deny(missing_docs)]
+
+/// The package version string, captured at build time from
+/// `CARGO_PKG_VERSION`. Kept as a crate-level constant so
+/// downstream tests can assert on the shipped version without
+/// re-reading `Cargo.toml`.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]

--- a/crates/xtask-vet-ttl/src/lib.rs
+++ b/crates/xtask-vet-ttl/src/lib.rs
@@ -7,6 +7,13 @@
 // free-form rationale in `notes`, and we only pluck the ISO-8601 date
 // that follows a `review-by:` label.
 
+// Internal supply-chain helper; `publish = false`. Deliberately outside
+// the `crates/mango-*` missing_docs gate per docs/documentation-policy.md
+// — but declared allowed explicitly so a future `rustc` default flip
+// from `allow` to `warn` for `missing_docs` cannot retroactively red
+// the `doc` CI job. One line of cheap insurance.
+#![allow(missing_docs)]
+
 use std::fmt;
 
 use time::format_description::FormatItem;

--- a/docs/documentation-policy.md
+++ b/docs/documentation-policy.md
@@ -1,0 +1,115 @@
+# Documentation policy
+
+Mango gates rustdoc output at PR time so broken references and
+undocumented public symbols can never land on `main`. The gate is
+[`doc` in `.github/workflows/ci.yml`](../.github/workflows/ci.yml);
+this doc is the policy.
+
+## The two layers
+
+### Layer 1 — `RUSTDOCFLAGS="-D warnings"` on `cargo doc`
+
+Turns every rustdoc lint from `warn`-by-default into a hard
+error. Catches, among others:
+
+- `rustdoc::broken_intra_doc_links` — stale `[Symbol]` refs
+  after a rename.
+- `rustdoc::invalid_html_tags` — hand-written HTML that
+  rustdoc can't parse.
+- `rustdoc::bare_urls` — URLs that weren't wrapped in `<...>`
+  or a markdown link.
+- `rustdoc::redundant_explicit_links` — when the text and the
+  target would collapse.
+
+**Why broad `-D warnings` and not an enumerated allowlist?**
+New rustdoc lints land every few releases. An enumerated
+allowlist rots silently — you would get coverage of existing
+lints but miss the new ones. Broad deny plus per-module
+`#![allow(...)]` for known-noisy generated code (today:
+`crates/mango-proto/src/lib.rs` for prost output) is the right
+shape — the `allow` is visible in the source, and any new
+rustdoc lint that lands is opt-out rather than opt-in.
+
+### Layer 2 — `#![deny(missing_docs)]` on every `crates/mango-*/src/lib.rs`
+
+Forces every `pub` item on Mango's API surface to carry at
+least one line of prose. The root attribute cascades into all
+public items in the crate; private items are exempt.
+
+**Scope**: applied to `crates/mango`, `crates/mango-proto`,
+`crates/mango-loom-demo`. Explicitly NOT applied to
+`crates/xtask-vet-ttl` — it is a `publish = false`
+supply-chain helper, not a user-facing API. It carries an
+explicit `#![allow(missing_docs)]` so that a future `rustc`
+flipping the `missing_docs` default from `allow` to `warn`
+cannot retroactively red the `doc` job.
+
+**Cascade exception** — `crates/mango-proto/src/hello/v0`
+carries an inner `#![allow(missing_docs, rustdoc::bare_urls,
+rustdoc::broken_intra_doc_links)]` because the module body is
+prost-generated code we don't own. The outer module boundary
+is still gated.
+
+## Local reproducer
+
+Run the same command CI runs:
+
+```
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --workspace --locked
+```
+
+To verify the gate is actually tight (smoke-test that both
+layers bite):
+
+```
+# Layer 1 — broken intra-doc link:
+echo '//! [not_a_real_symbol]' >> crates/mango/src/lib.rs
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --workspace --locked
+# Expect exit != 0, diagnostic: "unresolved link to `not_a_real_symbol`"
+git checkout -- crates/mango/src/lib.rs
+
+# Layer 2 — missing doc:
+# Add `pub fn foo() {}` to a mango-* lib.rs, without a doc comment above it.
+# `cargo build -p <crate>` fails with "missing documentation for a function".
+```
+
+## Interaction with other jobs
+
+- Doctest **execution** remains in the `test` job
+  (`cargo test --doc --workspace --locked` in
+  `.github/workflows/ci.yml`). The `doc` job is link- and
+  warning-only — it compiles doc pages but does not run code
+  blocks. This split keeps incremental doc rendering fast
+  without losing executable-example coverage.
+- **Cross-crate intra-doc links** ARE resolved by `cargo doc
+--workspace --no-deps`. `--no-deps` skips documentation for
+  third-party dep crates, but workspace members are still fully
+  traversed — a `[mango::VERSION]` reference from
+  `mango-proto` is validated against `mango`'s real surface. A
+  rename in `mango` that leaves a stale ref in `mango-proto`
+  will red CI. This is the desired behavior.
+- **`#![deny(missing_docs)]` fires at compile time.** A
+  contributor adding `pub fn foo()` without a `///` comment
+  sees a `cargo build` / `cargo check` failure, not a
+  `cargo doc`-only failure. This is intentional: catch the
+  omission in the editor, not in CI.
+
+## Adding a new mango-\* crate
+
+Any new crate under `crates/mango-*` (i.e., matching the
+glob the roadmap names) must:
+
+1. Include `#![deny(missing_docs)]` at the top of its
+   `src/lib.rs`.
+2. Pass the local reproducer command on first commit.
+3. Update `docs/documentation-policy.md` only if it introduces
+   a new cascade exception (e.g., new codegen target).
+
+rust-expert PR review will flag omissions.
+
+## Related docs
+
+- [`unsafe-policy.md`](unsafe-policy.md)
+- [`sbom-policy.md`](sbom-policy.md)
+- [`ct-comparison-policy.md`](ct-comparison-policy.md)
+- [`supply-chain-policy.md`](supply-chain-policy.md)


### PR DESCRIPTION
Ships item 0.6-doc (ROADMAP.md:801): a CI-blocking rustdoc gate.

## Scope

- **Layer 1**: `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --workspace --locked` as a new `doc` job in `.github/workflows/ci.yml`. Fails on any rustdoc lint (broken intra-doc links, bare URLs, invalid HTML, etc.).
- **Layer 2**: `#![deny(missing_docs)]` on every `crates/mango-*/src/lib.rs` (mango, mango-proto, mango-loom-demo). Forces every `pub` item on the Mango surface to carry at least one line of prose.

## What's NOT in scope

- `xtask-vet-ttl` is `publish = false` and doesn't match the `mango-*` glob — out of scope per the roadmap language "for public crates". It carries an explicit `#![allow(missing_docs)]` defensively, so a future `rustc` default flip from `allow` to `warn` for `missing_docs` cannot retroactively red the `doc` job.
- Doctest **execution** remains in the existing `test` job (`cargo test --doc`). This new job is link/warn-only.

## Commit topology (3 atomic)

1. `docs(doc-gate):` — `docs/documentation-policy.md`.
2. `refactor(docs):` — `#![deny(missing_docs)]` + three one-line doc fills (`mango::VERSION`, `mango_proto::hello`, `mango_proto::hello::v0`). Widened `hello::v0` inner allow to include `rustdoc::bare_urls` + `rustdoc::broken_intra_doc_links` against future prost-build regressions.
3. `ci(doc):` — the new `doc` job in `ci.yml`.

Ordered this way so when the CI job turns on, the working tree already satisfies it.

## Plan

Full plan + rust-expert review at `.planning/0-6-doc-gate.plan.md` (APPROVE_WITH_NITS; all five nits applied: R1 xtask defensive allow, R2 widened v0 inner allow, R3/R5/M2 policy doc callouts).

## Test plan

- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --workspace --locked` clean locally.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean.
- [x] `cargo test --workspace --locked`: 20 passed, 1 ignored.
- [x] Break-and-see: removing the `VERSION` doc comment produces a `cargo check` failure ("missing documentation for a constant"), confirming the gate bites at compile time, not just `cargo doc`.
- [x] YAML validates (`python3 yaml.safe_load`).
- [ ] `doc` CI job green on PR.
- [ ] All other required checks green.

## Test justification (per mandatory-tests policy)

The gate-under-test is `cargo doc`, a toolchain binary. A self-test script would be testing `cargo doc` itself, which is upstream's responsibility. The real test is: does this CI job block a doc regression on the live workspace? That's what the PR itself will prove when the `doc` job runs. The policy doc also ships a two-command local reproducer that any contributor can execute to verify both layers bite.

## Roadmap

Flips `ROADMAP.md:801` from `- [ ]` to `- [x]` in a post-merge chore commit on main.