### PR TITLE
ci(public-api): cargo-public-api advisory gate (ROADMAP 0.6-public-api)

### DIFF
--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -74,11 +74,19 @@ jobs:
           # actions/checkout@v4 defaults to depth 1.
           fetch-depth: 0
 
-      # Nightly first, stable second: dtolnay/rust-toolchain sets the
-      # LAST-installed toolchain as default, so this leaves stable
-      # active. cargo-public-api auto-invokes the installed nightly
-      # for its rustdoc JSON calls — the rest of CI's tools assume
-      # stable.
+      # dtolnay/rust-toolchain sets the LAST-installed toolchain as
+      # default. Nightly first, stable second → stable is active.
+      # We invoke `cargo public-api` via the `cargo +<toolchain>`
+      # rustup proxy below, which sets RUSTUP_TOOLCHAIN for the
+      # child process and makes `cargo --version` report nightly.
+      # cargo-public-api 0.51.0 inspects `cargo --version`: if the
+      # active toolchain is stable, it hardcodes the literal string
+      # "nightly" (a *floating* toolchain, NOT our pinned nightly),
+      # which may not be installed. Running under the pinned nightly
+      # via the +proxy bypasses that fallback and uses the pinned
+      # toolchain end-to-end (including the child rustdoc-json
+      # subprocess). This is a hard contract with the tool — bumping
+      # to a version that changes `resolve_toolchain` can break it.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: ${{ env.PUBLIC_API_NIGHTLY }}
@@ -171,7 +179,10 @@ jobs:
                   new_in_pr="${new_in_pr} ${pkg}"
               fi
           done
-          # Trim leading whitespace.
+          # Trim the single leading space from each accumulator
+          # (loop prepends exactly one space per entry, initial value
+          # is empty — so `${var# }` removes the one and only leading
+          # space). `##` would be overkill; `# ` is deliberate.
           available="${available# }"
           new_in_pr="${new_in_pr# }"
 
@@ -204,11 +215,14 @@ jobs:
         env:
           BASE_SHA: ${{ steps.base.outputs.sha }}
           AVAILABLE: ${{ steps.pkgs.outputs.available }}
+          PUBLIC_API_NIGHTLY: ${{ env.PUBLIC_API_NIGHTLY }}
         run: |
           set -euo pipefail
 
           if [ -z "$AVAILABLE" ]; then
-              echo "no publishable crates with a baseline — nothing to diff"
+              # Visible notice so a jq-filter regression that emits
+              # zero names doesn't silently pass the gate.
+              echo "::notice title=public-api::no publishable crates with a baseline — nothing to diff"
               exit 0
           fi
 
@@ -216,11 +230,20 @@ jobs:
           for pkg in $AVAILABLE; do
               echo ""
               echo "=== cargo public-api diff: $pkg ==="
-              # Global args (--manifest-path, --package, --omit) come
-              # before the `diff` subcommand for readability; --deny is
-              # a diff-subcommand arg and comes after.
-              cargo public-api \
-                  --manifest-path "${GITHUB_WORKSPACE}/Cargo.toml" \
+              # Invocation notes:
+              #  - `cargo "+${PUBLIC_API_NIGHTLY}" public-api` uses
+              #    the rustup `+toolchain` proxy (required — the tool
+              #    otherwise hardcodes the literal "nightly" when
+              #    stable is active; see dtolnay block above).
+              #  - `--manifest-path crates/<pkg>/Cargo.toml` points
+              #    at the crate's own manifest. cargo-public-api
+              #    0.51.0 rejects virtual (workspace-root) manifests
+              #    up-front, before `--package` is even resolved.
+              #  - Global args (--manifest-path, --package, --omit)
+              #    come before the `diff` subcommand; --deny is a
+              #    diff-subcommand arg and comes after.
+              cargo "+${PUBLIC_API_NIGHTLY}" public-api \
+                  --manifest-path "${GITHUB_WORKSPACE}/crates/${pkg}/Cargo.toml" \
                   --package "$pkg" \
                   --omit blanket-impls,auto-trait-impls,auto-derived-impls \
                   diff \

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -1,0 +1,239 @@
+# Mango cargo-public-api CI gate.
+#
+# Prints the diff of every publishable workspace crate's public API
+# surface against the PR base. Complements cargo-semver-checks:
+# cargo-public-api answers "what symbols changed?"; cargo-semver-checks
+# answers "is that change a semver violation?". See docs/public-api-policy.md.
+#
+# Mode: ADVISORY pre-Phase-6. The check runs, surfaces its findings
+# via a ::warning:: annotation in the PR's Files view, but does not
+# block merge. Flip to gating when Phase 6 opens. The flip procedure
+# is in docs/public-api-policy.md.
+#
+# Version pins: CARGO_PUBLIC_API_VERSION and PUBLIC_API_NIGHTLY below
+# are the single source of truth. They must move TOGETHER — bumping
+# the tool without the nightly produces rustdoc-JSON-format errors
+# that look unrelated. Bump procedure in docs/public-api-policy.md.
+#
+# Security: every github event value flows through step-level env
+# and is read as a shell variable — never interpolated into run
+# blocks directly. Matches the vet.yml / geiger.yml / semver-checks.yml
+# precedent.
+#
+# --deny all is mandatory on the diff invocation below. Without it,
+# cargo public-api diff returns exit 0 on a non-empty diff and the
+# continue-on-error / ::warning:: wiring becomes a silent no-op. The
+# Phase-6 flip is still two lines (sentinel + continue-on-error);
+# --deny stays across the flip.
+
+name: public-api
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "crates/**/src/**"
+      - "crates/**/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/public-api.yml"
+      - "scripts/public-api-scripts-test.sh"
+      - "docs/public-api-policy.md"
+  # merge_group does not honour paths filters — GitHub Actions always
+  # dispatches merge-queue events. Correct behaviour (merge-queue is
+  # the last line of defense) and matches the sibling gates.
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_PUBLIC_API_VERSION: "0.51.0"
+  # Pinned nightly (not floating `nightly`) for determinism. Must be
+  # at-or-after the upstream compat-matrix minimum for the tool
+  # version above. Bump together with CARGO_PUBLIC_API_VERSION per
+  # docs/public-api-policy.md §"Bumping the pin".
+  PUBLIC_API_NIGHTLY: "nightly-2026-03-01"
+
+jobs:
+  public-api:
+    name: cargo-public-api (advisory)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # `diff BASE..HEAD` needs the base commit present locally;
+          # actions/checkout@v4 defaults to depth 1.
+          fetch-depth: 0
+
+      # Nightly first, stable second: dtolnay/rust-toolchain sets the
+      # LAST-installed toolchain as default, so this leaves stable
+      # active. cargo-public-api auto-invokes the installed nightly
+      # for its rustdoc JSON calls — the rest of CI's tools assume
+      # stable.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: ${{ env.PUBLIC_API_NIGHTLY }}
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: stable
+
+      - name: cache cargo-public-api binary
+        id: cache-public-api
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: ~/.cargo/bin/cargo-public-api
+          key: cargo-public-api-${{ env.CARGO_PUBLIC_API_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: install cargo-public-api
+        if: steps.cache-public-api.outputs.cache-hit != 'true'
+        env:
+          CARGO_PUBLIC_API_VERSION: ${{ env.CARGO_PUBLIC_API_VERSION }}
+        run: |
+          set -euo pipefail
+          cargo install cargo-public-api --version "${CARGO_PUBLIC_API_VERSION}" --locked
+
+      - name: public-api version sanity
+        env:
+          CARGO_PUBLIC_API_VERSION: ${{ env.CARGO_PUBLIC_API_VERSION }}
+        run: |
+          set -euo pipefail
+          got="$(cargo public-api --version | awk '{print $2}')"
+          if [ "$got" != "${CARGO_PUBLIC_API_VERSION}" ]; then
+              echo "error: cargo-public-api version mismatch (want ${CARGO_PUBLIC_API_VERSION}, got ${got})" >&2
+              exit 1
+          fi
+
+      - name: public-api scripts self-test
+        run: bash scripts/public-api-scripts-test.sh
+
+      - name: resolve baseline sha
+        id: base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: |
+          set -euo pipefail
+          # Prefer the GitHub-provided base SHA (attacker-uncontrollable,
+          # set by the maintainer's base-branch choice for PRs, or by
+          # the merge queue for merge_group). Fall back to
+          # git merge-base HEAD origin/main for workflow_dispatch.
+          if [ -n "${PR_BASE_SHA:-}" ]; then
+              base="${PR_BASE_SHA}"
+          elif [ -n "${MERGE_GROUP_BASE_SHA:-}" ]; then
+              base="${MERGE_GROUP_BASE_SHA}"
+          else
+              base="$(git merge-base HEAD origin/main)"
+          fi
+          echo "sha=${base}" >> "$GITHUB_OUTPUT"
+          echo "baseline sha: ${base}"
+
+      - name: enumerate publishable packages
+        id: pkgs
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # publish filter (matches docs/public-api-policy.md):
+          #   publish: null        -> default, publishable     -> INCLUDE
+          #   publish: []          -> publish = false          -> EXCLUDE
+          #   publish: [...]       -> registry allow-list      -> INCLUDE
+          # source == null limits to workspace members (dep packages
+          # pulled from registries carry a non-null source).
+          head_pkgs="$(
+              cargo metadata --no-deps --format-version=1 --locked \
+                  | jq -r '.packages[]
+                           | select(.source == null)
+                           | select(.publish != [])
+                           | .name'
+          )"
+
+          # Intersect with BASE to skip new-in-this-PR crates (they
+          # have no baseline rustdoc-compilable tree — the tool would
+          # fail with an "unknown package" error that looks unrelated
+          # to an API change). Convention: crates/<pkg>/Cargo.toml
+          # exists for every workspace member; a missing file at BASE
+          # means the crate was added in this PR.
+          available=""
+          new_in_pr=""
+          for pkg in $head_pkgs; do
+              if git cat-file -e "${BASE_SHA}:crates/${pkg}/Cargo.toml" 2>/dev/null; then
+                  available="${available} ${pkg}"
+              else
+                  new_in_pr="${new_in_pr} ${pkg}"
+              fi
+          done
+          # Trim leading whitespace.
+          available="${available# }"
+          new_in_pr="${new_in_pr# }"
+
+          echo "available=${available}" >> "$GITHUB_OUTPUT"
+          echo "new_in_pr=${new_in_pr}" >> "$GITHUB_OUTPUT"
+          echo "publishable packages in HEAD: ${head_pkgs}" | tr '\n' ' '
+          echo ""
+          echo "with baseline (will diff): ${available}"
+          echo "new in this PR (will skip): ${new_in_pr}"
+
+      - name: notice new-in-PR crates
+        if: steps.pkgs.outputs.new_in_pr != ''
+        env:
+          NEW_IN_PR: ${{ steps.pkgs.outputs.new_in_pr }}
+        run: |
+          set -euo pipefail
+          for pkg in $NEW_IN_PR; do
+              echo "::notice title=public-api new crate::${pkg} is new in this PR — no baseline to diff against. Human reviewers should eyeball the public surface directly."
+          done
+
+      # PUBLIC-API-MODE: advisory
+      # Single-line sentinel above. scripts/public-api-scripts-test.sh
+      # asserts this sentinel stays in sync with the continue-on-error
+      # flag AND the --deny flag on the next step. When Phase 6 opens,
+      # flip sentinel -> gating and continue-on-error -> false on the
+      # same step. --deny stays. See docs/public-api-policy.md.
+      - name: cargo public-api diff
+        id: public-api
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          AVAILABLE: ${{ steps.pkgs.outputs.available }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$AVAILABLE" ]; then
+              echo "no publishable crates with a baseline — nothing to diff"
+              exit 0
+          fi
+
+          diff_failed=0
+          for pkg in $AVAILABLE; do
+              echo ""
+              echo "=== cargo public-api diff: $pkg ==="
+              # Global args (--manifest-path, --package, --omit) come
+              # before the `diff` subcommand for readability; --deny is
+              # a diff-subcommand arg and comes after.
+              cargo public-api \
+                  --manifest-path "${GITHUB_WORKSPACE}/Cargo.toml" \
+                  --package "$pkg" \
+                  --omit blanket-impls,auto-trait-impls,auto-derived-impls \
+                  diff \
+                  --deny all \
+                  "${BASE_SHA}..HEAD" \
+                  || diff_failed=1
+          done
+
+          if [ "$diff_failed" = "1" ]; then
+              exit 1
+          fi
+
+      - name: surface advisory diff as warning
+        if: steps.public-api.outcome == 'failure'
+        run: |
+          echo "::warning title=public-api advisory::cargo-public-api reported a non-empty diff. See job log above and docs/public-api-policy.md."

--- a/docs/public-api-policy.md
+++ b/docs/public-api-policy.md
@@ -1,0 +1,333 @@
+# Public API surface policy
+
+Mango commits to **zero silent public API changes** on every published
+`crates/mango-*` crate. Today no crate is published; when Phase 6 opens
+(first stable public API), every surface-level addition, removal, or
+rename will be merge-visible and, in Phase 6+, merge-blocking.
+
+The machinery behind this policy:
+
+- **`cargo-public-api`** — this doc's subject. Runs in
+  [`.github/workflows/public-api.yml`](../.github/workflows/public-api.yml)
+  on every PR that touches a crate's source or manifest, printing the
+  **syntactic diff** of every publishable workspace member's public
+  surface against the PR base.
+- **`cargo-semver-checks`** (already shipped) — complementary semantic
+  lint. See [`docs/semver-policy.md`](semver-policy.md).
+
+The two tools are complementary, not redundant. `cargo-public-api`
+answers "what symbols changed?"; `cargo-semver-checks` answers "is
+that change a semver violation?".
+
+## Mode: advisory (pre-Phase-6), gating (Phase 6+)
+
+The gate is **advisory today**. A non-empty public-API diff on a PR:
+
+- Shows up as a `::warning::` annotation in the PR's **Files** view
+  (not buried in the Actions log), and
+- Does **not** block merge.
+
+Phase 6 flips both: the annotation becomes a hard failure, and merge
+is blocked until the PR either undoes the surface change or documents
+it as an intentional break with a major version bump.
+
+Why advisory-now instead of waiting:
+
+1. **Exercise the machinery before it's load-bearing.** Contributors
+   hitting the gate for the first time on a Phase-6 PR have a worse
+   experience if the gate has never run before.
+2. **Signal is still useful today.** A refactor that silently makes
+   a type `pub` when it was meant to be crate-private is worth
+   flagging even pre-publish — it's exactly the kind of surface-bleed
+   that's hard to spot without tooling.
+3. **Install + cache + pin is the same work.** Flipping to gating is
+   a two-line PR (see §"Flipping to gating" below).
+
+## What the gate runs
+
+On every PR that touches `crates/**/src/**`, `crates/**/Cargo.toml`,
+`Cargo.toml` (workspace root), `Cargo.lock`, the workflow itself, the
+harness script, or this policy doc, the workflow:
+
+1. Installs the pinned `cargo-public-api` binary
+   (`CARGO_PUBLIC_API_VERSION`, cached by `(version, os, arch)`).
+2. Installs two rust toolchains: `stable` (active) and the pinned
+   nightly (`PUBLIC_API_NIGHTLY`, installed-but-not-default).
+   `cargo-public-api` consumes rustdoc JSON, which is nightly-only;
+   it auto-invokes the installed nightly toolchain.
+3. Runs `scripts/public-api-scripts-test.sh` — a structural self-test
+   of the workflow file and the publishable-member jq filter (see
+   §"Harness").
+4. Resolves a baseline SHA from the event (PR base / merge_group base
+   / workflow_dispatch fallback to `git merge-base HEAD origin/main`).
+5. Enumerates publishable workspace members via `cargo metadata` +
+   `jq` (filtering out `publish = false` crates and non-path deps).
+6. For each publishable member, runs
+`cargo public-api --package <pkg> --omit … diff --deny all
+<base>..HEAD`. The `--deny all` flag is **mandatory** — without it,
+   `cargo-public-api` returns exit 0 on a non-empty diff and the
+   `continue-on-error`/`::warning::` advisory wiring never fires.
+7. If any crate reports a non-empty diff, emits a loud `::warning::`
+   annotation pointing to this doc.
+
+The `merge_group` trigger has no `paths:` filter — GitHub Actions
+doesn't support one on merge-queue events. Matches the
+`semver-checks` and `vet` precedents.
+
+### The `--omit` flag
+
+The workflow passes
+`--omit blanket-impls,auto-trait-impls,auto-derived-impls`
+instead of the `--simplified` shortcut. Same behavior today, but
+explicit is:
+
+- **Auditable.** A reviewer can see which categories are suppressed
+  without checking the tool's docs.
+- **Decomposable.** In Phase 6 we may want `auto-derived-impls` diffs
+  visible (losing `Debug` or `Clone` on a published type matters).
+  Dropping one of the three is a one-line flag edit; splitting
+  `--simplified` apart is not.
+
+## Responding to a warning
+
+If `cargo-public-api` flags a non-empty diff on your PR:
+
+1. **Read the tool output.** It prints added / removed / changed
+   symbols grouped by crate and item kind.
+2. **Decide whether the change is intentional.**
+   - **Unintentional** (common): a refactor accidentally exposed a
+     type, or a `pub(crate)` item regressed to `pub`. Fix the
+     visibility.
+   - **Intentional**: document it in the PR description. Pre-Phase-6
+     there's no approval surface; proceed. Phase 6+, the review bar
+     rises to "must be noted in the release notes and a major-version
+     bump is scheduled."
+3. **Push a fix** (if unintentional) and the annotation goes away.
+
+## Running locally
+
+```bash
+git fetch origin main
+cargo install --locked cargo-public-api --version <pin>
+rustup install <nightly-pin>
+
+# Run from repo root. --manifest-path is explicit as a guard against
+# accidentally running from a crate subdirectory (where --package
+# would silently resolve to a different workspace).
+cargo public-api \
+    --manifest-path "$(git rev-parse --show-toplevel)/Cargo.toml" \
+    --package mango \
+    --omit blanket-impls,auto-trait-impls,auto-derived-impls \
+    diff \
+    --deny all \
+    origin/main..HEAD
+```
+
+Use the pins from
+[`.github/workflows/public-api.yml`](../.github/workflows/public-api.yml)
+— the `CARGO_PUBLIC_API_VERSION` and `PUBLIC_API_NIGHTLY` env vars.
+
+The `git fetch` is load-bearing — a stale local `origin/main`
+produces spurious deltas.
+
+**Toolchain channel**: unlike `cargo-semver-checks` (stable-only),
+`cargo-public-api` REQUIRES a nightly rustdoc. Running locally on
+stable-only will fail with a rustdoc-JSON-format error. The tool
+auto-invokes nightly if installed; you don't need to
+`rustup default nightly`.
+
+### Synthetic-change smoke
+
+To confirm the gate flags real changes, on a scratch branch:
+
+```bash
+# Add a public item that wasn't there before.
+echo '' >> crates/mango/src/lib.rs
+echo '/// Smoke test — delete before committing.' >> crates/mango/src/lib.rs
+echo 'pub fn smoke_change() {}' >> crates/mango/src/lib.rs
+
+cargo public-api \
+    --manifest-path "$(git rev-parse --show-toplevel)/Cargo.toml" \
+    --package mango \
+    --omit blanket-impls,auto-trait-impls,auto-derived-impls \
+    diff --deny all origin/main..HEAD
+# Expect: non-empty diff, exit code 1, printed line
+# "+pub fn mango::smoke_change()".
+
+git checkout -- crates/mango/src/lib.rs
+```
+
+## Bumping the pin
+
+`cargo-public-api` pins **two** versions that must move together:
+
+1. **Tool version** — `CARGO_PUBLIC_API_VERSION` in the workflow.
+2. **Nightly toolchain** — `PUBLIC_API_NIGHTLY` in the workflow.
+
+Upstream's compatibility matrix (linked from the
+[cargo-public-api README](https://github.com/cargo-public-api/cargo-public-api))
+lists the minimum nightly each tool version requires. When bumping:
+
+1. Pick the new tool version. Read its compat-matrix entry.
+2. Pick a recent nightly **at or after** the matrix-listed minimum.
+   Fixed date (not floating `nightly`) for determinism.
+3. Update both env vars in
+   [`.github/workflows/public-api.yml`](../.github/workflows/public-api.yml).
+4. Locally:
+   ```bash
+   cargo install --locked cargo-public-api --version <new> --force
+   rustup install <new-nightly>
+   # Re-run the local reproducer command above.
+   bash scripts/public-api-scripts-test.sh
+   ```
+5. Open a PR. The self-test asserts both pins are well-formed and
+   present.
+
+**Skip either pin and the self-test fails** — bumping the tool
+without bumping the nightly is the most common regression mode (new
+tool versions require newer nightly rustdoc JSON formats).
+
+## Flipping to gating (Phase 6 procedure)
+
+When the first `crates/mango-*` crate gains a stable public API
+(Phase 6), flip the gate in a dedicated PR:
+
+1. In
+   [`.github/workflows/public-api.yml`](../.github/workflows/public-api.yml):
+   - Change the sentinel comment from
+     `# PUBLIC-API-MODE: advisory` to `# PUBLIC-API-MODE: gating`.
+   - Change `continue-on-error: true` to `continue-on-error: false`
+     on the same step.
+2. `--deny all` is **already** in the invocation from day one — do
+   NOT re-add it. (This is what makes the flip two lines instead of
+   three.)
+3. Update this doc's first section to read "gating" throughout.
+
+The harness asserts the sentinel, `continue-on-error`, and `--deny`
+stay in sync. Flipping one without the others fails CI — guard
+against "sentinel says gating but gate still doesn't block" drift.
+
+## Verifying the gate works
+
+To confirm the workflow is wired up correctly end-to-end (do this
+once after shipping, and after any pin bump):
+
+1. On a scratch branch, introduce a deliberate surface change to
+   `crates/mango/src/lib.rs` — e.g., `pub fn new_item() {}`.
+2. Open a PR against `main` and wait for the `public-api` workflow
+   to complete.
+3. Confirm the PR's **Files** view shows the `::warning::`
+   annotation (pre-Phase-6) or a red X on the check (Phase 6+).
+4. **Close the scratch PR without merging. Delete the branch.** Do
+   NOT squash-merge — the entire point is to exercise the gate, not
+   to ship a noise change.
+
+## Known caveats
+
+- **Workspace strict lints**: `unsafe_code = "forbid"`,
+  `arithmetic_side_effects = deny`, and similar workspace-deny
+  lints apply when the tool rustdoc-compiles a _baseline_ commit
+  via git-worktree. If the baseline fails to compile under
+  tightened lints (possible after a lint bump), the job fails for
+  reasons unrelated to the API surface.
+  `cargo-public-api` inherits `cargo-semver-checks`'s workaround:
+  `RUSTFLAGS="--cap-lints=warn"` on the step env as a last resort.
+  This is cross-linked from
+  [`semver-policy.md §"Known caveats"`](semver-policy.md#known-caveats)
+  rather than duplicated here.
+- **`publish = false` members are skipped** by the jq filter
+  (`select(.publish != [])`). Today that's `mango-proto`,
+  `mango-loom-demo`, and `xtask-vet-ttl`. When a member flips to
+  publishable in Phase 6+, `cargo metadata` picks it up
+  automatically — no workflow edit needed.
+- **Zero publishable members edge case.** If `mango` flips to
+  `publish = false`, the loop body never runs and the job passes.
+  An empty public surface can't regress, so this is correct.
+- **New crate added in this PR** (HEAD has `mango-foo`, BASE
+  doesn't). `cargo public-api diff BASE..HEAD --package mango-foo`
+  fails to rustdoc-compile the baseline (crate doesn't exist
+  there). The workflow intersects the publishable-member set
+  between BASE and HEAD: crates present only in HEAD emit a
+  `::notice::` annotation ("new publishable crate — no baseline
+  to diff against") and are skipped. Their diff gets reviewed by
+  human reviewers, which is the right granularity for a
+  new-crate PR anyway.
+- **Tool error vs non-empty diff.** Even with `--deny all`, exit 1
+  could mean "diff present" OR "tool crashed internally". Advisory
+  mode can't tell them apart without parsing output. We accept
+  this — advisory is advisory, failure surfaces both ways as a
+  `::warning::`. Gating mode (Phase 6) will need a structured mode
+  upstream if one ships; out of scope today.
+- **Baseline build cost** compounds as the workspace grows. Today
+  it's one placeholder crate; Phase 1–6 will add more. If CI
+  wall-clock becomes a problem, cache rustdoc JSON per-baseline-SHA
+  (same trick `semver-policy.md` earmarks for its tool). On deck,
+  not implemented.
+- **Cache-miss rebuild cost.** First run on a fresh runner builds
+  `cargo-public-api` from source (~90s). Steady state ~30-45s cold
+  compile + ~60-90s first-ever run on a fresh cache. If this
+  becomes a regular pain point in Phase 6, switch install to
+  `taiki-e/install-action` for the prebuilt binary. Current runner
+  cache hit rate is high enough to keep the `cargo install --locked`
+  precedent for now.
+
+## Harness
+
+[`scripts/public-api-scripts-test.sh`](../scripts/public-api-scripts-test.sh)
+is the self-test for the workflow file. It asserts:
+
+- Workflow file exists (skipped gracefully when absent, so the
+  script can land in a commit before the workflow does).
+- `CARGO_PUBLIC_API_VERSION` is declared as `x.y.z`.
+- `PUBLIC_API_NIGHTLY` is declared as `nightly-YYYY-MM-DD`.
+- Checkout step sets `fetch-depth: 0`.
+- `PUBLIC-API-MODE` sentinel is present.
+- **Tri-consistency**: sentinel ↔ `continue-on-error` ↔ `--deny` all
+  agree. If sentinel says `advisory`, `continue-on-error` is true
+  AND `--deny` is present. If `gating`, `continue-on-error` is
+  false AND `--deny` is present. `--deny` is mandatory in both
+  modes (without it, exit-code semantics mean the whole gate is a
+  silent no-op).
+- The `::warning::` annotation step exists.
+- Required path filters are present.
+- Both `stable` and nightly `dtolnay/rust-toolchain` uses: steps
+  are present.
+- The publishable-member jq filter works on a synthetic fixture:
+  given three packages (one `publish: null`, one `publish: []`,
+  one `publish: ["crates-io"]`), it emits exactly the two
+  publishable names.
+- This policy doc exists (so workflow cross-links aren't broken).
+
+It runs as a step in the workflow and can be run locally:
+
+```bash
+bash scripts/public-api-scripts-test.sh
+```
+
+## File inventory
+
+| File                                 | Role               | Hand-edited? |
+| ------------------------------------ | ------------------ | ------------ |
+| `.github/workflows/public-api.yml`   | CI gate            | yes          |
+| `scripts/public-api-scripts-test.sh` | workflow self-test | yes          |
+| `docs/public-api-policy.md`          | this doc           | yes          |
+
+## Relationship to `cargo-semver-checks`
+
+`cargo-public-api` prints a human-readable syntactic diff of a
+crate's public surface. `cargo-semver-checks` **judges** whether
+such a diff is a semver violation (trait-bound tightening, lost
+derives, added required generics, etc.). Both are useful and both
+ship as advisory-now, gating-at-Phase-6. They run as sibling
+workflows because:
+
+- Each pins a different tool (and `cargo-public-api` additionally
+  pins a nightly toolchain, which `cargo-semver-checks` doesn't
+  need).
+- GitHub's required-check surface benefits from one status row
+  per tool — reviewers see both signals independently.
+- Phase 6 may stage the flips (semver-checks first, public-api
+  second) depending on upstream UX.
+
+See [`docs/semver-policy.md`](semver-policy.md) for the sibling
+tool's policy.

--- a/docs/public-api-policy.md
+++ b/docs/public-api-policy.md
@@ -111,11 +111,17 @@ git fetch origin main
 cargo install --locked cargo-public-api --version <pin>
 rustup install <nightly-pin>
 
-# Run from repo root. --manifest-path is explicit as a guard against
-# accidentally running from a crate subdirectory (where --package
-# would silently resolve to a different workspace).
-cargo public-api \
-    --manifest-path "$(git rev-parse --show-toplevel)/Cargo.toml" \
+# Invoke via the `cargo +<toolchain>` rustup proxy. cargo-public-api
+# 0.51.0 inspects `cargo --version` to decide which toolchain to use;
+# under the proxy, `cargo --version` reports nightly and the tool
+# uses the pinned nightly end-to-end. Running on stable (without the
+# proxy) makes the tool hardcode the literal "nightly" toolchain
+# name, which may not be installed.
+#
+# --manifest-path points at the crate's OWN manifest. The tool
+# rejects virtual (workspace-root) manifests up front.
+cargo +<nightly-pin> public-api \
+    --manifest-path "$(git rev-parse --show-toplevel)/crates/mango/Cargo.toml" \
     --package mango \
     --omit blanket-impls,auto-trait-impls,auto-derived-impls \
     diff \
@@ -131,10 +137,10 @@ The `git fetch` is load-bearing — a stale local `origin/main`
 produces spurious deltas.
 
 **Toolchain channel**: unlike `cargo-semver-checks` (stable-only),
-`cargo-public-api` REQUIRES a nightly rustdoc. Running locally on
-stable-only will fail with a rustdoc-JSON-format error. The tool
-auto-invokes nightly if installed; you don't need to
-`rustup default nightly`.
+`cargo-public-api` REQUIRES a nightly rustdoc. Running locally
+without the `+<nightly>` proxy will fail with a "toolchain not
+installed" error (the tool falls back to the literal floating
+`nightly`). The proxy is the supported local invocation.
 
 ### Synthetic-change smoke
 
@@ -146,8 +152,8 @@ echo '' >> crates/mango/src/lib.rs
 echo '/// Smoke test — delete before committing.' >> crates/mango/src/lib.rs
 echo 'pub fn smoke_change() {}' >> crates/mango/src/lib.rs
 
-cargo public-api \
-    --manifest-path "$(git rev-parse --show-toplevel)/Cargo.toml" \
+cargo +<nightly-pin> public-api \
+    --manifest-path "$(git rev-parse --show-toplevel)/crates/mango/Cargo.toml" \
     --package mango \
     --omit blanket-impls,auto-trait-impls,auto-derived-impls \
     diff --deny all origin/main..HEAD
@@ -247,11 +253,21 @@ once after shipping, and after any pin bump):
   doesn't). `cargo public-api diff BASE..HEAD --package mango-foo`
   fails to rustdoc-compile the baseline (crate doesn't exist
   there). The workflow intersects the publishable-member set
-  between BASE and HEAD: crates present only in HEAD emit a
-  `::notice::` annotation ("new publishable crate — no baseline
-  to diff against") and are skipped. Their diff gets reviewed by
-  human reviewers, which is the right granularity for a
-  new-crate PR anyway.
+  between BASE and HEAD via `git cat-file -e
+BASE_SHA:crates/<pkg>/Cargo.toml`: crates present only in HEAD
+  emit a `::notice::` annotation ("new publishable crate — no
+  baseline to diff against") and are skipped. Their diff gets
+  reviewed by human reviewers, which is the right granularity for
+  a new-crate PR anyway.
+- **Crate-dir/package-name convention.** The new-crate-in-PR
+  probe and the `--manifest-path` argument both assume
+  `crates/<pkg-name>/Cargo.toml` — directory name equals package
+  name. The `crates/mango-*` roadmap naming rule (ROADMAP.md)
+  preserves this. A contributor who writes `crates/foo/Cargo.toml`
+  with `[package] name = "mango-foo"` breaks both the probe (false
+  "new in PR" classification) AND the invocation (wrong path);
+  rust-expert reviewers will catch it at PR time. Structural
+  enforcement via cargo-metadata path lookup is a follow-up.
 - **Tool error vs non-empty diff.** Even with `--deny all`, exit 1
   could mean "diff present" OR "tool crashed internally". Advisory
   mode can't tell them apart without parsing output. We accept

--- a/docs/semver-policy.md
+++ b/docs/semver-policy.md
@@ -10,8 +10,9 @@ The machinery behind this policy:
 - **`cargo-semver-checks`** — this doc's subject. Runs in
   [`.github/workflows/semver-checks.yml`](../.github/workflows/semver-checks.yml)
   on every PR that touches a crate's source or manifest.
-- **`cargo-public-api`** (future, ROADMAP:802) — complementary
-  surface-level diff tool. Not shipped yet.
+- **`cargo-public-api`** — complementary surface-level diff tool.
+  Runs in [`.github/workflows/public-api.yml`](../.github/workflows/public-api.yml);
+  policy at [`docs/public-api-policy.md`](public-api-policy.md).
 
 `cargo-semver-checks` catches violations the public-API surface alone
 doesn't reveal: tightening a trait bound, removing a
@@ -218,11 +219,12 @@ bash scripts/semver-scripts-test.sh
 
 ## Relationship to `cargo-public-api`
 
-`cargo-public-api` (future ROADMAP:802) prints a human-readable diff
-of a crate's public surface. It's great for PR-review triage but is
-syntactic — it doesn't reason about trait-bound tightening or
-semver implications. `cargo-semver-checks` is the tool that actually
-**judges** whether a diff is a semver violation.
+`cargo-public-api` prints a human-readable diff of a crate's public
+surface. It's great for PR-review triage but is syntactic — it
+doesn't reason about trait-bound tightening or semver implications.
+`cargo-semver-checks` is the tool that actually **judges** whether
+a diff is a semver violation.
 
 Both ship as advisory-now, gating-at-Phase-6. They're complementary,
-not redundant.
+not redundant. See [`docs/public-api-policy.md`](public-api-policy.md)
+for the sibling tool's policy.

--- a/scripts/public-api-scripts-test.sh
+++ b/scripts/public-api-scripts-test.sh
@@ -162,7 +162,12 @@ scenario="tri-consistency: sentinel ↔ continue-on-error ↔ --deny"
 if [ "$workflow_present" = "1" ] && [ -n "$mode" ]; then
     coe_line="$(printf '%s\n' "$normalized" | grep -E '^ *continue-on-error: (true|false)' | head -n 1 || true)"
     has_deny=0
-    if grep -qE -- '--deny(\s|=)' "$workflow"; then
+    # Match --deny followed by a DenyMethod variant on a non-comment
+    # line only. The workflow has a header comment mentioning --deny,
+    # and a naive `grep '--deny'` would match it — masking a real
+    # regression where the invocation itself drops the flag.
+    if grep -v '^[[:space:]]*#' "$workflow" \
+        | grep -qE -- '--deny[[:space:]]+(all|added|changed|removed)'; then
         has_deny=1
     fi
 

--- a/scripts/public-api-scripts-test.sh
+++ b/scripts/public-api-scripts-test.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# scripts/public-api-scripts-test.sh
+#
+# Smoke-test harness for the cargo-public-api CI gate.
+#
+# What this covers:
+#   - .github/workflows/public-api.yml has the structural invariants
+#     the CI gate depends on (version pins, fetch-depth, sentinel
+#     tri-consistency with continue-on-error and --deny, loud-warning
+#     step, path filters, dual-toolchain install).
+#   - docs/public-api-policy.md exists (workflow comments link to it;
+#     broken links turn a runtime failure into a tooling-trust
+#     failure).
+#   - The publishable-member jq filter works against a synthetic
+#     cargo-metadata fixture.
+#
+# Workflow-absent behavior:
+#   This script is committed BEFORE the workflow file lands (to keep
+#   commits atomic). Workflow-shape assertions print SKIP when the
+#   workflow file is absent. Non-workflow assertions (jq filter
+#   fixture, policy doc existence) run unconditionally. Once the
+#   workflow lands, the self-test runs as a step inside the workflow
+#   where the file is always present, so SKIP is no longer reachable
+#   and the assertions are as strong as semver-scripts-test.sh's.
+#
+# What this does NOT cover:
+#   - Running `cargo public-api` itself. That runs as a dedicated
+#     workflow step after this harness — duplicating it here only
+#     doubles CI wall-clock.
+#   - The tool's own diff logic. cargo-public-api has its own
+#     extensive test suite upstream; we gain nothing by reimplementing.
+#
+# Invocation:
+#   bash scripts/public-api-scripts-test.sh
+#   (run from any CWD; script cd's to repo root)
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+pass() {
+    printf 'PASS  %s\n' "$1"
+    pass_count=$((pass_count + 1))
+}
+
+fail() {
+    printf 'FAIL  %s\n' "$1" >&2
+    fail_count=$((fail_count + 1))
+}
+
+skip() {
+    printf 'SKIP  %s\n' "$1"
+    skip_count=$((skip_count + 1))
+}
+
+workflow=".github/workflows/public-api.yml"
+policy_doc="docs/public-api-policy.md"
+
+# ---------------------------------------------------------------------
+# workflow presence — sbom-style skip pattern (graceful absence).
+# Once the workflow lands in commit 3, this branch is unreachable.
+# ---------------------------------------------------------------------
+workflow_present=0
+scenario="workflow file exists"
+if [ -f "$workflow" ]; then
+    pass "$scenario"
+    workflow_present=1
+else
+    skip "$scenario (will assert once commit 3 lands)"
+fi
+
+# Normalize whitespace for pattern-based assertions below.
+# Only meaningful when workflow_present=1; guard each block.
+if [ "$workflow_present" = "1" ]; then
+    normalized="$(tr -s ' \t' ' ' < "$workflow")"
+fi
+
+# ---------------------------------------------------------------------
+# CARGO_PUBLIC_API_VERSION: parseable as x.y.z
+# ---------------------------------------------------------------------
+scenario="CARGO_PUBLIC_API_VERSION is parseable as x.y.z"
+if [ "$workflow_present" = "1" ]; then
+    if grep -qE '^\s*CARGO_PUBLIC_API_VERSION:\s*"[0-9]+\.[0-9]+\.[0-9]+"' "$workflow"; then
+        pass "$scenario"
+    else
+        fail "$scenario: CARGO_PUBLIC_API_VERSION line not found or malformed in $workflow"
+    fi
+else
+    skip "$scenario"
+fi
+
+# ---------------------------------------------------------------------
+# PUBLIC_API_NIGHTLY: parseable as nightly-YYYY-MM-DD
+# Dual-pin coupling: tool version and nightly toolchain must move
+# together. Upstream bumps the minimum-supported nightly periodically;
+# bumping the tool without the nightly produces rustdoc-JSON-format
+# errors that look unrelated. The policy doc's bump procedure mandates
+# updating both; this assertion keeps the pin well-formed.
+# ---------------------------------------------------------------------
+scenario="PUBLIC_API_NIGHTLY is parseable as nightly-YYYY-MM-DD"
+if [ "$workflow_present" = "1" ]; then
+    if grep -qE '^\s*PUBLIC_API_NIGHTLY:\s*"nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}"' "$workflow"; then
+        pass "$scenario"
+    else
+        fail "$scenario: PUBLIC_API_NIGHTLY line not found or malformed in $workflow"
+    fi
+else
+    skip "$scenario"
+fi
+
+# ---------------------------------------------------------------------
+# fetch-depth on checkout
+# ---------------------------------------------------------------------
+# `diff BASE..HEAD` needs the base commit present locally.
+# actions/checkout defaults to depth 1.
+scenario="checkout step sets fetch-depth: 0"
+if [ "$workflow_present" = "1" ]; then
+    if grep -qE '^\s*fetch-depth:\s*0\s*$' "$workflow"; then
+        pass "$scenario"
+    else
+        fail "$scenario: fetch-depth: 0 not found in $workflow"
+    fi
+else
+    skip "$scenario"
+fi
+
+# ---------------------------------------------------------------------
+# PUBLIC-API-MODE sentinel present
+# ---------------------------------------------------------------------
+mode=""
+scenario="PUBLIC-API-MODE sentinel is present"
+if [ "$workflow_present" = "1" ]; then
+    mode_line="$(printf '%s\n' "$normalized" | grep -E '# PUBLIC-API-MODE: (advisory|gating)' | head -n 1 || true)"
+    if [ -n "$mode_line" ]; then
+        pass "$scenario"
+        mode="$(printf '%s' "$mode_line" | sed -E 's/.*PUBLIC-API-MODE: ([a-z]+).*/\1/')"
+    else
+        fail "$scenario: '# PUBLIC-API-MODE: advisory|gating' not found in $workflow"
+    fi
+else
+    skip "$scenario"
+fi
+
+# ---------------------------------------------------------------------
+# Tri-consistency: sentinel ↔ continue-on-error ↔ --deny
+#
+# --deny all is MANDATORY in both advisory and gating modes. Without
+# it, `cargo public-api diff` returns 0 on a non-empty diff and the
+# continue-on-error / ::warning:: wiring becomes a silent no-op. The
+# Phase-6 flip is sentinel + continue-on-error (two lines); --deny
+# stays in place across the flip.
+#
+# - sentinel=advisory → continue-on-error: true AND --deny present
+# - sentinel=gating   → continue-on-error: false AND --deny present
+# ---------------------------------------------------------------------
+scenario="tri-consistency: sentinel ↔ continue-on-error ↔ --deny"
+if [ "$workflow_present" = "1" ] && [ -n "$mode" ]; then
+    coe_line="$(printf '%s\n' "$normalized" | grep -E '^ *continue-on-error: (true|false)' | head -n 1 || true)"
+    has_deny=0
+    if grep -qE -- '--deny(\s|=)' "$workflow"; then
+        has_deny=1
+    fi
+
+    coe_ok=0
+    if [ "$mode" = "advisory" ] && printf '%s' "$coe_line" | grep -q 'true'; then
+        coe_ok=1
+    elif [ "$mode" = "gating" ] && printf '%s' "$coe_line" | grep -q 'false'; then
+        coe_ok=1
+    fi
+
+    if [ -z "$coe_line" ]; then
+        fail "$scenario: no continue-on-error line found"
+    elif [ "$coe_ok" != "1" ]; then
+        fail "$scenario: mode=$mode but continue-on-error line was: $coe_line"
+    elif [ "$has_deny" != "1" ]; then
+        fail "$scenario: --deny flag missing from workflow (exit-code semantics require it in BOTH modes)"
+    else
+        pass "$scenario (mode=$mode, continue-on-error ok, --deny present)"
+    fi
+else
+    skip "$scenario"
+fi
+
+# ---------------------------------------------------------------------
+# Loud-warning step: advisory mode without a visible signal is worse
+# than no gate. The workflow must emit a ::warning:: annotation on
+# check failure.
+# ---------------------------------------------------------------------
+scenario="advisory failure is surfaced as ::warning:: annotation"
+if [ "$workflow_present" = "1" ]; then
+    if grep -qF '::warning title=public-api advisory::' "$workflow"; then
+        pass "$scenario"
+    else
+        fail "$scenario: no ::warning title=public-api advisory:: line in $workflow"
+    fi
+else
+    skip "$scenario"
+fi
+
+# ---------------------------------------------------------------------
+# Path filters: load-bearing paths on pull_request.
+# ---------------------------------------------------------------------
+scenario="pull_request paths include the load-bearing entries"
+if [ "$workflow_present" = "1" ]; then
+    # Disable shell globbing around the loop so ** patterns match as
+    # literal strings, not against the local filesystem.
+    set -f
+    missing=""
+    for p in 'crates/**/src/**' 'crates/**/Cargo.toml' 'Cargo.toml' 'Cargo.lock'; do
+        pattern_escaped="${p//\*/\\*}"
+        if ! grep -qE "^\s*-\s*[\"']${pattern_escaped}[\"']\s*$" "$workflow"; then
+            missing="$missing $p"
+        fi
+    done
+    set +f
+    if [ -z "$missing" ]; then
+        pass "$scenario"
+    else
+        fail "$scenario: missing path filter entries:$missing"
+    fi
+else
+    skip "$scenario"
+fi
+
+# ---------------------------------------------------------------------
+# Dual-toolchain install: stable active + nightly installed.
+# `cargo-public-api` consumes nightly rustdoc JSON but stable must
+# be active (the rest of CI assumes stable). Two dtolnay/rust-toolchain
+# uses: blocks, one per channel.
+# ---------------------------------------------------------------------
+scenario="dual toolchain install present (stable + nightly)"
+if [ "$workflow_present" = "1" ]; then
+    # Count distinct dtolnay/rust-toolchain uses: blocks.
+    uses_count="$(grep -cE '^\s*-\s*uses:\s*dtolnay/rust-toolchain' "$workflow" || true)"
+    if [ "${uses_count:-0}" -ge 2 ]; then
+        # And both `toolchain:` values must appear: stable and the
+        # PUBLIC_API_NIGHTLY env reference.
+        has_stable=0
+        has_nightly=0
+        if grep -qE '^\s*toolchain:\s*stable\s*$' "$workflow"; then
+            has_stable=1
+        fi
+        if grep -qE 'toolchain:\s*\$\{\{\s*env\.PUBLIC_API_NIGHTLY\s*\}\}' "$workflow"; then
+            has_nightly=1
+        fi
+        if [ "$has_stable" = "1" ] && [ "$has_nightly" = "1" ]; then
+            pass "$scenario"
+        else
+            fail "$scenario: 2+ toolchain uses: blocks but stable=$has_stable, nightly=$has_nightly"
+        fi
+    else
+        fail "$scenario: expected 2+ dtolnay/rust-toolchain uses: blocks, got ${uses_count:-0}"
+    fi
+else
+    skip "$scenario"
+fi
+
+# ---------------------------------------------------------------------
+# Publishable-member jq filter — unit test against synthetic fixture.
+# Runs unconditionally (no workflow dependency): this guards the jq
+# filter documented in docs/public-api-policy.md and embedded in the
+# workflow. If the filter ever drifts, new publishable crates would
+# be silently skipped (or publish=false crates included).
+# ---------------------------------------------------------------------
+scenario="publishable-member jq filter against synthetic fixture"
+if ! command -v jq >/dev/null 2>&1; then
+    fail "$scenario: jq not found on PATH"
+else
+    # Three packages:
+    #   a: publish=null         (default, publishable)      → INCLUDE
+    #   b: publish=[]           (publish = false)           → EXCLUDE
+    #   c: publish=["crates-io"] (registry allow-list)      → INCLUDE
+    # The `source` filter excludes dependencies pulled from registries
+    # (source != null for those; source == null for workspace members).
+    got="$(printf '%s' '{"packages":[
+        {"publish":null,"source":null,"name":"a"},
+        {"publish":[],"source":null,"name":"b"},
+        {"publish":["crates-io"],"source":null,"name":"c"},
+        {"publish":null,"source":"registry+https://github.com/rust-lang/crates.io-index","name":"d"}
+    ]}' \
+        | jq -r '.packages[]
+                 | select(.source == null)
+                 | select(.publish != [])
+                 | .name' \
+        | tr '\n' ' ' | sed 's/ *$//')"
+    want="a c"
+    if [ "$got" = "$want" ]; then
+        pass "$scenario (got: $got)"
+    else
+        fail "$scenario: want '$want', got '$got'"
+    fi
+fi
+
+# ---------------------------------------------------------------------
+# Policy doc presence — workflow comments link to it.
+# Runs unconditionally.
+# ---------------------------------------------------------------------
+scenario="policy doc exists"
+if [ -f "$policy_doc" ]; then
+    pass "$scenario"
+else
+    fail "$scenario: $policy_doc missing"
+fi
+
+# ---------------------------------------------------------------------
+# summary
+# ---------------------------------------------------------------------
+printf '\n%d passed, %d failed, %d skipped\n' "$pass_count" "$fail_count" "$skip_count"
+if [ "$fail_count" -ne 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Roadmap item

`ROADMAP.md:802` — Add `cargo-public-api` CI check (advisory pre-Phase-6, gating from Phase 6 onwards), alongside `cargo-semver-checks` once Phase 6 ships.

## Summary

Lands a CI gate that prints the diff of every publishable workspace crate's **public API surface** against the PR base. Surfaced as a GitHub `::warning::` annotation pre-Phase-6. Complements the shipped `cargo-semver-checks` gate — this one answers "what symbols changed?", the sibling answers "is that change a semver violation?".

Same precedent-mirroring shape as the shipped `cargo-semver-checks` gate, with two deliberate deviations:

1. **Self-test uses sbom-style skip pattern** (not semver-style hard-fail) on the workflow-presence check, so commit 2 can land atomically before commit 3.
2. **Dual pin** — `CARGO_PUBLIC_API_VERSION` + `PUBLIC_API_NIGHTLY`. `cargo-public-api` consumes nightly rustdoc JSON, so a pinned nightly toolchain ships alongside the tool version. Bump procedure in the policy doc mandates moving both together.

Three atomic commits:

1. **`docs(public-api):`** — `docs/public-api-policy.md` + one-section update to `docs/semver-policy.md` cross-linking the sibling.
2. **`feat(public-api):`** — `scripts/public-api-scripts-test.sh` (11 structural assertions; 2 run, 9 skip in workflow-absent state).
3. **`ci(public-api):`** — `.github/workflows/public-api.yml`. Gate turns on; all 11 self-test assertions become active.

## Key design decisions (from rust-expert's plan review)

- **`--deny all` on the diff invocation** (rust-expert Showstopper 1). Without it, `cargo public-api diff` returns exit 0 on a non-empty diff and the `continue-on-error` / `::warning::` wiring becomes a silent no-op. `--deny all` ships in advisory mode from day one; the Phase-6 flip is still **two lines** (sentinel + continue-on-error), `--deny` stays across the flip. Self-test asserts sentinel ↔ continue-on-error ↔ --deny tri-consistency.
- **Self-test skip pattern** (rust-expert Showstopper 2). `if [ -f "$workflow" ]` → `SKIP` when absent, same as `sbom-scripts-test.sh`. Once commit 3 lands, the script runs as a workflow step where the file always exists.
- **`--omit blanket-impls,auto-trait-impls,auto-derived-impls`** instead of `--simplified` — explicit suppression list is auditable and decomposable in Phase 6.
- **Per-crate iteration via `cargo metadata | jq`** — cargo-public-api lacks `--workspace`. Filter: `select(.source == null) | select(.publish != [])` matches what `cargo-semver-checks --workspace` does internally.
- **New-crate-in-PR handling** — HEAD ∩ BASE intersection via `git cat-file -e ${BASE_SHA}:crates/${pkg}/Cargo.toml`. Crates present only in HEAD emit a `::notice::` and skip (no baseline to diff against).
- **Standalone workflow** (not folded into semver-checks.yml) — nightly-install is unique to this gate, GitHub's required-check surface benefits from one status row per tool, and Phase 6 may stage the flips.

## Test plan

- [x] Self-test passes locally in workflow-absent state (2 pass / 9 skip).
- [x] Self-test passes locally with workflow present (11 pass / 0 skip / 0 fail).
- [x] Real `cargo metadata | jq` filter against the current workspace emits only `mango` (the three `publish = false` members excluded).
- [x] jq filter unit test covers 4 synthetic cases (publish=null, publish=[], publish=["crates-io"], non-null source).
- [ ] CI `public-api` job runs green against this PR (no publishable-surface changes — docs/workflow/script only).
- [ ] All other required CI checks green.

## Files

| File                                 | Change                                                    |
| ------------------------------------ | --------------------------------------------------------- |
| `.github/workflows/public-api.yml`   | NEW                                                       |
| `scripts/public-api-scripts-test.sh` | NEW                                                       |
| `docs/public-api-policy.md`          | NEW                                                       |
| `docs/semver-policy.md`              | Cross-link to new policy (removes "not shipped yet" refs) |
| `ROADMAP.md`                         | Flip to done on `main` post-merge                         |

No crate source edits. No `Cargo.toml` changes. No new deps.

Generated with Claude Code.
