### PR TITLE
ci(madsim): madsim dev-dep + CI gate (ROADMAP 0.5.3)

### DIFF
--- a/.github/workflows/madsim.yml
+++ b/.github/workflows/madsim.yml
@@ -101,15 +101,19 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-
-      # MSRV toolchain — installed alongside stable so the MSRV
-      # compile-check below can invoke `cargo +1.80` via the rustup
-      # proxy. Pinned exactly to workspace.package.rust-version.
+      # MSRV toolchain installed FIRST so the final
+      # `dtolnay/rust-toolchain` call (stable, below) becomes the
+      # rustup default. If MSRV were installed last, default would
+      # flip to 1.80 and `cargo fetch --locked` would reject
+      # `wit-bindgen` (edition2024 unstable on 1.80). Same failure
+      # mode as Issue #23 / task #15. See
+      # .planning/msrv-wit-bindgen-fix.plan.md for the incident.
       - name: install MSRV toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           toolchain: ${{ env.MSRV }}
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (default toolchain)
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:

--- a/.github/workflows/madsim.yml
+++ b/.github/workflows/madsim.yml
@@ -1,0 +1,200 @@
+# Mango madsim workflow
+#
+# Runs `cargo nextest run` against the curated subset declared in
+# `[workspace.metadata.mango.madsim]` (see scripts/madsim-crates.sh)
+# under `RUSTFLAGS="--cfg madsim"`. The cfg flips the
+# workspace-renamed `tokio` (= `madsim-tokio`) re-export from real
+# tokio to the deterministic simulator at link time — source in
+# `crates/mango-madsim-demo/src/lib.rs` is unchanged across profiles.
+#
+# Orthogonal to loom/miri:
+#   - loom permutes interleavings of a tiny model to prove an
+#     ordering invariant.
+#   - miri interprets a single execution to detect UB in unsafe.
+#   - madsim replaces the async runtime with a deterministic
+#     scheduler, so message ordering, task interleaving, and
+#     timer firing are reproducible from a fixed seed.
+# All three coexist; each owns a different class of bug.
+#
+# Separate workflow from ci.yml because the madsim build uses
+# RUSTFLAGS="--cfg madsim", which is ABI-incompatible with the
+# default build cache. Sharing a Swatinem/rust-cache scope would
+# thrash; separate job → separate cache prefix (`v0-madsim`).
+# Per-invocation `--target-dir target/madsim` further isolates the
+# build artifacts so a local developer alternating `cargo test` and
+# the madsim build does not invalidate either cache.
+#
+# Pinned seeds: MADSIM_TEST_SEED and MADSIM_TEST_NUM are set at the
+# workflow-top so a failure is reproducible. Bump the seed only when
+# adding new sim tests that need wider exploration; rotating the
+# seed without reason would mask a flake as a new bug.
+#
+# Path filter: this workflow only runs when madsim-relevant files
+# change. Required-check policy (branch protection) should list
+# "madsim" with `require_for_changed_paths` so the check stays green
+# when the path filter skips it.
+#
+# Security: no `github.event.*` interpolation inside `run:` blocks.
+# All inputs are static; dynamic GITHUB_* usage is limited to the
+# `concurrency.group` expression (ref name, GitHub-sanitized).
+# Pattern mirrors loom.yml and miri.yml hardening precedent.
+
+name: madsim
+
+on:
+  pull_request:
+    paths:
+      - "crates/**/src/**"
+      - "crates/**/tests/**"
+      - "crates/**/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/madsim.yml"
+      - "scripts/madsim-crates.sh"
+      - "scripts/madsim-scripts-test.sh"
+      - ".config/nextest.toml"
+      - "docs/madsim.md"
+  push:
+    branches: [main]
+    paths:
+      - "crates/**/src/**"
+      - "crates/**/tests/**"
+      - "crates/**/Cargo.toml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/madsim.yml"
+      - "scripts/madsim-crates.sh"
+      - "scripts/madsim-scripts-test.sh"
+      - ".config/nextest.toml"
+      - "docs/madsim.md"
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  # Fixed seed + iteration count. See docs/madsim.md section on CI
+  # invocation. Bumping MADSIM_TEST_NUM trades CI minutes for
+  # exploration depth; 10 is the smoke-level default. Flipping
+  # MADSIM_TEST_SEED rotates the schedule space and is a knob for
+  # triaging a seed-specific flake; don't rotate by default.
+  MADSIM_TEST_SEED: "1"
+  MADSIM_TEST_NUM: "10"
+  # MSRV pin; mirrors workspace.package.rust-version. Used by the
+  # MSRV check step to prove the curated subset compiles on the
+  # oldest supported toolchain under `--cfg madsim`.
+  MSRV: "1.80"
+
+jobs:
+  madsim:
+    name: madsim
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      # MSRV toolchain — installed alongside stable so the MSRV
+      # compile-check below can invoke `cargo +1.80` via the rustup
+      # proxy. Pinned exactly to workspace.package.rust-version.
+      - name: install MSRV toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: ${{ env.MSRV }}
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          # Separate from ci.yml and loom.yml caches. The `--cfg
+          # madsim` build produces different artifacts (the renamed
+          # `tokio` crate resolves to the simulator's code path);
+          # colliding with the default cache invalidates it on every
+          # run. Prefix scopes isolate the two build graphs.
+          prefix-key: v0-madsim
+          shared-key: ""
+
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458  # v2
+        with:
+          tool: cargo-nextest
+
+      - name: cargo fetch
+        run: cargo fetch --locked
+
+      - name: madsim scripts self-test
+        run: bash scripts/madsim-scripts-test.sh
+
+      - name: enumerate curated subset
+        run: |
+          set -euo pipefail
+          crates=$(bash scripts/madsim-crates.sh)
+          if [ -z "$crates" ]; then
+              echo "error: curated subset is empty; madsim has nothing to run" >&2
+              exit 1
+          fi
+          echo "Curated subset:"
+          printf '  %s\n' $crates
+          echo "MADSIM_CRATES=$(printf '%s ' $crates)" >> "${GITHUB_ENV}"
+
+      # The canonical madsim invocation.
+      #
+      # --cfg madsim: swaps the workspace-renamed `tokio` (=
+      #   `madsim-tokio`) from real tokio to the simulator at link
+      #   time. See docs/madsim.md section on the rename.
+      # --target-dir target/madsim: isolates the `--cfg madsim` build
+      #   graph from the default cache so alternating builds don't
+      #   invalidate each other.
+      # --profile ci: inherits the nextest timeouts from
+      #   .config/nextest.toml.
+      # Per-crate loop: nextest does not multiplex `-p` args across
+      #   different RUSTFLAGS; looping keeps the invocation explicit
+      #   and makes per-crate logs easy to find via ::group::.
+      - name: cargo nextest run (--cfg madsim)
+        env:
+          MADSIM_CRATES: ${{ env.MADSIM_CRATES }}
+          RUSTFLAGS: "--cfg madsim"
+        run: |
+          set -euo pipefail
+          for crate in ${MADSIM_CRATES}; do
+              echo "::group::nextest run ${crate} (--cfg madsim)"
+              cargo nextest run \
+                  --profile ci \
+                  --target-dir target/madsim \
+                  -p "${crate}"
+              echo "::endgroup::"
+          done
+
+      # MSRV compile check under `--cfg madsim`. Complements the
+      # stable-toolchain test above: proves that the pinned madsim
+      # crates (=0.2.30) compile on the workspace's rust-version
+      # floor. Check-only (not test) — MSRV is a compile contract,
+      # not a runtime contract.
+      # MSRV toolchain referenced via `cargo +${{ env.MSRV }}`.
+      # YAML-level expansion (NOT a `run:`-time shell expansion)
+      # produces the literal string `cargo +1.80` at workflow-dispatch
+      # time. The expansion is safe because `env.MSRV` is declared as
+      # a static literal at workflow-top — it never carries untrusted
+      # input. See scripts/madsim-scripts-test.sh for the matching
+      # regex that asserts the MSRV-pinned invocation is present.
+      - name: cargo check (MSRV, --cfg madsim)
+        env:
+          MADSIM_CRATES: ${{ env.MADSIM_CRATES }}
+          RUSTFLAGS: "--cfg madsim"
+        run: |
+          set -euo pipefail
+          for crate in ${MADSIM_CRATES}; do
+              echo "::group::check (MSRV ${{ env.MSRV }}, --cfg madsim) ${crate}"
+              cargo +${{ env.MSRV }} check \
+                  --target-dir target/madsim-msrv \
+                  -p "${crate}" \
+                  --all-targets
+              echo "::endgroup::"
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,16 @@ with worked examples: [`docs/arithmetic-policy.md`][arith].
   ship with a `loom` model that exercises its ordering invariants;
   see [`docs/loom.md`](./docs/loom.md) and the template crate
   [`crates/mango-loom-demo`](./crates/mango-loom-demo/).
+- **madsim (deterministic simulation).** Any crate introducing an
+  async primitive (spawns tokio tasks, uses tokio channels / timers,
+  or serves tonic RPCs) must also add itself to
+  `[workspace.metadata.mango.madsim]` in the workspace
+  [`Cargo.toml`](./Cargo.toml) **in the same PR**, and ship at
+  least one `#[madsim::test]` test paired with a real-tokio
+  `#[tokio::test]` test. The template crate
+  [`crates/mango-madsim-demo`](./crates/mango-madsim-demo/) is the
+  canonical starting point; full policy:
+  [`docs/madsim.md`](./docs/madsim.md).
 - **Miri.** Any crate introducing `unsafe` must also add itself to
   `[workspace.metadata.mango.miri]` in the workspace
   [`Cargo.toml`](./Cargo.toml) **in the same PR**. That table is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +29,55 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -46,6 +108,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +165,12 @@ checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -77,6 +195,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +234,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +294,17 @@ dependencies = [
  "rustversion",
  "windows-link 0.2.1",
  "windows-result",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -132,6 +330,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -177,6 +381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +409,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "madsim"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88753ddf8d3cd43b9cf71a93626dd9aad3c24086a04420beb31922e1f856d02"
+dependencies = [
+ "ahash",
+ "async-channel",
+ "async-stream",
+ "async-task",
+ "bincode",
+ "bytes",
+ "downcast-rs",
+ "futures-util",
+ "lazy_static",
+ "libc",
+ "madsim-macros",
+ "naive-timer",
+ "panic-message",
+ "rand",
+ "rand_xoshiro",
+ "rustversion",
+ "serde",
+ "spin",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "madsim-macros"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d248e97b1a48826a12c3828d921e8548e714394bf17274dd0a93910dc946e1"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "madsim-tokio"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3eb2acc57c82d21d699119b859e2df70a91dbdb84734885a1e72be83bdecb5"
+dependencies = [
+ "madsim",
+ "spin",
+ "tokio",
+]
+
+[[package]]
 name = "mango"
 version = "0.1.0"
 
@@ -204,6 +471,14 @@ name = "mango-loom-demo"
 version = "0.1.0"
 dependencies = [
  "loom",
+]
+
+[[package]]
+name = "mango-madsim-demo"
+version = "0.1.0"
+dependencies = [
+ "madsim",
+ "madsim-tokio",
 ]
 
 [[package]]
@@ -230,10 +505,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "naive-timer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
 
 [[package]]
 name = "nu-ansi-term"
@@ -255,6 +547,18 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "panic-message"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384e52fd8fbd4cbe3c317e8216260c21a0f9134de108cea8a4dd4e7e152c472d"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "petgraph"
@@ -279,13 +583,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -323,7 +636,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -337,7 +650,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -363,6 +676,45 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "regex"
@@ -419,12 +771,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -444,7 +803,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -472,10 +831,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -495,7 +906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -539,6 +950,46 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -593,7 +1044,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -603,7 +1054,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -656,6 +1119,18 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -717,4 +1192,24 @@ version = "0.1.0"
 dependencies = [
  "time",
  "toml",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/mango",
     "crates/mango-proto",
     "crates/mango-loom-demo",
+    "crates/mango-madsim-demo",
     "crates/xtask-vet-ttl",
 ]
 # tests/fixtures/geiger-toy-workspace is a self-contained workspace
@@ -29,6 +30,16 @@ exclude = ["tests/fixtures/geiger-toy-workspace"]
 [workspace.metadata.mango.miri]
 crates = ["mango-loom-demo"]
 
+# madsim deterministic-simulation curated-subset opt-in (see
+# docs/madsim.md). A crate lands in this list the same PR that
+# starts using `tokio.workspace = true` and ships at least one
+# `#[madsim::test]` test. `.github/workflows/madsim.yml` reads
+# this list via `scripts/madsim-crates.sh`. Typos land silently
+# (Cargo does not validate metadata contents) — the regression
+# test is `scripts/madsim-scripts-test.sh`.
+[workspace.metadata.mango.madsim]
+crates = ["mango-madsim-demo"]
+
 # Exact-version pin for loom. Env-var semantics (LOOM_MAX_PREEMPTIONS,
 # LOOM_MAX_BRANCHES, etc.) and model behavior can drift between minor
 # versions; pinning exact prevents `cargo update` from silently
@@ -36,6 +47,27 @@ crates = ["mango-loom-demo"]
 # procedure.
 [workspace.dependencies]
 loom = "=0.7.2"
+
+# madsim deterministic-simulator runtime. Package-rename shape
+# per madsim's integration guide: source code writes
+# `use tokio::time::sleep;` unchanged; the rename does the swap
+# at link time. Activated by RUSTFLAGS="--cfg madsim".
+#
+# Under the default build, `madsim-tokio` re-exports real tokio.
+# Under `--cfg madsim`, it substitutes the deterministic simulator.
+#
+# `package = "madsim-tokio"` inside [workspace.dependencies] is
+# accepted by Cargo; member crates inherit the rename via
+# `tokio.workspace = true` (RisingWave uses this same pattern).
+# See docs/madsim.md §"The rename".
+#
+# Exact pins — same rationale as loom above: env-var semantics
+# (MADSIM_TEST_SEED / MADSIM_TEST_NUM) and simulator behavior
+# can drift between patch versions. Move both lines together.
+# madsim-tonic is deliberately NOT declared yet; Phase 6 adds
+# it in the same PR as the first tonic-using crate.
+tokio = { version = "=0.2.30", package = "madsim-tokio" }
+madsim = { version = "=0.2.30", features = ["macros"] }
 # Constant-time comparison primitives for secret byte compares in
 # `auth*` / `crypto*` / `token*` / `hash_chain*` modules. Enforced
 # by `scripts/ct-comparison-check.sh` per `docs/ct-comparison-policy.md`.

--- a/crates/mango-madsim-demo/Cargo.toml
+++ b/crates/mango-madsim-demo/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "mango-madsim-demo"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Canonical madsim-test template. Scaffolds the pattern Phase 3+ async crates copy. PEDAGOGICAL — not a dependency."
+publish = false
+
+# Same rationale as mango-loom-demo: this crate uses cfg-gated
+# test scaffolding and would fight workspace-level pedantic lints.
+# Opts out of workspace lint inheritance entirely; minimal local
+# policy below. Workspace lints only apply to members with
+# `[lints] workspace = true`; omitting that line is the documented
+# escape hatch (Cargo reference, RFC 3389).
+
+# `tokio` is the workspace-renamed `madsim-tokio` crate. Under the
+# default build, madsim-tokio re-exports real tokio at link time.
+# Under RUSTFLAGS="--cfg madsim", madsim-tokio substitutes its
+# simulator. Source code in src/lib.rs and tests/*.rs writes
+# `use tokio::...` unchanged in both profiles. See docs/madsim.md.
+[dependencies]
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
+
+# madsim provides #[madsim::test] via its `macros` feature.
+# Test-only dep; the library itself never references `madsim::...`.
+[dev-dependencies]
+madsim = { workspace = true }
+
+[lints.rust]
+unsafe_code = "forbid"
+unreachable_pub = "warn"
+# `--cfg madsim` is the ecosystem-standard activation mechanism
+# (see docs/madsim.md). Declare the cfg here so rustc's
+# unexpected_cfgs lint doesn't warn on every `#[cfg(madsim)]` /
+# `#[cfg(not(madsim))]` gate in tests/.
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(madsim)"] }
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+# Preserve hardening where reasonable — the demo still shouldn't
+# panic, slice-index blindly, or use unwrap/expect outside tests.
+unwrap_used = { level = "deny", priority = 1 }
+expect_used = { level = "deny", priority = 1 }
+panic = { level = "deny", priority = 1 }
+unimplemented = { level = "deny", priority = 1 }
+todo = { level = "deny", priority = 1 }
+indexing_slicing = { level = "deny", priority = 1 }
+dbg_macro = { level = "deny", priority = 1 }

--- a/crates/mango-madsim-demo/src/lib.rs
+++ b/crates/mango-madsim-demo/src/lib.rs
@@ -1,0 +1,44 @@
+//! Canonical `madsim` demo — a tiny async primitive exercising
+//! `tokio::sync::mpsc`, `tokio::spawn`, and `tokio::time::sleep`.
+//!
+//! The exact same source compiles under both the default build
+//! (real `tokio`, surfaced via the workspace `package =
+//! "madsim-tokio"` rename) and under `RUSTFLAGS="--cfg madsim"`
+//! (simulated runtime). This file MUST NOT contain any
+//! `#[cfg(madsim)]` gates — the whole point of the scaffold is
+//! that library code is unchanged; sim-only scaffolding lives in
+//! tests.
+//!
+//! See [`docs/madsim.md`](../../../docs/madsim.md) for the full
+//! policy.
+
+#![deny(missing_docs)]
+
+use tokio::sync::mpsc;
+use tokio::time::{sleep, Duration};
+
+/// Runs a producer-consumer pair where the producer sends `n`
+/// sequential indices spaced 1ms apart and the consumer collects
+/// them. Returns the collected values in arrival order.
+///
+/// Under `RUSTFLAGS="--cfg madsim"`, `sleep` and `spawn` are
+/// driven by the deterministic simulator — the output is
+/// reproducible from a fixed seed. Under the default build, the
+/// function runs on real tokio.
+pub async fn producer_consumer(n: usize) -> Vec<usize> {
+    let (tx, mut rx) = mpsc::channel::<usize>(16);
+    let producer = tokio::spawn(async move {
+        for i in 0..n {
+            sleep(Duration::from_millis(1)).await;
+            if tx.send(i).await.is_err() {
+                break;
+            }
+        }
+    });
+    let mut seen = Vec::with_capacity(n);
+    while let Some(v) = rx.recv().await {
+        seen.push(v);
+    }
+    let _ = producer.await;
+    seen
+}

--- a/crates/mango-madsim-demo/src/lib.rs
+++ b/crates/mango-madsim-demo/src/lib.rs
@@ -15,6 +15,7 @@
 #![deny(missing_docs)]
 
 use tokio::sync::mpsc;
+use tokio::task;
 use tokio::time::{sleep, Duration};
 
 /// Runs a producer-consumer pair where the producer sends `n`
@@ -25,9 +26,15 @@ use tokio::time::{sleep, Duration};
 /// driven by the deterministic simulator — the output is
 /// reproducible from a fixed seed. Under the default build, the
 /// function runs on real tokio.
+///
+/// Uses `tokio::task::spawn` rather than `tokio::spawn` because
+/// `madsim-tokio` (the simulator shim activated by `--cfg madsim`)
+/// only re-exports `spawn` under `tokio::task::`; the crate-root
+/// `tokio::spawn` works under real tokio but is missing under the
+/// simulator. Writing `task::spawn` compiles in both profiles.
 pub async fn producer_consumer(n: usize) -> Vec<usize> {
     let (tx, mut rx) = mpsc::channel::<usize>(16);
-    let producer = tokio::spawn(async move {
+    let producer = task::spawn(async move {
         for i in 0..n {
             sleep(Duration::from_millis(1)).await;
             if tx.send(i).await.is_err() {

--- a/crates/mango-madsim-demo/tests/madsim_demo.rs
+++ b/crates/mango-madsim-demo/tests/madsim_demo.rs
@@ -1,0 +1,14 @@
+//! Sim-only test — compiled and executed only under
+//! `RUSTFLAGS="--cfg madsim"`; a no-op otherwise.
+//!
+//! Proves the library's `producer_consumer` compiles against the
+//! simulated `tokio` (the workspace-renamed `madsim-tokio`) and
+//! that the output order is deterministic under a fixed seed.
+
+#![cfg(madsim)]
+
+#[madsim::test]
+async fn producer_consumer_is_deterministic() {
+    let out = mango_madsim_demo::producer_consumer(5).await;
+    assert_eq!(out, vec![0, 1, 2, 3, 4]);
+}

--- a/crates/mango-madsim-demo/tests/tokio_demo.rs
+++ b/crates/mango-madsim-demo/tests/tokio_demo.rs
@@ -1,0 +1,15 @@
+//! Real-runtime test — compiled and executed only under the
+//! default build; a no-op under `--cfg madsim`.
+//!
+//! Proves that the same library source compiles and runs under
+//! real tokio via the `madsim-tokio` re-export (the package
+//! rename is link-time only; absent `--cfg madsim`, the renamed
+//! crate is a thin passthrough).
+
+#![cfg(not(madsim))]
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn producer_consumer_runs_on_real_tokio() {
+    let out = mango_madsim_demo::producer_consumer(5).await;
+    assert_eq!(out, vec![0, 1, 2, 3, 4]);
+}

--- a/deny.toml
+++ b/deny.toml
@@ -61,6 +61,7 @@ unsound = "all"
 # at every MSRV bump and crate major-version review.
 ignore = [
     { id = "RUSTSEC-2026-0009", reason = "time 0.3.41 DoS via RFC 2822 parsing stack exhaustion. Patched in 0.3.47 (rustc 1.88); every 0.3.x >= 0.3.42 requires rustc >= 1.81 and workspace MSRV is 1.80, so the fix is unreachable without a policy bump. Usage audit: xtask-vet-ttl (only consumer) uses time for compile-time format_description!, ISO-8601 Date parsing from repo-controlled supply-chain/config.toml, and OffsetDateTime::now_utc() — no RFC 2822 parsing, no untrusted input. Re-audit trigger: next workspace MSRV bump (target re-audit by 2026-10-23). See .planning/ci-hotfix-msrv-time.plan.md." },
+    { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 formally unmaintained (the bincode team ceased development after a harassment incident; they consider 1.3.3 a complete version). Pulled in as a TRANSITIVE DEV-DEP of madsim 0.2.30 through mango-madsim-demo; not a runtime dep of any mango crate (sim scaffolding only). Blast radius: deterministic-simulator tests that serialize data the test itself controls — no untrusted input path. The advisory is informational (category `unmaintained`, no active CVE). Re-audit trigger: next madsim minor bump (0.3.x) — upstream may migrate to postcard/bitcode — or by 2026-10-23. See docs/madsim.md and .planning/0-5-3-madsim-dev-dep.plan.md." },
 ]
 
 [bans]

--- a/docs/madsim.md
+++ b/docs/madsim.md
@@ -1,0 +1,215 @@
+# `madsim` — deterministic-simulation runtime
+
+Mango uses [`madsim`](https://github.com/madsim-rs/madsim) as its
+deterministic-simulator runtime for async tests. Every Phase 3+
+async primitive (`mango-raft`, `mango-mvcc`, `mango-server`,
+`mango-client`) MUST be `madsim`-compatible by the time its phase
+ships. This document pins the mechanism, the version, the CI
+invocation, and the contract.
+
+## Why madsim (and not a custom harness)
+
+- **Deterministic task scheduling, timers, channels, network, and
+  RNG** — a seeded madsim run schedules tasks, delivers messages,
+  fires timers, and generates random numbers in the exact same
+  order on every machine. A failing test replays.
+- **Runtime-layer simulation, not test-layer** — the swap happens
+  at `tokio::time::sleep` / `tokio::spawn` / `tonic::Channel`, not
+  at a mocked trait boundary. Application code is unchanged.
+- **Upstream-maintained ecosystem of renamed crates**
+  (`madsim-tokio`, `madsim-tonic`, etc.) used by RisingWave and
+  others. No bespoke runtime to maintain.
+- **Why Phase 0.5 instead of Phase 5/13**: retrofitting the
+  package rename across an established codebase is more expensive
+  than adopting it from the first tokio-using crate. Adopting in
+  Phase 0.5 turns the Phase 5 "deterministic simulation testing
+  harness" item from "build it" into "write tests against it."
+
+## The rename
+
+Mango activates madsim via Cargo's **package-rename** mechanism,
+not `[patch.crates-io]`:
+
+```toml
+# workspace Cargo.toml
+[workspace.dependencies]
+tokio = { version = "=0.2.30", package = "madsim-tokio" }
+madsim = { version = "=0.2.30", features = ["macros"] }
+```
+
+```toml
+# crates/mango-<something>/Cargo.toml
+[dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+
+[dev-dependencies]
+madsim = { workspace = true, features = ["macros"] }
+```
+
+Source code then writes `use tokio::time::sleep;` / `use
+tokio::sync::mpsc;` **unchanged** — the rename does the swap at
+link time.
+
+### Why the workspace-level rename is accepted by Cargo
+
+`package = "..."` inside `[workspace.dependencies]` is accepted
+by Cargo and the rename is inherited through `dep.workspace =
+true` on each member crate. This is the pattern RisingWave uses
+in its workspace `Cargo.toml` today. Cargo issue
+[#12546](https://github.com/rust-lang/cargo/issues/12546)
+discusses the inverse case (member-side `package` with
+`workspace = true`, which emits an unused-manifest-key warning);
+mango does not hit that case.
+
+If upstream Cargo ever tightens this behavior, the assertion in
+`scripts/madsim-scripts-test.sh` (which probes `cargo metadata`
+for the demo crate's `tokio` dep resolving to the `madsim-tokio`
+package) will go red the same day.
+
+## The cfg and the flag — `--cfg madsim` vs `#[cfg(madsim)]`
+
+- `RUSTFLAGS="--cfg madsim"` — the rustc flag that activates the
+  simulator inside `madsim-tokio`. Set at the CI matrix level,
+  never in `Cargo.toml`. Not a Cargo feature (so it doesn't leak
+  through the dep graph to downstream builds).
+- `#[cfg(madsim)]` — the Rust-source attribute that gates
+  **sim-only scaffolding** (fault injectors, `madsim::rand` calls,
+  simulated-network setup).
+- `#[cfg(not(madsim))]` — gates code that only makes sense under
+  real tokio (TLS handshake tests, OS-level I/O, signal handlers).
+- Library code should have **zero cfg gates** — the rename handles
+  the swap transparently. Every `#[cfg(madsim)]` in a `src/` file
+  is a code smell to review.
+
+## What does not work under sim
+
+- **TLS**: there is no published `madsim-tokio-rustls` shim.
+  Real `tokio-rustls` works under `cfg(madsim)` but the handshake
+  timing is non-deterministic; most sim tests skip TLS or
+  terminate it in front of the simulator (e.g., a real load
+  balancer in integration tests, a no-TLS test profile in sim).
+- **RNG**: `rand::thread_rng()` is not intercepted. Use
+  `madsim::rand` from inside `#[cfg(madsim)]` code, or carry a
+  `rand::rngs::StdRng` seeded from `madsim::runtime::Handle` in
+  sim tests.
+- **File I/O**: `madsim::fs` is partial. For storage-engine sim
+  tests, mock the storage trait rather than relying on simulated
+  filesystem semantics.
+- **OS signals**: no-op under sim.
+
+## CI invocation
+
+```bash
+RUSTFLAGS="--cfg madsim" \
+MADSIM_TEST_SEED=1 \
+MADSIM_TEST_NUM=100 \
+  cargo +stable nextest run \
+      --profile ci \
+      --target-dir target/madsim \
+      -p mango-madsim-demo
+```
+
+- **`--cfg madsim`** — activates the simulator.
+- **`MADSIM_TEST_SEED=1`** — fixed seed for CI reproducibility.
+  Local debugging of a flake uses the same var.
+- **`MADSIM_TEST_NUM=100`** — each test runs 100 times with
+  different seeds internally. Upstream-recommended CI value.
+- **`--target-dir target/madsim`** — dedicated target dir; the
+  `cfg(madsim)` compilation produces a different artifact graph
+  from the default build, so sharing `target/` thrashes the
+  incremental cache.
+- **`--profile ci`** — from `.config/nextest.toml` (per-class
+  timeouts, JUnit output).
+- **`-p <crate>`** — the curated subset is read from
+  `[workspace.metadata.mango.madsim].crates` via
+  `scripts/madsim-crates.sh`.
+
+## Running locally
+
+```bash
+# real tokio (default build — no flag)
+cargo nextest run -p mango-madsim-demo
+
+# deterministic simulator
+RUSTFLAGS="--cfg madsim" MADSIM_TEST_SEED=1 MADSIM_TEST_NUM=100 \
+    cargo nextest run --target-dir target/madsim -p mango-madsim-demo
+
+# MSRV check under --cfg madsim (matches CI)
+RUSTFLAGS="--cfg madsim" \
+    cargo +1.80 check --tests -p mango-madsim-demo \
+    --target-dir target/madsim
+```
+
+## Writing a sim test
+
+Every async crate gets two test files in `tests/`:
+
+- `tests/madsim_<scenario>.rs` — file-scoped `#![cfg(madsim)]`,
+  uses `#[madsim::test]`.
+- `tests/tokio_<scenario>.rs` — file-scoped `#![cfg(not(madsim))]`,
+  uses `#[tokio::test]`.
+
+Library code (`src/`) is unchanged across profiles. Never mix
+profiles in one test file.
+
+The canonical template lives at
+[`crates/mango-madsim-demo/`](../crates/mango-madsim-demo/) —
+copy it into the new crate's `tests/` and rename.
+
+## When to add a crate to the curated subset
+
+The same PR that starts using `tokio.workspace = true` on a new
+crate MUST:
+
+1. Add the crate name to `[workspace.metadata.mango.madsim].crates`
+   in the workspace `Cargo.toml`.
+2. Ship at least one `#[madsim::test]` test in `tests/`.
+3. Ship the paired real-tokio test so the default-build CI job
+   exercises the same code path.
+
+Reviewers enforce this. `scripts/madsim-scripts-test.sh` enforces
+the metadata-table consistency; the `madsim.yml` CI job enforces
+that the sim tests pass.
+
+## Bumping the pin
+
+madsim's env-var semantics (`MADSIM_TEST_SEED`, `MADSIM_TEST_NUM`,
+`MADSIM_ALLOW_SYSTEM_THREAD`) and simulated-runtime behavior can
+drift between minor versions. The pin is exact (`=0.2.30`) for
+the same reason `loom = "=0.7.2"`.
+
+Bump procedure:
+
+1. Verify the new version exists for **both** `madsim` and
+   `madsim-tokio` at crates.io. If Phase 6 has added
+   `madsim-tonic`, verify it too. Versions must be mutually
+   compatible (check `madsim-tokio`'s `madsim` dep req).
+2. Bump all three `=x.y.z` strings in workspace `Cargo.toml` in
+   a single PR.
+3. Run the full CI matrix on the bump PR:
+   - `cargo nextest run -p mango-madsim-demo` (real tokio)
+   - `RUSTFLAGS="--cfg madsim" cargo nextest run --target-dir
+target/madsim -p mango-madsim-demo` (simulator)
+   - The MSRV check under `--cfg madsim`.
+4. If any breakage, pin back down and file an upstream issue
+   before retrying.
+
+Patch bumps are usually safe and can be proposed by Dependabot.
+Minor bumps require a human smoke-test via the demo crate's
+sim + tokio tests. Major bumps (e.g., `0.3.x`) are a design
+discussion — open an ADR.
+
+## Scope — the Phase-6 gate
+
+Mirrors [ROADMAP.md:792]:
+
+> `mango-raft`, `mango-mvcc`, `mango-server`, `mango-client`
+> MUST be `madsim`-compatible by the time their respective
+> phases ship. The CI matrix runs every async test under both
+> the default profile (real `tokio`) and the `sim` profile
+> (`RUSTFLAGS="--cfg madsim"`); regressions in either profile
+> fail the PR.
+
+The rust-expert is instructed to refuse any Phase 6 PR that
+lands before every async primitive has paired sim + tokio test
+coverage.

--- a/scripts/madsim-crates.sh
+++ b/scripts/madsim-crates.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/madsim-crates.sh
+#
+# Emits the madsim curated subset — one crate name per line — as
+# declared in the workspace manifest:
+#
+#   [workspace.metadata.mango.madsim]
+#   crates = ["mango-madsim-demo", ...]
+#
+# Consumed by `.github/workflows/madsim.yml` to build the
+# `-p <crate>` list passed to `cargo nextest run` under
+# RUSTFLAGS="--cfg madsim". See docs/madsim.md.
+#
+# Fails on empty / missing metadata table rather than silently
+# no-opping — an empty curated subset means the gate is doing
+# nothing, and that regression should be loud, not silent.
+#
+# Requires: bash, cargo, jq.
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || {
+    echo "error: jq not found on PATH (required to parse cargo metadata)" >&2
+    exit 2
+}
+
+crates="$(
+    cargo metadata --format-version=1 --no-deps \
+        | jq -r '.metadata.mango.madsim.crates // [] | .[]'
+)"
+
+if [ -z "$crates" ]; then
+    echo "error: [workspace.metadata.mango.madsim].crates is empty or missing" >&2
+    echo "       update workspace Cargo.toml per docs/madsim.md" >&2
+    exit 1
+fi
+
+printf '%s\n' "$crates"

--- a/scripts/madsim-scripts-test.sh
+++ b/scripts/madsim-scripts-test.sh
@@ -115,9 +115,14 @@ else
 fi
 
 # --- 7. demo lib.rs has zero cfg(madsim) gates ----------------------
+# Excludes line comments (`//` / `//!`) so the doc-comment that
+# *documents* the invariant ("This file MUST NOT contain any
+# `#[cfg(madsim)]` gates...") does not false-positive the test.
+# A real `#[cfg(madsim)]` attribute would live on a non-comment line.
 scenario="demo lib.rs has zero #[cfg(madsim)] / #[cfg(not(madsim))] gates"
 if [ -f "$demo_lib" ]; then
-    if grep -qE 'cfg\(\s*(not\s*\(\s*)?madsim' "$demo_lib"; then
+    if grep -v '^[[:space:]]*//' "$demo_lib" \
+        | grep -qE 'cfg\(\s*(not\s*\(\s*)?madsim'; then
         fail "$scenario (found cfg(madsim) gate — scaffold invariant violated)"
     else
         pass "$scenario"

--- a/scripts/madsim-scripts-test.sh
+++ b/scripts/madsim-scripts-test.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# scripts/madsim-scripts-test.sh
+#
+# Smoke-test harness for the madsim CI gate (item 0.5.3).
+#
+# What this covers:
+#   - .github/workflows/madsim.yml has the structural invariants the
+#     CI gate depends on (cfg activation, pinned env vars, per-crate
+#     target dir, curated-subset enumeration, path filters).
+#   - docs/madsim.md exists.
+#   - scripts/madsim-crates.sh resolves the curated subset.
+#   - Workspace Cargo.toml carries the package-rename and the
+#     metadata.mango.madsim table.
+#   - The demo crate's lib.rs contains zero `#[cfg(madsim)]` gates
+#     (scaffold invariant).
+#   - `cargo metadata` resolves the demo crate's `tokio` dep to the
+#     `madsim-tokio` package (regression test for the workspace-level
+#     package-rename-through-workspace-inheritance contract).
+#
+# Workflow-absent behavior (sbom-style):
+#   Assertions that need the workflow file print SKIP if the file is
+#   absent. The metadata / script / docs assertions run unconditionally.
+#   Once the workflow lands, this script runs as a step inside it,
+#   and SKIP becomes unreachable.
+#
+# Invocation:
+#   bash scripts/madsim-scripts-test.sh
+#   (run from any CWD; script cd's to repo root)
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+pass() {
+    printf 'PASS  %s\n' "$1"
+    pass_count=$((pass_count + 1))
+}
+fail() {
+    printf 'FAIL  %s\n' "$1" >&2
+    fail_count=$((fail_count + 1))
+}
+skip() {
+    printf 'SKIP  %s\n' "$1"
+    skip_count=$((skip_count + 1))
+}
+
+workflow=".github/workflows/madsim.yml"
+demo_lib="crates/mango-madsim-demo/src/lib.rs"
+
+# --- 1. policy doc exists -------------------------------------------
+scenario="docs/madsim.md exists"
+if [ -f "docs/madsim.md" ]; then
+    pass "$scenario"
+else
+    fail "$scenario"
+fi
+
+# --- 2. madsim-crates.sh is executable & returns ≥1 crate -----------
+scenario="madsim-crates.sh emits ≥1 crate on this workspace"
+if [ -x "scripts/madsim-crates.sh" ]; then
+    out="$(bash scripts/madsim-crates.sh 2>/dev/null || true)"
+    if [ -n "$out" ]; then
+        pass "$scenario (got: $(echo "$out" | tr '\n' ' '))"
+    else
+        # Before the workspace.metadata table lands, this is legitimately
+        # empty; skip rather than fail so the script can land first.
+        skip "$scenario (empty output — metadata table not yet populated?)"
+    fi
+else
+    fail "$scenario (scripts/madsim-crates.sh not executable)"
+fi
+
+# --- 3. workspace Cargo.toml has the package-rename -----------------
+scenario="workspace.dependencies has tokio = { package = \"madsim-tokio\" }"
+if grep -qE '^\s*tokio\s*=\s*\{[^}]*package\s*=\s*"madsim-tokio"' Cargo.toml; then
+    pass "$scenario"
+else
+    skip "$scenario (workspace Cargo.toml not yet wired)"
+fi
+
+# --- 4. workspace Cargo.toml has madsim pin with macros feature -----
+scenario="workspace.dependencies has madsim with macros feature"
+if grep -qE '^\s*madsim\s*=\s*\{[^}]*"macros"' Cargo.toml; then
+    pass "$scenario"
+else
+    skip "$scenario (workspace Cargo.toml not yet wired)"
+fi
+
+# --- 5. metadata.mango.madsim table present -------------------------
+scenario="[workspace.metadata.mango.madsim] table present"
+if grep -qE '^\[workspace\.metadata\.mango\.madsim\]' Cargo.toml; then
+    pass "$scenario"
+else
+    skip "$scenario (metadata table not yet wired)"
+fi
+
+# --- 6. metadata table contains mango-madsim-demo -------------------
+scenario="metadata.mango.madsim.crates contains mango-madsim-demo"
+# Probe via cargo metadata (authoritative) if we have jq, else grep.
+if command -v jq >/dev/null 2>&1 && command -v cargo >/dev/null 2>&1; then
+    got="$(cargo metadata --no-deps --format-version=1 --locked 2>/dev/null \
+        | jq -r '.metadata.mango.madsim.crates // [] | .[]' 2>/dev/null || true)"
+    if printf '%s\n' "$got" | grep -qx 'mango-madsim-demo'; then
+        pass "$scenario"
+    else
+        skip "$scenario (table not yet populated)"
+    fi
+else
+    skip "$scenario (jq/cargo unavailable)"
+fi
+
+# --- 7. demo lib.rs has zero cfg(madsim) gates ----------------------
+scenario="demo lib.rs has zero #[cfg(madsim)] / #[cfg(not(madsim))] gates"
+if [ -f "$demo_lib" ]; then
+    if grep -qE 'cfg\(\s*(not\s*\(\s*)?madsim' "$demo_lib"; then
+        fail "$scenario (found cfg(madsim) gate — scaffold invariant violated)"
+    else
+        pass "$scenario"
+    fi
+else
+    skip "$scenario (demo crate not yet present)"
+fi
+
+# --- 8. cargo metadata: demo crate's tokio dep resolves to madsim-tokio --
+# The load-bearing assertion for the "workspace-level package rename
+# through workspace = true" contract. If Cargo ever changes that
+# behavior, this goes red.
+scenario="demo crate tokio dep resolves to madsim-tokio (package-rename regression test)"
+if command -v jq >/dev/null 2>&1 && command -v cargo >/dev/null 2>&1 \
+    && [ -f "crates/mango-madsim-demo/Cargo.toml" ]; then
+    # Use --no-deps to get the crate's declared deps; the `rename` field
+    # is populated when package != name.
+    got="$(cargo metadata --no-deps --format-version=1 --locked 2>/dev/null \
+        | jq -r '.packages[]
+                 | select(.name == "mango-madsim-demo")
+                 | .dependencies[]
+                 | select(.name == "madsim-tokio")
+                 | .rename // .name' 2>/dev/null || true)"
+    if [ "$got" = "tokio" ] || [ "$got" = "madsim-tokio" ]; then
+        pass "$scenario (resolved: name=madsim-tokio, local=$got)"
+    else
+        fail "$scenario (got: '$got' — expected the crate to depend on madsim-tokio)"
+    fi
+else
+    skip "$scenario (demo crate or jq unavailable)"
+fi
+
+# --- Workflow-presence gated assertions -----------------------------
+if [ ! -f "$workflow" ]; then
+    skip "workflow file exists ($workflow)"
+    skip "workflow name is 'madsim'"
+    skip "workflow sets RUSTFLAGS=\"--cfg madsim\" on the test step"
+    skip "workflow sets MADSIM_TEST_SEED and MADSIM_TEST_NUM env vars"
+    skip "workflow uses --target-dir target/madsim"
+    skip "workflow pull_request paths include load-bearing entries"
+    skip "workflow has merge_group trigger without paths"
+    skip "workflow runs MSRV check under --cfg madsim"
+else
+    scenario="workflow file exists ($workflow)"
+    pass "$scenario"
+
+    scenario="workflow name is 'madsim'"
+    if grep -qE '^name:[[:space:]]+madsim[[:space:]]*$' "$workflow"; then
+        pass "$scenario"
+    else
+        fail "$scenario"
+    fi
+
+    # Regex excludes comment lines (public-api precedent): a naive grep
+    # matches the prose in the header comment and masks a regression
+    # where the env block itself drops the flag.
+    scenario="workflow sets RUSTFLAGS=\"--cfg madsim\" on a non-comment line"
+    if grep -v '^[[:space:]]*#' "$workflow" \
+        | grep -qE 'RUSTFLAGS:[[:space:]]*["'\'']?--cfg[[:space:]]+madsim'; then
+        pass "$scenario"
+    else
+        fail "$scenario"
+    fi
+
+    scenario="workflow sets MADSIM_TEST_SEED and MADSIM_TEST_NUM env vars"
+    if grep -v '^[[:space:]]*#' "$workflow" | grep -qE '^\s*MADSIM_TEST_SEED:' \
+        && grep -v '^[[:space:]]*#' "$workflow" | grep -qE '^\s*MADSIM_TEST_NUM:'; then
+        pass "$scenario"
+    else
+        fail "$scenario"
+    fi
+
+    scenario="workflow uses --target-dir target/madsim"
+    if grep -v '^[[:space:]]*#' "$workflow" \
+        | grep -qE -- '--target-dir[[:space:]]+target/madsim'; then
+        pass "$scenario"
+    else
+        fail "$scenario"
+    fi
+
+    scenario="workflow pull_request paths include load-bearing entries"
+    missing=""
+    for needle in \
+        'crates/\*\*/src/\*\*' \
+        'crates/\*\*/tests/\*\*' \
+        'crates/\*\*/Cargo.toml' \
+        'Cargo.toml' \
+        'Cargo.lock' \
+        '.github/workflows/madsim.yml' \
+        'scripts/madsim-crates.sh' \
+        'scripts/madsim-scripts-test.sh' \
+        'docs/madsim.md'
+    do
+        if ! grep -qE -- "$needle" "$workflow"; then
+            missing="$missing $needle"
+        fi
+    done
+    if [ -z "$missing" ]; then
+        pass "$scenario"
+    else
+        fail "$scenario (missing:$missing)"
+    fi
+
+    scenario="workflow has merge_group trigger without paths"
+    # merge_group does not honour paths; asserting the trigger is present.
+    if grep -qE '^\s*merge_group:' "$workflow"; then
+        pass "$scenario"
+    else
+        fail "$scenario"
+    fi
+
+    scenario="workflow runs MSRV check under --cfg madsim"
+    # Match a line referencing `cargo +1.80` (MSRV toolchain) in a step
+    # that also mentions --cfg madsim. Kept permissive because exact
+    # syntax (cargo +1.80.0 vs cargo +1.80 vs $MSRV var) is an impl choice.
+    if grep -v '^[[:space:]]*#' "$workflow" \
+        | grep -qE 'cargo[[:space:]]+\+?(1\.80|\$\{?\{?[[:space:]]*env\.MSRV)'; then
+        pass "$scenario"
+    else
+        fail "$scenario (no MSRV-pinned cargo invocation found)"
+    fi
+fi
+
+# --- summary --------------------------------------------------------
+echo
+echo "$pass_count passed, $fail_count failed, $skip_count skipped"
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -16,18 +16,27 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [policy.mango]
 audit-as-crates-io = false
 criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [policy.mango-loom-demo]
 audit-as-crates-io = false
 criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [policy.mango-proto]
 audit-as-crates-io = false
 criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [policy.xtask-vet-ttl]
 audit-as-crates-io = false
 criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.ahash]]
+version = "0.8.12"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.aho-corasick]]
 version = "1.1.4"
@@ -38,6 +47,26 @@ notes = "review-by: 2026-10-23 — regex dep, BurntSushi, audit pending"
 version = "1.0.102"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — error-handling, dtolnay, audit pending"
+
+[[exemptions.async-channel]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.async-stream]]
+version = "0.3.6"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.async-stream-impl]]
+version = "0.3.6"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.bincode]]
+version = "1.3.3"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.bytes]]
 version = "1.11.1"
@@ -54,10 +83,50 @@ version = "1.0.4"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — rust-lang, audit pending"
 
+[[exemptions.concurrent-queue]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.crossbeam-utils]]
+version = "0.8.8"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.darling]]
+version = "0.14.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.darling_core]]
+version = "0.14.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.darling_macro]]
+version = "0.14.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.downcast-rs]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
 [[exemptions.errno]]
 version = "0.3.14"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — rustix dep, lambda-fairy, audit pending"
+
+[[exemptions.event-listener]]
+version = "5.4.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.event-listener-strategy]]
+version = "0.5.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.fastrand]]
 version = "2.4.1"
@@ -74,10 +143,40 @@ version = "0.5.7"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — petgraph dep, audit pending"
 
+[[exemptions.futures-core]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.futures-macro]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.futures-sink]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.futures-task]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.futures-util]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
 [[exemptions.generator]]
 version = "0.8.8"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — loom dep, Xudong-Huang, audit pending"
+
+[[exemptions.getrandom]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.getrandom]]
 version = "0.3.4"
@@ -88,6 +187,11 @@ notes = "review-by: 2026-10-23 — rust-random, audit pending"
 version = "0.16.1"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — rust-lang, audit pending"
+
+[[exemptions.ident_case]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.itertools]]
 version = "0.14.0"
@@ -109,25 +213,60 @@ version = "0.12.1"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — rustix dep, sunfishcode, audit pending"
 
+[[exemptions.lock_api]]
+version = "0.4.14"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
 [[exemptions.loom]]
 version = "0.7.2"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — tokio-rs, exact-pinned for determinism"
+
+[[exemptions.madsim]]
+version = "0.2.30"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.madsim-macros]]
+version = "0.2.12"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.madsim-tokio]]
+version = "0.2.30"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.memchr]]
 version = "2.8.0"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — BurntSushi, audit pending"
 
+[[exemptions.mio]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
 [[exemptions.multimap]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — prost-build dep, havarnov, audit pending"
 
+[[exemptions.naive-timer]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
 [[exemptions.once_cell]]
 version = "1.21.4"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — matklad, audit pending"
+
+[[exemptions.panic-message]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.petgraph]]
 version = "0.7.1"
@@ -138,6 +277,11 @@ notes = "review-by: 2026-10-23 — petgraph team, audit pending"
 version = "0.2.17"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — taiki-e, audit pending"
+
+[[exemptions.ppv-lite86]]
+version = "0.2.21"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.prettyplease]]
 version = "0.2.37"
@@ -179,6 +323,16 @@ version = "5.3.0"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — getrandom transitive, r-efi maintainers, audit pending"
 
+[[exemptions.rand]]
+version = "0.8.6"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.rand_xoshiro]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
 [[exemptions.regex]]
 version = "1.12.3"
 criteria = "safe-to-deploy"
@@ -209,6 +363,11 @@ version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — alexcrichton, audit pending"
 
+[[exemptions.scopeguard]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
 [[exemptions.serde]]
 version = "1.0.228"
 criteria = "safe-to-deploy"
@@ -229,6 +388,31 @@ version = "0.6.9"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — toml dep, toml-rs team, audit pending"
 
+[[exemptions.signal-hook-registry]]
+version = "1.4.8"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.slab]]
+version = "0.4.12"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.socket2]]
+version = "0.6.3"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.spin]]
+version = "0.9.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.syn]]
+version = "1.0.109"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
 [[exemptions.syn]]
 version = "2.0.117"
 criteria = "safe-to-deploy"
@@ -248,6 +432,21 @@ notes = "review-by: 2026-10-23 — Amanieu, audit pending"
 version = "0.3.41"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — jhpratt, audit pending"
+
+[[exemptions.tokio]]
+version = "1.52.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.tokio-macros]]
+version = "2.7.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.tokio-util]]
+version = "0.7.18"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.toml]]
 version = "0.8.23"
@@ -279,6 +478,11 @@ version = "0.1.44"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — tokio-rs tracing, audit pending"
 
+[[exemptions.tracing-attributes]]
+version = "0.1.31"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
 [[exemptions.tracing-core]]
 version = "0.1.36"
 criteria = "safe-to-deploy"
@@ -298,6 +502,16 @@ notes = "review-by: 2026-10-23 — dtolnay, audit pending"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — tracing dep, rust-lang, audit pending"
+
+[[exemptions.version_check]]
+version = "0.9.5"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.wasi]]
+version = "0.11.1+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
 [[exemptions.windows-link]]
 version = "0.1.3"
@@ -323,3 +537,13 @@ notes = "review-by: 2026-10-23 — microsoft/windows-rs, audit pending"
 version = "0.7.15"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — toml-rs team / epage, audit pending"
+
+[[exemptions.zerocopy]]
+version = "0.8.48"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.zerocopy-derive]]
+version = "0.8.48"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -31,6 +31,12 @@ start = "2025-08-13"
 end = "2027-01-08"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.bytecode-alliance.audits.async-task]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "4.7.1"
+notes = "Fairly significant chunk of unsafe code in the async executor core, but seems isolated to well-understood patterns, e.g. a manual vtable and some manual layout code."
+
 [[audits.bytecode-alliance.audits.bitflags]]
 who = "Jamey Sharp <jsharp@fastly.com>"
 criteria = "safe-to-deploy"
@@ -106,6 +112,12 @@ criteria = "safe-to-deploy"
 delta = "0.50.1 -> 0.50.3"
 notes = "CI changes, Rust changes, nothing out of the ordinary."
 
+[[audits.bytecode-alliance.audits.parking]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+version = "2.2.1"
+notes = "forbid-unsafe crate with straightforward imports."
+
 [[audits.bytecode-alliance.audits.sharded-slab]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -123,6 +135,11 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "1.13.2 -> 1.14.0"
 notes = "Minor new feature, nothing out of the ordinary."
+
+[[audits.bytecode-alliance.audits.spin]]
+who = "Pat Hickey <pat@moreproductive.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.4 -> 0.9.8"
 
 [[audits.bytecode-alliance.audits.tracing-log]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -281,10 +298,39 @@ delta = "0.4.25 -> 0.4.26"
 notes = "Only trivial code and documentation changes."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.rand_chacha]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.rand_core]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.6.4"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.smallvec]]
 who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
 version = "1.13.2"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.strsim]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+version = "0.10.0"
+notes = """
+Reviewed in https://crrev.com/c/5171063
+
+Previously reviewed during security review and the audit is grandparented in.
+"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.mozilla.audits.bitflags]]
@@ -334,6 +380,37 @@ criteria = "safe-to-deploy"
 delta = "2.9.4 -> 2.10.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.crossbeam-utils]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.8.8 -> 0.8.11"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crossbeam-utils]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.8.11 -> 0.8.14"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crossbeam-utils]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.14 -> 0.8.19"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crossbeam-utils]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.19 -> 0.8.20"
+notes = "Minor changes."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crossbeam-utils]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.8.20 -> 0.8.21"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.deranged]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -350,6 +427,13 @@ who = "Lars Eggert <lars@eggert.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.11 -> 0.4.0"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fnv]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.7"
+notes = "Simple hasher implementation with no unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.indexmap]]
 who = "Erich Gubler <erichdongubler@gmail.com>"


### PR DESCRIPTION
## Summary

Lands ROADMAP item **0.5.3** — the `madsim` deterministic-simulator workspace dev-dep + CI gate. Scaffolds the pattern Phase 3+ async crates will copy.

- **Workspace-level package rename**: `tokio = { version = "=0.2.30", package = "madsim-tokio" }` in `[workspace.dependencies]`. Member crates write `tokio.workspace = true` unchanged; default build re-exports real tokio, `RUSTFLAGS="--cfg madsim"` swaps in the simulator at link time (RisingWave pattern).
- **Curated subset** via `[workspace.metadata.mango.madsim]` + `scripts/madsim-crates.sh` — mirrors the miri opt-in mechanism.
- **Demo crate** `mango-madsim-demo`: producer/consumer over `tokio::sync::mpsc`, `tokio::task::spawn`, `tokio::time::sleep`. Two test files (`tests/madsim_demo.rs` with `#![cfg(madsim)]`, `tests/tokio_demo.rs` with `#![cfg(not(madsim))]`) prove the same library source compiles under both runtimes.
- **Policy doc** `docs/madsim.md`: the rename, `cfg(madsim)` semantics, what does not work under sim (TLS, RNG, signals), bump procedure, Phase-6 gate.
- **CI gate** `.github/workflows/madsim.yml`: stable nextest under `--cfg madsim` + MSRV compile-check under `--cfg madsim`, separate cache prefix and `--target-dir target/madsim`.
- **Self-test** `scripts/madsim-scripts-test.sh`: 16 assertions covering workflow/metadata/script/doc consistency, sbom-style skip when workflow absent, plus a `cargo metadata` regression test for the package-rename contract.

Linked roadmap item: `ROADMAP.md:774`.

## Test plan

- [x] `cargo fmt --check --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p mango-madsim-demo` — real tokio path, 1 passed
- [x] `RUSTFLAGS="--cfg madsim" cargo test -p mango-madsim-demo --target-dir target/madsim` — simulator path, 1 passed
- [x] `bash scripts/madsim-scripts-test.sh` — 16 passed / 0 failed / 0 skipped
- [ ] CI: the new `madsim` workflow runs green on this PR
- [ ] CI: existing workflows (ci, loom, miri, sbom, public-api, semver-checks, audit, vet, ct-comparison, doc, geiger) remain green

## Notes for reviewer

- `tokio::task::spawn` (not `tokio::spawn`) — `madsim-tokio` only re-exports `spawn` under `tokio::task::`; using `task::spawn` compiles in both profiles.
- `madsim-tonic` is intentionally **not** declared yet; per the plan it lands in the same PR as the first tonic-using crate (Phase 6).
- The `[lints]` table in `mango-madsim-demo/Cargo.toml` deliberately opts out of workspace pedantic inheritance (same rationale as `mango-loom-demo`) while keeping the hardening denies.
- Path filters exclude docs and top-level markdown intentionally — the `madsim` workflow only runs when madsim-relevant files change.

Generated with [Claude Code](https://claude.com/claude-code)
