### PR TITLE
ci(dependabot): Dependabot config + self-test gate (ROADMAP 0.5-renovate-dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,116 @@
+# Dependabot config for mango.
+#
+# Preserves the SHA-pin policy for GitHub Actions (all `uses:` lines
+# are 40-hex SHAs with a trailing `# <ref>` comment) and keeps the
+# workspace crate versions current. Every bump ships as a PR through
+# the normal expert-review + CI-gate loop — no auto-merge anywhere.
+#
+# Policy:     docs/dependency-updates.md
+# Self-test:  scripts/dependabot-scripts-test.sh
+# JSON Schema: .github/schemas/dependabot-2.0.json
+#
+# Re-run the self-test whenever this file changes.
+version: 2
+updates:
+  # ------------------------------------------------------------
+  # GitHub Actions
+  #
+  # Dependabot bumps the 40-hex SHA and (for actions that publish
+  # semver tags) the trailing `# vN` / `# vN.M.P` comment in lockstep.
+  # For branch-tracking actions (dtolnay/rust-toolchain → `# stable`),
+  # Dependabot updates the SHA and leaves the ref comment untouched —
+  # that is correct; the ref is still "stable." See
+  # docs/dependency-updates.md §"Trailing comments" for the policy.
+  # ------------------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "14:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    commit-message:
+      # Intentionally no `include: scope` — the prefix already
+      # carries the scope, and `include: scope` produces ugly
+      # `chore(actions)(deps): ...` doubled parens.
+      prefix: "chore(actions)"
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions-minor-patch:
+        patterns: ["*"]
+        update-types:
+          - minor
+          - patch
+      github-actions-major:
+        patterns: ["*"]
+        update-types:
+          - major
+
+  # ------------------------------------------------------------
+  # Cargo workspace
+  #
+  # `insecure-external-code-execution: deny` blocks dependency build
+  # scripts from running during version resolution — mandated by
+  # mango's supply-chain posture. cargo-deny / cargo-vet catch
+  # build-script-dependent issues on the resulting PR instead.
+  #
+  # `madsim-family` is load-bearing: `madsim` and `madsim-tokio`
+  # (manifest key `tokio` under the workspace package-rename at
+  # Cargo.toml:69) MUST be bumped together. Cargo.toml header says
+  # "move both lines together." Dependabot groups by manifest key,
+  # so we list `tokio` here even though the package name is
+  # `madsim-tokio`. Named groups are evaluated in declaration order
+  # — `madsim-family` claims its crates before the catch-all groups
+  # below see them; the catch-alls explicitly `exclude-patterns`
+  # the same three to avoid overlap.
+  # ------------------------------------------------------------
+  - package-ecosystem: cargo
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "14:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    insecure-external-code-execution: deny
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - rust
+    groups:
+      madsim-family:
+        patterns:
+          - "madsim"
+          - "madsim-*"
+          - "tokio"
+        update-types:
+          - patch
+          - minor
+          - major
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "madsim"
+          - "madsim-*"
+          - "tokio"
+        update-types:
+          - minor
+          - patch
+      cargo-major:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "madsim"
+          - "madsim-*"
+          - "tokio"
+        update-types:
+          - major

--- a/.github/schemas/README.md
+++ b/.github/schemas/README.md
@@ -1,0 +1,30 @@
+# Vendored JSON Schemas
+
+This directory holds JSON Schema files committed to the repo so CI
+validation is offline and reproducible (independent of schemastore.org
+availability and URL stability).
+
+## `dependabot-2.0.json`
+
+- **Source**: https://json.schemastore.org/dependabot-2.0.json
+  (redirects to https://www.schemastore.org/dependabot-2.0.json)
+- **Fetched**: 2026-04-23
+- **SHA-256**: `1f61eb228202e5f7a394ce295eebf602b8b676dff0d51dbe489a9a9434263c51`
+- **Used by**: [`scripts/dependabot-scripts-test.sh`](../../scripts/dependabot-scripts-test.sh)
+  via `check-jsonschema --schemafile`.
+
+To refresh:
+
+```bash
+curl -sSL -o .github/schemas/dependabot-2.0.json \
+  https://json.schemastore.org/dependabot-2.0.json
+shasum -a 256 .github/schemas/dependabot-2.0.json
+# update the SHA-256 + Fetched lines above
+bash scripts/dependabot-scripts-test.sh
+```
+
+Schemastore occasionally rewrites paths. If the URL stops resolving,
+fall back to [SchemaStore's repo] and pick the latest
+`dependabot-2.0.json`.
+
+[SchemaStore's repo]: https://github.com/SchemaStore/schemastore

--- a/.github/schemas/dependabot-2.0.json
+++ b/.github/schemas/dependabot-2.0.json
@@ -1,0 +1,1525 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/dependabot-2.0.json",
+  "additionalProperties": false,
+  "definitions": {
+    "timezone": {
+      "type": "string",
+      "enum": [
+        "Africa/Abidjan",
+        "Africa/Accra",
+        "Africa/Addis_Ababa",
+        "Africa/Algiers",
+        "Africa/Asmara",
+        "Africa/Asmera",
+        "Africa/Bamako",
+        "Africa/Bangui",
+        "Africa/Banjul",
+        "Africa/Bissau",
+        "Africa/Blantyre",
+        "Africa/Brazzaville",
+        "Africa/Bujumbura",
+        "Africa/Cairo",
+        "Africa/Casablanca",
+        "Africa/Ceuta",
+        "Africa/Conakry",
+        "Africa/Dakar",
+        "Africa/Dar_es_Salaam",
+        "Africa/Djibouti",
+        "Africa/Douala",
+        "Africa/El_Aaiun",
+        "Africa/Freetown",
+        "Africa/Gaborone",
+        "Africa/Harare",
+        "Africa/Johannesburg",
+        "Africa/Juba",
+        "Africa/Kampala",
+        "Africa/Khartoum",
+        "Africa/Kigali",
+        "Africa/Kinshasa",
+        "Africa/Lagos",
+        "Africa/Libreville",
+        "Africa/Lome",
+        "Africa/Luanda",
+        "Africa/Lubumbashi",
+        "Africa/Lusaka",
+        "Africa/Malabo",
+        "Africa/Maputo",
+        "Africa/Maseru",
+        "Africa/Mbabane",
+        "Africa/Mogadishu",
+        "Africa/Monrovia",
+        "Africa/Nairobi",
+        "Africa/Ndjamena",
+        "Africa/Niamey",
+        "Africa/Nouakchott",
+        "Africa/Ouagadougou",
+        "Africa/Porto-Novo",
+        "Africa/Sao_Tome",
+        "Africa/Timbuktu",
+        "Africa/Tripoli",
+        "Africa/Tunis",
+        "Africa/Windhoek",
+        "America/Adak",
+        "America/Anchorage",
+        "America/Anguilla",
+        "America/Antigua",
+        "America/Araguaina",
+        "America/Argentina/Buenos_Aires",
+        "America/Argentina/Catamarca",
+        "America/Argentina/ComodRivadavia",
+        "America/Argentina/Cordoba",
+        "America/Argentina/Jujuy",
+        "America/Argentina/La_Rioja",
+        "America/Argentina/Mendoza",
+        "America/Argentina/Rio_Gallegos",
+        "America/Argentina/Salta",
+        "America/Argentina/San_Juan",
+        "America/Argentina/San_Luis",
+        "America/Argentina/Tucuman",
+        "America/Argentina/Ushuaia",
+        "America/Aruba",
+        "America/Asuncion",
+        "America/Atikokan",
+        "America/Atka",
+        "America/Bahia",
+        "America/Bahia_Banderas",
+        "America/Barbados",
+        "America/Belem",
+        "America/Belize",
+        "America/Blanc-Sablon",
+        "America/Boa_Vista",
+        "America/Bogota",
+        "America/Boise",
+        "America/Buenos_Aires",
+        "America/Cambridge_Bay",
+        "America/Campo_Grande",
+        "America/Cancun",
+        "America/Caracas",
+        "America/Catamarca",
+        "America/Cayenne",
+        "America/Cayman",
+        "America/Chicago",
+        "America/Chihuahua",
+        "America/Ciudad_Juarez",
+        "America/Coral_Harbour",
+        "America/Cordoba",
+        "America/Costa_Rica",
+        "America/Coyhaique",
+        "America/Creston",
+        "America/Cuiaba",
+        "America/Curacao",
+        "America/Danmarkshavn",
+        "America/Dawson",
+        "America/Dawson_Creek",
+        "America/Denver",
+        "America/Detroit",
+        "America/Dominica",
+        "America/Edmonton",
+        "America/Eirunepe",
+        "America/El_Salvador",
+        "America/Ensenada",
+        "America/Fort_Nelson",
+        "America/Fort_Wayne",
+        "America/Fortaleza",
+        "America/Glace_Bay",
+        "America/Godthab",
+        "America/Goose_Bay",
+        "America/Grand_Turk",
+        "America/Grenada",
+        "America/Guadeloupe",
+        "America/Guatemala",
+        "America/Guayaquil",
+        "America/Guyana",
+        "America/Halifax",
+        "America/Havana",
+        "America/Hermosillo",
+        "America/Indiana/Indianapolis",
+        "America/Indiana/Knox",
+        "America/Indiana/Marengo",
+        "America/Indiana/Petersburg",
+        "America/Indiana/Tell_City",
+        "America/Indiana/Vevay",
+        "America/Indiana/Vincennes",
+        "America/Indiana/Winamac",
+        "America/Indianapolis",
+        "America/Inuvik",
+        "America/Iqaluit",
+        "America/Jamaica",
+        "America/Jujuy",
+        "America/Juneau",
+        "America/Kentucky/Louisville",
+        "America/Kentucky/Monticello",
+        "America/Knox_IN",
+        "America/Kralendijk",
+        "America/La_Paz",
+        "America/Lima",
+        "America/Los_Angeles",
+        "America/Louisville",
+        "America/Lower_Princes",
+        "America/Maceio",
+        "America/Managua",
+        "America/Manaus",
+        "America/Marigot",
+        "America/Martinique",
+        "America/Matamoros",
+        "America/Mazatlan",
+        "America/Mendoza",
+        "America/Menominee",
+        "America/Merida",
+        "America/Metlakatla",
+        "America/Mexico_City",
+        "America/Miquelon",
+        "America/Moncton",
+        "America/Monterrey",
+        "America/Montevideo",
+        "America/Montreal",
+        "America/Montserrat",
+        "America/Nassau",
+        "America/New_York",
+        "America/Nipigon",
+        "America/Nome",
+        "America/Noronha",
+        "America/North_Dakota/Beulah",
+        "America/North_Dakota/Center",
+        "America/North_Dakota/New_Salem",
+        "America/Nuuk",
+        "America/Ojinaga",
+        "America/Panama",
+        "America/Pangnirtung",
+        "America/Paramaribo",
+        "America/Phoenix",
+        "America/Port-au-Prince",
+        "America/Port_of_Spain",
+        "America/Porto_Acre",
+        "America/Porto_Velho",
+        "America/Puerto_Rico",
+        "America/Punta_Arenas",
+        "America/Rainy_River",
+        "America/Rankin_Inlet",
+        "America/Recife",
+        "America/Regina",
+        "America/Resolute",
+        "America/Rio_Branco",
+        "America/Rosario",
+        "America/Santa_Isabel",
+        "America/Santarem",
+        "America/Santiago",
+        "America/Santo_Domingo",
+        "America/Sao_Paulo",
+        "America/Scoresbysund",
+        "America/Shiprock",
+        "America/Sitka",
+        "America/St_Barthelemy",
+        "America/St_Johns",
+        "America/St_Kitts",
+        "America/St_Lucia",
+        "America/St_Thomas",
+        "America/St_Vincent",
+        "America/Swift_Current",
+        "America/Tegucigalpa",
+        "America/Thule",
+        "America/Thunder_Bay",
+        "America/Tijuana",
+        "America/Toronto",
+        "America/Tortola",
+        "America/Vancouver",
+        "America/Virgin",
+        "America/Whitehorse",
+        "America/Winnipeg",
+        "America/Yakutat",
+        "America/Yellowknife",
+        "Antarctica/Casey",
+        "Antarctica/Davis",
+        "Antarctica/DumontDUrville",
+        "Antarctica/Macquarie",
+        "Antarctica/Mawson",
+        "Antarctica/McMurdo",
+        "Antarctica/Palmer",
+        "Antarctica/Rothera",
+        "Antarctica/South_Pole",
+        "Antarctica/Syowa",
+        "Antarctica/Troll",
+        "Antarctica/Vostok",
+        "Arctic/Longyearbyen",
+        "Asia/Aden",
+        "Asia/Almaty",
+        "Asia/Amman",
+        "Asia/Anadyr",
+        "Asia/Aqtau",
+        "Asia/Aqtobe",
+        "Asia/Ashgabat",
+        "Asia/Ashkhabad",
+        "Asia/Atyrau",
+        "Asia/Baghdad",
+        "Asia/Bahrain",
+        "Asia/Baku",
+        "Asia/Bangkok",
+        "Asia/Barnaul",
+        "Asia/Beirut",
+        "Asia/Bishkek",
+        "Asia/Brunei",
+        "Asia/Calcutta",
+        "Asia/Chita",
+        "Asia/Choibalsan",
+        "Asia/Chongqing",
+        "Asia/Chungking",
+        "Asia/Colombo",
+        "Asia/Dacca",
+        "Asia/Damascus",
+        "Asia/Dhaka",
+        "Asia/Dili",
+        "Asia/Dubai",
+        "Asia/Dushanbe",
+        "Asia/Famagusta",
+        "Asia/Gaza",
+        "Asia/Harbin",
+        "Asia/Hebron",
+        "Asia/Ho_Chi_Minh",
+        "Asia/Hong_Kong",
+        "Asia/Hovd",
+        "Asia/Irkutsk",
+        "Asia/Istanbul",
+        "Asia/Jakarta",
+        "Asia/Jayapura",
+        "Asia/Jerusalem",
+        "Asia/Kabul",
+        "Asia/Kamchatka",
+        "Asia/Karachi",
+        "Asia/Kashgar",
+        "Asia/Kathmandu",
+        "Asia/Katmandu",
+        "Asia/Khandyga",
+        "Asia/Kolkata",
+        "Asia/Krasnoyarsk",
+        "Asia/Kuala_Lumpur",
+        "Asia/Kuching",
+        "Asia/Kuwait",
+        "Asia/Macao",
+        "Asia/Macau",
+        "Asia/Magadan",
+        "Asia/Makassar",
+        "Asia/Manila",
+        "Asia/Muscat",
+        "Asia/Nicosia",
+        "Asia/Novokuznetsk",
+        "Asia/Novosibirsk",
+        "Asia/Omsk",
+        "Asia/Oral",
+        "Asia/Phnom_Penh",
+        "Asia/Pontianak",
+        "Asia/Pyongyang",
+        "Asia/Qatar",
+        "Asia/Qostanay",
+        "Asia/Qyzylorda",
+        "Asia/Rangoon",
+        "Asia/Riyadh",
+        "Asia/Saigon",
+        "Asia/Sakhalin",
+        "Asia/Samarkand",
+        "Asia/Seoul",
+        "Asia/Shanghai",
+        "Asia/Singapore",
+        "Asia/Srednekolymsk",
+        "Asia/Taipei",
+        "Asia/Tashkent",
+        "Asia/Tbilisi",
+        "Asia/Tehran",
+        "Asia/Tel_Aviv",
+        "Asia/Thimbu",
+        "Asia/Thimphu",
+        "Asia/Tokyo",
+        "Asia/Tomsk",
+        "Asia/Ujung_Pandang",
+        "Asia/Ulaanbaatar",
+        "Asia/Ulan_Bator",
+        "Asia/Urumqi",
+        "Asia/Ust-Nera",
+        "Asia/Vientiane",
+        "Asia/Vladivostok",
+        "Asia/Yakutsk",
+        "Asia/Yangon",
+        "Asia/Yekaterinburg",
+        "Asia/Yerevan",
+        "Atlantic/Azores",
+        "Atlantic/Bermuda",
+        "Atlantic/Canary",
+        "Atlantic/Cape_Verde",
+        "Atlantic/Faeroe",
+        "Atlantic/Faroe",
+        "Atlantic/Jan_Mayen",
+        "Atlantic/Madeira",
+        "Atlantic/Reykjavik",
+        "Atlantic/South_Georgia",
+        "Atlantic/St_Helena",
+        "Atlantic/Stanley",
+        "Australia/ACT",
+        "Australia/Adelaide",
+        "Australia/Brisbane",
+        "Australia/Broken_Hill",
+        "Australia/Canberra",
+        "Australia/Currie",
+        "Australia/Darwin",
+        "Australia/Eucla",
+        "Australia/Hobart",
+        "Australia/LHI",
+        "Australia/Lindeman",
+        "Australia/Lord_Howe",
+        "Australia/Melbourne",
+        "Australia/NSW",
+        "Australia/North",
+        "Australia/Perth",
+        "Australia/Queensland",
+        "Australia/South",
+        "Australia/Sydney",
+        "Australia/Tasmania",
+        "Australia/Victoria",
+        "Australia/West",
+        "Australia/Yancowinna",
+        "Brazil/Acre",
+        "Brazil/DeNoronha",
+        "Brazil/East",
+        "Brazil/West",
+        "CET",
+        "CST6CDT",
+        "Canada/Atlantic",
+        "Canada/Central",
+        "Canada/Eastern",
+        "Canada/Mountain",
+        "Canada/Newfoundland",
+        "Canada/Pacific",
+        "Canada/Saskatchewan",
+        "Canada/Yukon",
+        "Chile/Continental",
+        "Chile/EasterIsland",
+        "Cuba",
+        "EET",
+        "EST",
+        "EST5EDT",
+        "Egypt",
+        "Eire",
+        "Etc/GMT",
+        "Etc/GMT+0",
+        "Etc/GMT+1",
+        "Etc/GMT+10",
+        "Etc/GMT+11",
+        "Etc/GMT+12",
+        "Etc/GMT+2",
+        "Etc/GMT+3",
+        "Etc/GMT+4",
+        "Etc/GMT+5",
+        "Etc/GMT+6",
+        "Etc/GMT+7",
+        "Etc/GMT+8",
+        "Etc/GMT+9",
+        "Etc/GMT-0",
+        "Etc/GMT-1",
+        "Etc/GMT-10",
+        "Etc/GMT-11",
+        "Etc/GMT-12",
+        "Etc/GMT-13",
+        "Etc/GMT-14",
+        "Etc/GMT-2",
+        "Etc/GMT-3",
+        "Etc/GMT-4",
+        "Etc/GMT-5",
+        "Etc/GMT-6",
+        "Etc/GMT-7",
+        "Etc/GMT-8",
+        "Etc/GMT-9",
+        "Etc/GMT0",
+        "Etc/Greenwich",
+        "Etc/UCT",
+        "Etc/UTC",
+        "Etc/Universal",
+        "Etc/Zulu",
+        "Europe/Amsterdam",
+        "Europe/Andorra",
+        "Europe/Astrakhan",
+        "Europe/Athens",
+        "Europe/Belfast",
+        "Europe/Belgrade",
+        "Europe/Berlin",
+        "Europe/Bratislava",
+        "Europe/Brussels",
+        "Europe/Bucharest",
+        "Europe/Budapest",
+        "Europe/Busingen",
+        "Europe/Chisinau",
+        "Europe/Copenhagen",
+        "Europe/Dublin",
+        "Europe/Gibraltar",
+        "Europe/Guernsey",
+        "Europe/Helsinki",
+        "Europe/Isle_of_Man",
+        "Europe/Istanbul",
+        "Europe/Jersey",
+        "Europe/Kaliningrad",
+        "Europe/Kiev",
+        "Europe/Kirov",
+        "Europe/Kyiv",
+        "Europe/Lisbon",
+        "Europe/Ljubljana",
+        "Europe/London",
+        "Europe/Luxembourg",
+        "Europe/Madrid",
+        "Europe/Malta",
+        "Europe/Mariehamn",
+        "Europe/Minsk",
+        "Europe/Monaco",
+        "Europe/Moscow",
+        "Europe/Nicosia",
+        "Europe/Oslo",
+        "Europe/Paris",
+        "Europe/Podgorica",
+        "Europe/Prague",
+        "Europe/Riga",
+        "Europe/Rome",
+        "Europe/Samara",
+        "Europe/San_Marino",
+        "Europe/Sarajevo",
+        "Europe/Saratov",
+        "Europe/Simferopol",
+        "Europe/Skopje",
+        "Europe/Sofia",
+        "Europe/Stockholm",
+        "Europe/Tallinn",
+        "Europe/Tirane",
+        "Europe/Tiraspol",
+        "Europe/Ulyanovsk",
+        "Europe/Uzhgorod",
+        "Europe/Vaduz",
+        "Europe/Vatican",
+        "Europe/Vienna",
+        "Europe/Vilnius",
+        "Europe/Volgograd",
+        "Europe/Warsaw",
+        "Europe/Zagreb",
+        "Europe/Zaporozhye",
+        "Europe/Zurich",
+        "GB",
+        "GB-Eire",
+        "GMT",
+        "GMT+0",
+        "GMT-0",
+        "GMT0",
+        "Greenwich",
+        "HST",
+        "Hongkong",
+        "Iceland",
+        "Indian/Antananarivo",
+        "Indian/Chagos",
+        "Indian/Christmas",
+        "Indian/Cocos",
+        "Indian/Comoro",
+        "Indian/Kerguelen",
+        "Indian/Mahe",
+        "Indian/Maldives",
+        "Indian/Mauritius",
+        "Indian/Mayotte",
+        "Indian/Reunion",
+        "Iran",
+        "Israel",
+        "Jamaica",
+        "Japan",
+        "Kwajalein",
+        "Libya",
+        "MET",
+        "MST",
+        "MST7MDT",
+        "Mexico/BajaNorte",
+        "Mexico/BajaSur",
+        "Mexico/General",
+        "NZ",
+        "NZ-CHAT",
+        "Navajo",
+        "PRC",
+        "PST8PDT",
+        "Pacific/Apia",
+        "Pacific/Auckland",
+        "Pacific/Bougainville",
+        "Pacific/Chatham",
+        "Pacific/Chuuk",
+        "Pacific/Easter",
+        "Pacific/Efate",
+        "Pacific/Enderbury",
+        "Pacific/Fakaofo",
+        "Pacific/Fiji",
+        "Pacific/Funafuti",
+        "Pacific/Galapagos",
+        "Pacific/Gambier",
+        "Pacific/Guadalcanal",
+        "Pacific/Guam",
+        "Pacific/Honolulu",
+        "Pacific/Johnston",
+        "Pacific/Kanton",
+        "Pacific/Kiritimati",
+        "Pacific/Kosrae",
+        "Pacific/Kwajalein",
+        "Pacific/Majuro",
+        "Pacific/Marquesas",
+        "Pacific/Midway",
+        "Pacific/Nauru",
+        "Pacific/Niue",
+        "Pacific/Norfolk",
+        "Pacific/Noumea",
+        "Pacific/Pago_Pago",
+        "Pacific/Palau",
+        "Pacific/Pitcairn",
+        "Pacific/Pohnpei",
+        "Pacific/Ponape",
+        "Pacific/Port_Moresby",
+        "Pacific/Rarotonga",
+        "Pacific/Saipan",
+        "Pacific/Samoa",
+        "Pacific/Tahiti",
+        "Pacific/Tarawa",
+        "Pacific/Tongatapu",
+        "Pacific/Truk",
+        "Pacific/Wake",
+        "Pacific/Wallis",
+        "Pacific/Yap",
+        "Poland",
+        "Portugal",
+        "ROC",
+        "ROK",
+        "Singapore",
+        "Turkey",
+        "UCT",
+        "US/Alaska",
+        "US/Aleutian",
+        "US/Arizona",
+        "US/Central",
+        "US/East-Indiana",
+        "US/Eastern",
+        "US/Hawaii",
+        "US/Indiana-Starke",
+        "US/Michigan",
+        "US/Mountain",
+        "US/Pacific",
+        "US/Samoa",
+        "UTC",
+        "Universal",
+        "W-SU",
+        "WET",
+        "Zulu"
+      ]
+    },
+    "dependency-type": {
+      "type": "string",
+      "enum": ["direct", "indirect", "all", "production", "development"],
+      "x-intellij-enum-metadata": {
+        "direct": {
+          "description": "All explicitly defined dependencies."
+        },
+        "indirect": {
+          "description": "Dependencies of direct dependencies (also known as sub-dependencies, or transient dependencies)."
+        },
+        "all": {
+          "description": "All explicitly defined dependencies. For bundler, pip, composer, cargo, also the dependencies of direct dependencies."
+        },
+        "production": {
+          "description": "Only dependencies in the 'Product dependency group'."
+        },
+        "development": {
+          "description": "Only dependencies in the 'Development dependency group'."
+        }
+      }
+    },
+    "update-types": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "version-update:semver-major",
+          "version-update:semver-minor",
+          "version-update:semver-patch"
+        ]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "insecure-external-code-execution": {
+      "type": "string",
+      "enum": ["allow", "deny"]
+    },
+    "versioning-strategy": {
+      "type": "string",
+      "enum": [
+        "auto",
+        "increase",
+        "increase-if-necessary",
+        "lockfile-only",
+        "widen"
+      ],
+      "x-intellij-enum-metadata": {
+        "auto": {
+          "description": "Try to differentiate between apps and libraries. Use 'increase' for apps and 'widen' for libraries."
+        },
+        "increase": {
+          "description": "Always increase the minimum version requirement to match the new version. If a range already exists, typically this only increases the lower bound."
+        },
+        "increase-if-necessary": {
+          "description": "Leave the constraint if the original constraint allows the new version, otherwise, bump the constraint."
+        },
+        "lockfile-only": {
+          "description": "Only create pull requests to update lockfiles. Ignore any new versions that would require package manifest changes."
+        },
+        "widen": {
+          "description": "Widen the allowed version requirements to include both the new and old versions, when possible. Typically, this only increases the maximum allowed version requirement."
+        }
+      }
+    },
+    "package-ecosystem-values": {
+      "enum": [
+        "bazel",
+        "bun",
+        "bundler",
+        "cargo",
+        "composer",
+        "conda",
+        "devcontainers",
+        "docker",
+        "docker-compose",
+        "dotnet-sdk",
+        "elm",
+        "github-actions",
+        "gitsubmodule",
+        "gomod",
+        "gradle",
+        "helm",
+        "julia",
+        "maven",
+        "mix",
+        "nix",
+        "npm",
+        "nuget",
+        "opentofu",
+        "pip",
+        "pre-commit",
+        "pub",
+        "rust-toolchain",
+        "swift",
+        "terraform",
+        "uv",
+        "vcpkg"
+      ]
+    },
+    "schedule-day": {
+      "type": "string",
+      "enum": [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday"
+      ]
+    },
+    "schedule-interval": {
+      "type": "string",
+      "enum": [
+        "daily",
+        "weekly",
+        "monthly",
+        "quarterly",
+        "semiannually",
+        "yearly",
+        "cron"
+      ]
+    },
+    "update": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "description": "Customize which updates are allowed",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dependency-name": {
+                "type": "string"
+              },
+              "dependency-type": {
+                "$ref": "#/definitions/dependency-type"
+              },
+              "update-types": {
+                "$ref": "#/definitions/update-types",
+                "description": "Use to allow specific types of updates. You can combine this with 'dependency-name: \"*\"' to allow particular update-types for all dependencies."
+              }
+            },
+            "anyOf": [
+              {
+                "required": ["dependency-name"]
+              },
+              {
+                "required": ["dependency-type"]
+              }
+            ],
+            "additionalProperties": false
+          }
+        },
+        "assignees": {
+          "description": "Assignees to set on pull requests",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "commit-message": {
+          "description": "Dependabot attempts to detect your commit message preferences and use similar patterns. Use this option to specify your preferences explicitly.",
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "description": "A prefix for all commit messages. When you specify a prefix for commit messages, GitHub will automatically add a colon between the defined prefix and the commit message provided the defined prefix ends with a letter, number, closing parenthesis, or closing bracket. This means that, for example, if you end the prefix with a whitespace, there will be no colon added between the prefix and the commit message.",
+              "type": "string",
+              "maxLength": 50
+            },
+            "prefix-development": {
+              "description": "A separate prefix for all commit messages that update dependencies in the Development dependency group. When you specify a value for this option, the prefix is used only for updates to dependencies in the Production dependency group. This is not supported by all package ecosystems.",
+              "type": "string",
+              "maxLength": 50
+            },
+            "include": {
+              "description": "Specifies that any prefix is followed by a list of the dependencies updated in the commit.",
+              "type": "string",
+              "enum": ["scope"],
+              "default": "scope"
+            }
+          },
+          "anyOf": [
+            {
+              "required": ["prefix"]
+            },
+            {
+              "required": ["prefix-development"]
+            },
+            {
+              "required": ["include"]
+            }
+          ],
+          "additionalProperties": false
+        },
+        "cooldown": {
+          "description": "Defines a cooldown period for dependency updates, allowing updates to be delayed for a configurable number of days. This feature enables users to customize how often Dependabot generates new version updates, offering greater control over update frequency.",
+          "type": "object",
+          "properties": {
+            "default-days": {
+              "description": "Default cooldown period for dependencies without specific rules (optional).",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90
+            },
+            "semver-major-days": {
+              "description": "Cooldown period for major version updates (optional, applies only to package managers supporting SemVer).",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90
+            },
+            "semver-minor-days": {
+              "description": "Cooldown period for minor version updates (optional, applies only to package managers supporting SemVer).",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 90
+            },
+            "semver-patch-days": {
+              "description": "Cooldown period for patch version updates (optional, applies only to package managers supporting SemVer).",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 90
+            },
+            "include": {
+              "description": "List of dependencies to apply cooldown. Supports wildcards (`*`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 100
+            },
+            "exclude": {
+              "description": "List of dependencies excluded from cooldown. Supports wildcards (`*`).",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 100
+            }
+          },
+          "additionalProperties": false
+        },
+        "directories": {
+          "description": "Locations of package manifests",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "directory": {
+          "description": "Location of package manifests",
+          "type": "string",
+          "examples": ["/", "/ecosystem"]
+        },
+        "exclude-paths": {
+          "description": "List of file paths to exclude from dependency updates",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "description": "Configure groups for dependencies. Each 'groups' property is arbitrary will appear in pull request titles and branch names. For example, the code snippet '{\"groups\": {\"NPM dependencies\": {\"patterns\": [\"*\"]}}}' sets the group name to 'NPM dependencies'.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "applies-to": {
+                "description": "Use to specify a whether the rules in the group apply to version updates or security updates.",
+                "type": "string",
+                "enum": ["version-updates", "security-updates"]
+              },
+              "dependency-type": {
+                "description": "Specify a dependency type to be included in the group.",
+                "type": "string",
+                "enum": ["development", "production"]
+              },
+              "patterns": {
+                "description": "Define strings of characters that match with a dependency name (or multiple dependency names) to include those dependencies in the group.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "minItems": 1
+              },
+              "exclude-patterns": {
+                "description": "Exclude certain dependencies from the group. If a dependency is excluded from a group, Dependabot will continue to raise single pull requests to update the dependency to its latest version.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "uniqueItems": true,
+                "minItems": 1
+              },
+              "update-types": {
+                "description": "Specify the semantic versioning level to include in the group",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["major", "minor", "patch"]
+                },
+                "minItems": 1,
+                "uniqueItems": true
+              },
+              "group-by": {
+                "description": "Configure how dependencies are grouped within this group.",
+                "type": "string",
+                "enum": ["dependency-name"]
+              }
+            },
+            "anyOf": [
+              {
+                "required": ["dependency-type"]
+              },
+              {
+                "required": ["patterns"]
+              },
+              {
+                "required": ["exclude-patterns"]
+              },
+              {
+                "required": ["update-types"]
+              },
+              {
+                "required": ["group-by"]
+              }
+            ],
+            "additionalProperties": false
+          },
+          "minProperties": 1
+        },
+        "ignore": {
+          "description": "Ignore certain dependencies or versions",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dependency-name": {
+                "description": "Use to ignore updates for dependencies with matching names, optionally using * to match zero or more characters.",
+                "type": "string"
+              },
+              "update-types": {
+                "$ref": "#/definitions/update-types",
+                "description": "Use to ignore types of updates. You can combine this with 'dependency-name: \"*\"' to ignore particular update-types for all dependencies."
+              },
+              "versions": {
+                "description": "Use to ignore specific versions or ranges of versions. If you want to define a range, use the standard pattern for the package manager.",
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                  }
+                ]
+              }
+            },
+            "anyOf": [
+              {
+                "required": ["dependency-name"]
+              },
+              {
+                "required": ["update-types"]
+              },
+              {
+                "required": ["versions"]
+              }
+            ],
+            "additionalProperties": false
+          }
+        },
+        "insecure-external-code-execution": {
+          "$ref": "#/definitions/insecure-external-code-execution",
+          "description": "Allow or deny code execution in manifest files"
+        },
+        "labels": {
+          "description": "Labels to set on pull requests",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": ["dependencies"]
+        },
+        "milestone": {
+          "description": "Associate all pull requests raised for a package manager with a milestone. You need to specify the numeric identifier of the milestone and not its label.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "name": {
+          "description": "A name for the update configuration.",
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 100
+        },
+        "open-pull-requests-limit": {
+          "description": "Limit number of open pull requests for version updates",
+          "type": "integer",
+          "minimum": 0,
+          "default": 5
+        },
+        "package-ecosystem": {
+          "$comment": "These values are restricted by a top-level if-then-else when 'enable-beta-ecosystems' is not enabled.",
+          "description": "Package manager to use",
+          "type": "string",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/package-ecosystem-values"
+            },
+            {
+              "minLength": 1
+            }
+          ]
+        },
+        "pull-request-branch-name": {
+          "description": "Pull request branch name preferences",
+          "type": "object",
+          "properties": {
+            "separator": {
+              "description": "Change separator for PR branch name",
+              "type": "string",
+              "default": "/",
+              "enum": ["-", "_", "/"]
+            }
+          },
+          "required": ["separator"],
+          "additionalProperties": false
+        },
+        "rebase-strategy": {
+          "description": "Disable automatic rebasing. 'auto' is the default and Dependabot will rebase open pull requests when changes are detected. 'disabled' will disable automatic rebasing.",
+          "type": "string",
+          "enum": ["auto", "disabled"],
+          "default": "auto"
+        },
+        "registries": {
+          "$comment": "'registries' must be either an array of strings, or the string constant '*'.",
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "uniqueItems": true,
+              "minItems": 1
+            },
+            {
+              "type": "string",
+              "const": "*"
+            }
+          ]
+        },
+        "schedule": {
+          "description": "Schedule preferences",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "$ref": "#/definitions/schedule-interval"
+            },
+            "day": {
+              "$ref": "#/definitions/schedule-day",
+              "description": "Specify an alternative day to check for updates"
+            },
+            "time": {
+              "type": "string",
+              "description": "Specify an alternative time of day to check for updates (format: hh:mm)",
+              "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$"
+            },
+            "timezone": {
+              "$ref": "#/definitions/timezone",
+              "description": "The time zone identifier must be from the Time Zone database maintained by IANA"
+            },
+            "cronjob": {
+              "type": "string",
+              "description": "Specify a valid cron expression for updates"
+            }
+          },
+          "allOf": [
+            {
+              "$comment": "If interval type is 'cron', enforce 'cronjob' property.",
+              "if": {
+                "properties": {
+                  "interval": {
+                    "const": "cron"
+                  }
+                }
+              },
+              "then": {
+                "required": ["interval", "cronjob"]
+              },
+              "else": {
+                "required": ["interval"]
+              }
+            }
+          ]
+        },
+        "target-branch": {
+          "description": "Specify a different branch for manifest files and for pull requests.",
+          "type": "string",
+          "minLength": 1
+        },
+        "vendor": {
+          "description": "Tell Dependabot to vendor dependencies when updating them. Don't use this option if you're using 'gomod'.",
+          "type": "boolean"
+        },
+        "versioning-strategy": {
+          "$ref": "#/definitions/versioning-strategy",
+          "description": "How to update manifest version requirements"
+        },
+        "patterns": {
+          "description": "Array of dependency patterns to include in a multi-ecosystem group. Required when using multi-ecosystem-group. Use '*' to include all dependencies.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "multi-ecosystem-group": {
+          "description": "String identifier linking this ecosystem to a multi-ecosystem group",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "$comment": "Schedule is required UNLESS multi-ecosystem-group is specified",
+          "if": {
+            "required": ["multi-ecosystem-group"]
+          },
+          "then": {
+            "required": ["package-ecosystem"]
+          },
+          "else": {
+            "required": ["package-ecosystem", "schedule"]
+          }
+        },
+        {
+          "oneOf": [
+            {
+              "required": ["directories"]
+            },
+            {
+              "required": ["directory"]
+            }
+          ]
+        },
+        {
+          "$comment": "If multi-ecosystem-group is specified, patterns is required",
+          "if": {
+            "required": ["multi-ecosystem-group"]
+          },
+          "then": {
+            "required": ["patterns"]
+          }
+        }
+      ]
+    },
+    "registry": {
+      "type": "object",
+      "description": "The top-level registries key is optional. It allows you to specify authentication details that Dependabot can use to access private package registries.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "type": {
+            "description": "Identifies the type of registry.",
+            "enum": [
+              "cargo-registry",
+              "composer-repository",
+              "docker-registry",
+              "git",
+              "goproxy-server",
+              "hex-organization",
+              "hex-repository",
+              "helm-registry",
+              "maven-repository",
+              "npm-registry",
+              "nuget-feed",
+              "pub-repository",
+              "python-index",
+              "rubygems-server",
+              "terraform-registry"
+            ]
+          },
+          "url": {
+            "description": "The URL to use to access the dependencies in this registry. The protocol is optional. If not specified, 'https://' is assumed. Dependabot adds or ignores trailing slashes as required.",
+            "type": "string"
+          },
+          "username": {
+            "description": "The username that Dependabot uses to access the registry.",
+            "type": "string"
+          },
+          "password": {
+            "description": "A reference to a Dependabot secret containing the password for the specified user.",
+            "type": "string"
+          },
+          "key": {
+            "description": "A reference to a Dependabot secret containing an access key for this registry.",
+            "type": "string"
+          },
+          "token": {
+            "description": "A reference to a Dependabot secret containing an access token for this registry.",
+            "type": "string"
+          },
+          "replaces-base": {
+            "description": "For registries with type: python-index, if the boolean value is true, pip resolves dependencies by using the specified URL rather than the base URL of the Python Package Index (by default https://pypi.org/simple).",
+            "type": "boolean"
+          },
+          "organization": {
+            "description": "",
+            "type": "string"
+          },
+          "repo": {
+            "description": "",
+            "type": "string"
+          },
+          "auth-key": {
+            "description": "",
+            "type": "string"
+          },
+          "public-key-fingerprint": {
+            "description": "",
+            "type": "string"
+          },
+          "registry": {
+            "description": "The name of the cargo registry.",
+            "type": "string"
+          },
+          "tenant-id": {
+            "description": "The tenant ID for Azure OIDC authentication.",
+            "type": "string"
+          },
+          "client-id": {
+            "description": "The client ID for Azure OIDC authentication.",
+            "type": "string"
+          },
+          "jfrog-oidc-provider-name": {
+            "description": "The JFrog OIDC provider name for authentication.",
+            "type": "string"
+          },
+          "identity-mapping-name": {
+            "description": "The identity mapping name for JFrog OIDC authentication.",
+            "type": "string"
+          },
+          "audience": {
+            "description": "The audience for OIDC or AWS authentication.",
+            "type": "string"
+          },
+          "aws-region": {
+            "description": "The AWS region for AWS CodeArtifact authentication.",
+            "type": "string"
+          },
+          "account-id": {
+            "description": "The AWS account ID for AWS CodeArtifact authentication.",
+            "type": "string"
+          },
+          "role-name": {
+            "description": "The AWS role name for AWS CodeArtifact authentication.",
+            "type": "string"
+          },
+          "domain": {
+            "description": "The domain for AWS CodeArtifact authentication.",
+            "type": "string"
+          },
+          "domain-owner": {
+            "description": "The domain owner for AWS CodeArtifact authentication.",
+            "type": "string"
+          }
+        },
+        "required": ["type", "url"]
+      },
+      "minProperties": 1
+    },
+    "multi-ecosystem-group": {
+      "type": "object",
+      "description": "Define a group that spans multiple package ecosystems, allowing consolidated pull requests across different ecosystems",
+      "additionalProperties": false,
+      "properties": {
+        "schedule": {
+          "description": "Schedule preferences for the group",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "$ref": "#/definitions/schedule-interval"
+            },
+            "day": {
+              "$ref": "#/definitions/schedule-day",
+              "description": "Specify an alternative day to check for updates"
+            },
+            "time": {
+              "type": "string",
+              "description": "Specify an alternative time of day to check for updates (format: hh:mm)",
+              "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$"
+            },
+            "timezone": {
+              "$ref": "#/definitions/timezone",
+              "description": "The time zone identifier must be from the Time Zone database maintained by IANA"
+            },
+            "cronjob": {
+              "type": "string",
+              "description": "Specify a valid cron expression for updates"
+            }
+          },
+          "allOf": [
+            {
+              "$comment": "If interval type is 'cron', enforce 'cronjob' property.",
+              "if": {
+                "properties": {
+                  "interval": {
+                    "const": "cron"
+                  }
+                }
+              },
+              "then": {
+                "required": ["interval", "cronjob"]
+              },
+              "else": {
+                "required": ["interval"]
+              }
+            }
+          ]
+        },
+        "labels": {
+          "description": "Labels to set on pull requests (additive - merges with ecosystem-level labels)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 0,
+          "uniqueItems": true
+        },
+        "assignees": {
+          "description": "Assignees to set on pull requests (additive - merges with ecosystem-level assignees)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "milestone": {
+          "description": "Associate all pull requests raised for this group with a milestone. You need to specify the numeric identifier of the milestone and not its label.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "target-branch": {
+          "description": "Specify a different branch for manifest files and for pull requests.",
+          "type": "string",
+          "minLength": 1
+        },
+        "commit-message": {
+          "description": "Commit message preferences for the group",
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "description": "A prefix for all commit messages",
+              "type": "string",
+              "maxLength": 50
+            },
+            "prefix-development": {
+              "description": "A separate prefix for all commit messages that update dependencies in the Development dependency group",
+              "type": "string",
+              "maxLength": 50
+            },
+            "include": {
+              "description": "Specifies that any prefix is followed by a list of the dependencies updated in the commit",
+              "type": "string",
+              "enum": ["scope"]
+            }
+          },
+          "anyOf": [
+            {
+              "required": ["prefix"]
+            },
+            {
+              "required": ["prefix-development"]
+            },
+            {
+              "required": ["include"]
+            }
+          ],
+          "additionalProperties": false
+        },
+        "pull-request-branch-name": {
+          "description": "Pull request branch name preferences for the group",
+          "type": "object",
+          "properties": {
+            "separator": {
+              "description": "Change separator for PR branch name",
+              "type": "string",
+              "default": "/",
+              "enum": ["-", "_", "/"]
+            }
+          },
+          "required": ["separator"],
+          "additionalProperties": false
+        },
+        "open-pull-requests-limit": {
+          "description": "Limit number of open pull requests for version updates.",
+          "type": "integer",
+          "minimum": 0,
+          "default": 5
+        },
+        "update-types": {
+          "description": "Specify the semantic versioning update types for the group.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["major", "minor", "patch"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "dependency-type": {
+          "description": "Specify a dependency type to be included in the group.",
+          "type": "string",
+          "enum": ["production", "development"]
+        },
+        "exclude-patterns": {
+          "description": "Exclude certain dependencies from the group.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      },
+      "required": ["schedule"]
+    }
+  },
+  "properties": {
+    "version": {
+      "title": "Config file version",
+      "description": "Dependabot configuration files require this key, and its value must be 2",
+      "type": "integer",
+      "enum": [2]
+    },
+    "enable-beta-ecosystems": {
+      "description": "Enable ecosystems that have beta-level support",
+      "type": "boolean"
+    },
+    "updates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/update",
+        "title": "Package Ecosystem",
+        "description": "Element for each one package manager that you want GitHub Dependabot to monitor for new versions"
+      }
+    },
+    "registries": {
+      "$ref": "#/definitions/registry"
+    },
+    "multi-ecosystem-groups": {
+      "type": "object",
+      "description": "Define groups that span multiple package ecosystems, allowing consolidated pull requests across different ecosystems",
+      "additionalProperties": {
+        "$ref": "#/definitions/multi-ecosystem-group"
+      },
+      "minProperties": 1
+    }
+  },
+  "required": ["version", "updates"],
+  "title": "GitHub Dependabot v2 config",
+  "type": "object",
+  "allOf": [
+    {
+      "$comment": "If 'enable-beta-ecosystems' is NOT enabled, enforce known 'package-ecosystem' values.",
+      "if": {
+        "properties": {
+          "enable-beta-ecosystems": {
+            "const": true
+          }
+        },
+        "required": ["enable-beta-ecosystems"]
+      },
+      "then": {},
+      "else": {
+        "properties": {
+          "updates": {
+            "items": {
+              "properties": {
+                "package-ecosystem": {
+                  "$ref": "#/definitions/package-ecosystem-values"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.github/workflows/dependabot-selftest.yml
+++ b/.github/workflows/dependabot-selftest.yml
@@ -1,0 +1,70 @@
+# Mango dependabot-selftest workflow
+#
+# Runs `scripts/dependabot-scripts-test.sh` on every PR and push that
+# touches the Dependabot config, its self-test script, the vendored
+# JSON Schema, the policy doc, or this workflow. The self-test
+# asserts the structural invariants Dependabot's runtime + mango's
+# SHA-pin policy depend on (see the script header for the full list).
+#
+# Why a dedicated workflow:
+#   - Narrow path filter keeps every other PR from paying the cost
+#     of installing `check-jsonschema`.
+#   - Matches the one-workflow-per-gate convention (geiger, madsim,
+#     miri, semver-checks, vet, etc.).
+#   - Independent status check for branch protection.
+#
+# Security: no `github.event.*` interpolation in `run:` blocks; all
+# inputs are static. Actions SHA-pinned per repo convention. The
+# only dynamic expression is `github.ref` in `concurrency.group`,
+# which GitHub sanitizes.
+#
+# In CI (`CI` env set by GitHub Actions), the self-test treats
+# missing validator tools as hard failures. Locally they skip with
+# an install hint — see scripts/dependabot-scripts-test.sh header.
+
+name: dependabot-selftest
+
+on:
+  pull_request:
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/schemas/dependabot-2.0.json"
+      - ".github/schemas/README.md"
+      - ".github/workflows/dependabot-selftest.yml"
+      - "scripts/dependabot-scripts-test.sh"
+      - "docs/dependency-updates.md"
+      # Workflow uses: lines are covered by assertion #15; any
+      # workflow change should re-run the regex check.
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/schemas/dependabot-2.0.json"
+      - ".github/schemas/README.md"
+      - ".github/workflows/dependabot-selftest.yml"
+      - "scripts/dependabot-scripts-test.sh"
+      - "docs/dependency-updates.md"
+      - ".github/workflows/**"
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  selftest:
+    name: selftest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: install check-jsonschema
+        # pipx ships in the ubuntu-24.04 runner image; `pipx install`
+        # places the binary on PATH for subsequent steps.
+        run: pipx install check-jsonschema
+      - name: run dependabot self-test
+        run: bash scripts/dependabot-scripts-test.sh

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -1,0 +1,221 @@
+# Dependency updates
+
+Mango uses [Dependabot] to keep GitHub Action SHAs and Cargo workspace
+crate versions current. Every proposed bump ships as a PR and goes
+through the normal expert-review + CI-gate loop — **no auto-merge
+anywhere**. The bot is a signal, not an authority.
+
+Config: [`.github/dependabot.yml`](../.github/dependabot.yml)
+Self-test: [`scripts/dependabot-scripts-test.sh`](../scripts/dependabot-scripts-test.sh)
+Schema: [`.github/schemas/dependabot-2.0.json`](../.github/schemas/dependabot-2.0.json)
+
+[Dependabot]: https://docs.github.com/en/code-security/dependabot
+
+## Why Dependabot, not Renovate
+
+Dependabot is GitHub-native, understands our SHA-pin policy for
+`uses:` lines, and reads `[workspace.dependencies]` (including the
+`=` exact pins on `loom`, `madsim`, and `madsim-tokio`). Renovate is
+more powerful but requires installing the Mend GitHub App — a
+supply-chain surface we would need to audit to re-gain capabilities
+we do not currently use.
+
+## What Dependabot watches
+
+- **GitHub Actions** — every `uses:` line in `.github/workflows/*.yml`.
+  Dependabot bumps the 40-hex SHA and, for actions that publish
+  semver tags, the trailing `# <ref>` comment in lockstep.
+- **Cargo** — `[workspace.dependencies]` in `Cargo.toml` + `Cargo.lock`.
+  Exact pins (`=0.7.2`) are bumped as exact pins (the `=` is kept).
+
+## Schedule
+
+Both ecosystems run **Monday 14:00 UTC** (10:00 ET / 07:00 PT).
+Grouped PRs — minor/patch and major split per ecosystem, plus a
+named `madsim-family` group for `madsim` + `madsim-tokio` (see
+"Grouping and atomicity" below). Queue bounded by
+`open-pull-requests-limit: 5` per ecosystem.
+
+## Reviewer checklist for a Dependabot PR
+
+For every Dependabot PR, verify on the green-CI path:
+
+1. **MSRV gate green** — `ci.yml` + `madsim.yml` both run under
+   workspace MSRV (1.80). A proposed bump that requires rustc >= 1.81
+   red-flags these jobs. See "MSRV-incompatible bumps" below.
+2. **cargo-deny green** — license / bans / sources / advisories.
+3. **cargo-vet green** — supply-chain audit. Transitive graph shifts
+   are the common failure mode; see "Transitive graph shifts" below.
+4. **cargo-audit green** — RUSTSEC advisories. If the bump closes
+   an advisory cited by `deny.toml`'s ignore list, prune the stale
+   entry in the same PR.
+5. **cargo-public-api / cargo-semver-checks green** — once Phase 6
+   ships these are gating; today they are advisory.
+6. **SHA-pin regression test (actions PRs)** — the self-test
+   `scripts/dependabot-scripts-test.sh` asserts every workflow
+   `uses:` line still carries a 40-hex SHA. `ci.yml` runs it on
+   any PR that touches dependabot-adjacent files.
+7. **Trailing comment** — see "Trailing comments" below.
+8. **madsim-family bumps** — verify both `madsim` and `madsim-tokio`
+   (manifest key `tokio`) are moved together in the same PR. The
+   `madsim-family` group enforces this structurally; if you see a
+   split PR, something has regressed.
+9. **Stale ignore reasons in `deny.toml`** — if this PR bumps a
+   crate cited by a `deny.toml` ignore entry (today: `time`,
+   `bincode`), prune or rewrite the entry's reason text to reflect
+   the new version.
+
+## Grouping and atomicity
+
+Named groups are evaluated in declaration order. `madsim-family` is
+load-bearing:
+
+```yaml
+madsim-family:
+  patterns:
+    - "madsim"
+    - "madsim-*"
+    - "tokio" # madsim-tokio under the workspace package-rename
+  update-types: [patch, minor, major]
+```
+
+`tokio` here is the _manifest key_, not the upstream crate name —
+the workspace renames the `madsim-tokio` crate to `tokio` at
+[`Cargo.toml:69`](../Cargo.toml):
+
+```toml
+tokio = { version = "=0.2.30", package = "madsim-tokio" }
+```
+
+Dependabot groups by manifest key, so listing `tokio` captures
+`madsim-tokio`. If a future refactor removes this rename, the
+`tokio` entry in `madsim-family` becomes dead and should either be
+removed or repointed.
+
+Why atomic: the Cargo.toml header comment for these lines says
+_"move both lines together."_ `madsim` and `madsim-tokio` are
+released in lockstep by upstream; splitting the bump across PRs
+leaves one of the two PRs with a broken `cargo check` and red CI.
+The group makes this impossible by construction — both land in the
+same PR or neither does.
+
+## Trailing comments (SHA-pin policy)
+
+Every `uses:` line in `.github/workflows/*.yml` MUST be a 40-hex SHA.
+The trailing `# <ref>` comment is a human-readable hint; its exact
+form depends on whether the upstream action publishes semver tags
+or tracks branches:
+
+| Action                            | Example trailing comment |
+| --------------------------------- | ------------------------ |
+| `actions/checkout`                | `# v4`                   |
+| `actions/cache`                   | `# v4`                   |
+| `actions/upload-artifact`         | `# v4`                   |
+| `Swatinem/rust-cache`             | `# v2`                   |
+| `taiki-e/install-action`          | `# v2`                   |
+| `EmbarkStudios/cargo-deny-action` | `# v2.0.17`              |
+| `rustsec/audit-check`             | `# v2.0.0`               |
+| `dtolnay/rust-toolchain`          | `# stable`               |
+
+For **semver-tagged** actions, Dependabot bumps the SHA and updates
+the comment to match the new tag. For **branch-tracking** actions
+(`dtolnay/rust-toolchain`), Dependabot updates the SHA but leaves
+the comment alone — that is correct; the ref is still "stable."
+
+The self-test's regex is tolerant: `uses: <owner>/<repo>@<40-hex>`
+with an **optional** trailing `# <anything>`. A missing comment is
+acceptable (not preferred). A non-SHA ref (`@v4` short form) is a
+regression that fails the check.
+
+## MSRV-incompatible bumps
+
+Policy: **do not pre-seed the `ignore:` list with MSRV guards.**
+Let CI catch them.
+
+When Dependabot proposes a bump that requires rustc >= MSRV+1:
+
+1. CI red on ci.yml / madsim.yml MSRV job.
+2. Reviewer decides: hold or bump MSRV?
+   - **Hold** → close the PR and add an `ignore:` entry with a
+     removal trigger:
+     ```yaml
+     ignore:
+       - dependency-name: "time"
+         versions: [">=0.3.42"]
+         # Remove when workspace MSRV reaches 1.81. Cross-ref:
+         # deny.toml (RUSTSEC-2026-0009) and this file's header.
+     ```
+     Every ignore entry MUST carry a removal trigger in a YAML
+     comment — same discipline as deny.toml ignores and vet
+     exemptions. Stale ignores accrete; audits miss them.
+   - **Bump MSRV** → open a separate PR bumping
+     `rust-version = "1.80"` in Cargo.toml, ship that first, then
+     return to the Dependabot PR and retry.
+
+## Transitive graph shifts
+
+When Dependabot bumps a top-level crate, the resolved transitive
+graph can shift. cargo-vet expects an exemption for every unvetted
+dep; new transitive versions cause the `vet.yml` job to fail.
+
+Recipe on the Dependabot branch:
+
+```bash
+# On the Dependabot branch, after `cargo fetch --locked`:
+cargo vet regenerate exemptions
+
+# Annotate every new exemption with a review-by date. The
+# xtask-vet-ttl gate requires a `notes = "review-by: YYYY-MM-DD ..."`
+# line on every exemption entry — missing notes fail CI.
+# (A helper script exists at scripts/vet-annotate-exemptions.sh if
+# the drift is large; for single-crate bumps a manual edit is
+# faster.)
+
+git add supply-chain/config.toml
+git commit -m "chore(vet): regenerate exemptions for <crate> bump"
+git push
+```
+
+## Stale `deny.toml` ignore reasons
+
+`deny.toml` carries RUSTSEC ignore entries whose reason text cites
+specific crate versions (e.g. `time 0.3.41`, `bincode 1.3.3`). When
+Dependabot bumps those crates, the reason text becomes stale but
+the advisory `id` is still the canonical reference — cargo-deny
+does not complain.
+
+**Reviewer responsibility**: on any PR that bumps a crate cited in
+a `deny.toml` ignore reason, prune or rewrite the entry in the
+same PR. A mechanical lint (`scripts/deny-ignore-lint.sh`) is
+tracked as a follow-up but not yet in place.
+
+## Rebase strategy
+
+Dependabot uses `rebase-strategy: auto`. When a new Dependabot PR
+lands and a prior open one auto-rebases, **human commits on that
+branch may be rewritten**. Keep human follow-ups (vet
+regenerations, deny.toml edits) as amendments to Dependabot's
+commit, or as last-mile commits immediately before merge. Do not
+leave long-lived hand-written commits on a Dependabot branch.
+
+## Pre-merge checklist
+
+Before approving:
+
+- [ ] CI green on all required workflows
+- [ ] For actions PRs: trailing `# <ref>` comment sane
+- [ ] For cargo PRs: any `deny.toml` / `supply-chain/config.toml`
+      fallout handled in the same commit
+- [ ] For madsim-family PRs: both crates in one commit
+- [ ] No auto-merge enabled
+
+## Follow-ups (tracked separately)
+
+- `scripts/deny-ignore-lint.sh` — mechanical cross-check of ignore
+  entry versions against Cargo.lock. Today it's reviewer eyeball.
+- Consider a second cargo entry with
+  `versioning-strategy: lockfile-only` for transitive security
+  patches — decide after observing Dependabot's first month of
+  traffic.
+- Split cargo grouping into `cargo-dev` vs `cargo-prod` when Phase 1
+  production crates land (the whole workspace is scaffolding today).

--- a/scripts/dependabot-scripts-test.sh
+++ b/scripts/dependabot-scripts-test.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# scripts/dependabot-scripts-test.sh
+#
+# Self-test harness for the Dependabot CI gate (ROADMAP 0.5-renovate-
+# dependabot).
+#
+# What this covers:
+#   - .github/dependabot.yml has the structural invariants the
+#     Dependabot runtime + our SHA-pin policy depend on.
+#   - The madsim-family group is wired (atomicity for `madsim` +
+#     `madsim-tokio`, the latter under the workspace package-rename
+#     at Cargo.toml → `tokio.workspace = true`).
+#   - Cargo ecosystem sets `insecure-external-code-execution: deny`
+#     (supply-chain posture).
+#   - File validates against Dependabot's vendored JSON Schema.
+#   - Every `uses:` line in .github/workflows/*.yml carries a 40-hex
+#     SHA pin with a trailing comment (SHA-pin policy regression
+#     test).
+#
+# CI vs local:
+#   When $CI is set (GitHub Actions sets CI=true unconditionally),
+#   validator tools MUST be installed or the script fails hard. A
+#   silent pass in CI on a malformed dependabot.yml would be
+#   catastrophic — Dependabot itself silently ignores files it
+#   can't parse, so our CI gate is the only alert path.
+#
+#   Locally the script prints an install hint and skips only the
+#   specific assertion requiring the missing tool; other assertions
+#   still run. Hard-failing locally on missing tools would break
+#   the first-run iteration loop.
+#
+# Invocation:
+#   bash scripts/dependabot-scripts-test.sh
+#   (run from any CWD; script cd's to repo root)
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+pass() {
+    printf 'PASS  %s\n' "$1"
+    pass_count=$((pass_count + 1))
+}
+fail() {
+    printf 'FAIL  %s\n' "$1" >&2
+    fail_count=$((fail_count + 1))
+}
+skip() {
+    printf 'SKIP  %s\n' "$1"
+    skip_count=$((skip_count + 1))
+}
+
+# In CI, missing validator tools MUST fail hard. Locally, skip is
+# acceptable so first-run iteration works without a full toolchain.
+missing_tool() {
+    local scenario="$1"
+    local tool="$2"
+    local hint="$3"
+    if [ -n "${CI:-}" ]; then
+        fail "$scenario ($tool missing in CI — $hint)"
+    else
+        skip "$scenario ($tool missing locally — $hint)"
+    fi
+}
+
+config=".github/dependabot.yml"
+schema=".github/schemas/dependabot-2.0.json"
+policy_doc="docs/dependency-updates.md"
+
+# --- 1. dependabot.yml exists ---------------------------------------
+scenario="dependabot.yml exists at $config"
+if [ -f "$config" ]; then
+    pass "$scenario"
+else
+    fail "$scenario"
+    echo
+    echo "$pass_count passed, $fail_count failed, $skip_count skipped"
+    exit 1
+fi
+
+# --- 2. version: 2 --------------------------------------------------
+scenario="dependabot.yml declares version: 2"
+if grep -qE '^[[:space:]]*version:[[:space:]]*2[[:space:]]*$' "$config"; then
+    pass "$scenario"
+else
+    fail "$scenario"
+fi
+
+# --- 3. github-actions ecosystem present ----------------------------
+scenario="github-actions ecosystem present"
+if grep -qE '^[[:space:]]*-[[:space:]]*package-ecosystem:[[:space:]]*github-actions[[:space:]]*$' "$config"; then
+    pass "$scenario"
+else
+    fail "$scenario"
+fi
+
+# --- 4. cargo ecosystem present -------------------------------------
+scenario="cargo ecosystem present"
+if grep -qE '^[[:space:]]*-[[:space:]]*package-ecosystem:[[:space:]]*cargo[[:space:]]*$' "$config"; then
+    pass "$scenario"
+else
+    fail "$scenario"
+fi
+
+# --- 5. both ecosystems: directory "/" ------------------------------
+scenario="both ecosystems set directory: \"/\""
+# Expect exactly 2 matches (one per ecosystem).
+dir_count=$(grep -cE '^[[:space:]]*directory:[[:space:]]*"/"[[:space:]]*$' "$config" || true)
+if [ "$dir_count" = "2" ]; then
+    pass "$scenario"
+else
+    fail "$scenario (expected 2 matches, got $dir_count)"
+fi
+
+# --- 6. both ecosystems: schedule.interval: weekly ------------------
+scenario="both ecosystems set schedule.interval: weekly"
+int_count=$(grep -cE '^[[:space:]]*interval:[[:space:]]*weekly[[:space:]]*$' "$config" || true)
+if [ "$int_count" = "2" ]; then
+    pass "$scenario"
+else
+    fail "$scenario (expected 2 matches, got $int_count)"
+fi
+
+# --- 7. both ecosystems: open-pull-requests-limit -------------------
+scenario="both ecosystems set open-pull-requests-limit"
+lim_count=$(grep -cE '^[[:space:]]*open-pull-requests-limit:[[:space:]]+[0-9]+' "$config" || true)
+if [ "$lim_count" = "2" ]; then
+    pass "$scenario"
+else
+    fail "$scenario (expected 2 matches, got $lim_count)"
+fi
+
+# --- 8. both ecosystems: commit-message.prefix ----------------------
+scenario="both ecosystems set commit-message.prefix"
+pfx_count=$(grep -cE '^[[:space:]]*prefix:[[:space:]]*"chore\((actions|deps)\)"' "$config" || true)
+if [ "$pfx_count" = "2" ]; then
+    pass "$scenario"
+else
+    fail "$scenario (expected 2 matches, got $pfx_count)"
+fi
+
+# --- 9. both ecosystems: groups: block ------------------------------
+scenario="both ecosystems declare a groups: block"
+grp_count=$(grep -cE '^[[:space:]]*groups:[[:space:]]*$' "$config" || true)
+if [ "$grp_count" = "2" ]; then
+    pass "$scenario"
+else
+    fail "$scenario (expected 2 matches, got $grp_count)"
+fi
+
+# --- 10. madsim-family group wired ----------------------------------
+# Load-bearing atomicity check: madsim + madsim-tokio (manifest key
+# `tokio` under the workspace rename at Cargo.toml) must be grouped
+# so they ship in a single PR. See docs/dependency-updates.md.
+scenario="madsim-family group present with patterns madsim / madsim-* / tokio"
+# Extract a window starting at `madsim-family:` and check it names all
+# three patterns before the next top-level group or ecosystem entry.
+if awk '
+    /^[[:space:]]*madsim-family:[[:space:]]*$/ { in_group = 1; next }
+    in_group && /^[[:space:]]*(cargo-minor-patch|cargo-major|github-actions-|-[[:space:]]+package-ecosystem):/ { exit }
+    in_group { print }
+' "$config" | grep -qE '"madsim"' \
+  && awk '
+    /^[[:space:]]*madsim-family:[[:space:]]*$/ { in_group = 1; next }
+    in_group && /^[[:space:]]*(cargo-minor-patch|cargo-major|github-actions-|-[[:space:]]+package-ecosystem):/ { exit }
+    in_group { print }
+' "$config" | grep -qE '"madsim-\*"' \
+  && awk '
+    /^[[:space:]]*madsim-family:[[:space:]]*$/ { in_group = 1; next }
+    in_group && /^[[:space:]]*(cargo-minor-patch|cargo-major|github-actions-|-[[:space:]]+package-ecosystem):/ { exit }
+    in_group { print }
+' "$config" | grep -qE '"tokio"'; then
+    pass "$scenario"
+else
+    fail "$scenario (madsim-family must list \"madsim\", \"madsim-*\", and \"tokio\" — load-bearing for madsim + madsim-tokio atomicity)"
+fi
+
+# --- 11. cargo: insecure-external-code-execution: deny --------------
+scenario="cargo ecosystem sets insecure-external-code-execution: deny"
+if grep -qE '^[[:space:]]*insecure-external-code-execution:[[:space:]]*deny[[:space:]]*$' "$config"; then
+    pass "$scenario"
+else
+    fail "$scenario (supply-chain posture requires deny — see docs/dependency-updates.md)"
+fi
+
+# --- 12. YAML well-formedness ---------------------------------------
+scenario="dependabot.yml is valid YAML"
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+    if python3 -c "import yaml,sys; yaml.safe_load(open('$config'))" >/dev/null 2>&1; then
+        pass "$scenario"
+    else
+        fail "$scenario (python3 -c yaml.safe_load raised)"
+    fi
+else
+    missing_tool "$scenario" "python3 + pyyaml" "install python3 and 'pip install pyyaml'"
+fi
+
+# --- 13. JSON Schema validation -------------------------------------
+# A typo like `scheudle:` parses as valid YAML but is silently ignored
+# by Dependabot. Schema validation catches it.
+scenario="dependabot.yml validates against vendored Dependabot JSON Schema"
+if [ ! -f "$schema" ]; then
+    fail "$scenario (vendored schema missing at $schema)"
+elif command -v check-jsonschema >/dev/null 2>&1; then
+    if check-jsonschema --schemafile "$schema" "$config" >/dev/null 2>&1; then
+        pass "$scenario"
+    else
+        # Re-run to surface the error in logs.
+        err=$(check-jsonschema --schemafile "$schema" "$config" 2>&1 || true)
+        fail "$scenario
+$err"
+    fi
+else
+    missing_tool "$scenario" "check-jsonschema" "pipx install check-jsonschema (or pip install in a venv)"
+fi
+
+# --- 14. policy doc exists ------------------------------------------
+scenario="policy doc exists at $policy_doc"
+if [ -f "$policy_doc" ]; then
+    pass "$scenario"
+else
+    fail "$scenario"
+fi
+
+# --- 15. every workflow `uses:` line is SHA-pinned ------------------
+# Regression test for the SHA-pin policy that Dependabot is here to
+# preserve. A PR that adds `uses: actions/checkout@v4` short form
+# would cause Dependabot to start bumping to floating tags — this
+# check catches that before Dependabot's next run.
+#
+# Regex (POSIX ERE, portable between macOS BSD grep and Linux GNU
+# grep): line may start with whitespace, optional `- ` list marker,
+# `uses: ` then `<owner>/<repo>@<40-hex>` then optional `# <ref>`.
+scenario="all workflow uses: lines are SHA-pinned with 40-hex"
+shopt -s nullglob
+workflows=(.github/workflows/*.yml)
+shopt -u nullglob
+if [ "${#workflows[@]}" -eq 0 ]; then
+    skip "$scenario (no workflow files found)"
+else
+    violators=""
+    for wf in "${workflows[@]}"; do
+        # Lines that contain a `uses:` directive but DO NOT match the
+        # SHA-pinned pattern. Comment lines starting with `#` are
+        # excluded (header prose can legitimately mention uses: ...).
+        bad=$(grep -nE '^[[:space:]]*(-[[:space:]]+)?uses:' "$wf" \
+            | grep -v '^[^:]*:[[:space:]]*#' \
+            | grep -vE '^[^:]*:[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]+[^@[:space:]]+@[0-9a-f]{40}([[:space:]]+#.*)?[[:space:]]*$' \
+            || true)
+        if [ -n "$bad" ]; then
+            violators="${violators}${wf}:
+${bad}
+"
+        fi
+    done
+    if [ -z "$violators" ]; then
+        pass "$scenario"
+    else
+        fail "$scenario
+$violators"
+    fi
+fi
+
+# --- summary --------------------------------------------------------
+echo
+echo "$pass_count passed, $fail_count failed, $skip_count skipped"
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` configuring Dependabot for both `github-actions` (preserves the SHA-pin policy) and `cargo` (bumps `[workspace.dependencies]` + `Cargo.lock`). Weekly schedule Monday 14:00 UTC, bounded queue, grouped PRs, no auto-merge.
- Named `madsim-family` group binds `madsim` + `madsim-tokio` (manifest key `tokio` under the workspace package-rename) atomically so the "move both lines together" invariant in `Cargo.toml` holds by construction.
- Cargo ecosystem sets `insecure-external-code-execution: deny` — build scripts cannot run during version resolution.
- Ships with a 15-assertion self-test (`scripts/dependabot-scripts-test.sh`) + dedicated CI workflow (`dependabot-selftest.yml`) + vendored JSON Schema (`.github/schemas/dependabot-2.0.json`) + policy doc (`docs/dependency-updates.md`).

Closes ROADMAP.md:803 — "Add a Renovate / Dependabot config so action SHAs and crate versions get bumped via PR (preserves the SHA-pin policy without it rotting)."

Decision record: Dependabot chosen over Renovate. Rationale in `docs/dependency-updates.md` §"Why Dependabot, not Renovate".

## Test plan

- [x] Self-test passes locally: 14 passed, 0 failed, 1 skipped (`check-jsonschema` skipped locally, installed in CI).
- [x] Schema validation passes on the current config via `check-jsonschema --schemafile .github/schemas/dependabot-2.0.json .github/dependabot.yml`.
- [x] Negative test: typo'd `scheudle:` correctly rejected by schema validator.
- [x] All 11 existing workflow files pass the `uses:`-line SHA-pin regex (assertion #15).
- [x] YAML parses cleanly via `python3 -c 'yaml.safe_load(...)'`.
- [x] `madsim-family` group contains exactly the three load-bearing patterns (`madsim`, `madsim-*`, `tokio`).
- [ ] `dependabot-selftest` workflow green in CI on this PR.
- [ ] After merge: pre-create `dependencies` / `github-actions` / `rust` labels via `gh label create` before Dependabot's first run.

## Follow-ups (tracked, not in scope here)

- `scripts/deny-ignore-lint.sh` — mechanical cross-check of `deny.toml` ignore-entry versions against `Cargo.lock`. Reviewer eyeball until it lands.
- Evaluate `versioning-strategy: lockfile-only` as a second cargo entry after first month of PR traffic.
- Split cargo grouping into `cargo-dev` / `cargo-prod` when production crates land in Phase 1.

Plan: `.planning/0-5-renovate-dependabot.plan.md` (APPROVE_WITH_NITS from rust-expert). Nits folded into implementation:

1. POSIX ERE throughout the self-test (no `\s` — portable between macOS BSD grep and Linux GNU grep).
2. Schema provenance (URL + fetch date + SHA-256) recorded in `.github/schemas/README.md`.
3. `Cargo.toml:69` confirmed to carry `package = "madsim-tokio"` rename; the `tokio` pattern in `madsim-family` captures it.
