### PR TITLE
feat(non-exhaustive): #[non_exhaustive] policy on public enums (ROADMAP 0.5)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,7 @@ Reviewer's Contract:
 - [ ] **Unsafe** (#5) — paths: <...>.
       `// SAFETY:` on every block: yes
       Miri: `MIRIFLAGS=-Zmiri-strict-provenance cargo +nightly miri
-      test -p <crate>` — <output / FFI-no-Miri justification>
+    test -p <crate>` — <output / FFI-no-Miri justification>
       Workspace `unsafe` count delta: <+N / 0>;
       `unsafe`-growth PR label applied if +N > 0
 - [ ] **Security** (#6) — axis #N / bar `<name>`.
@@ -51,7 +51,8 @@ Reviewer's Contract:
       applies.
       Doctest: yes
       `#[must_use]` considered: yes
-      `#[non_exhaustive]` on new enums: yes
+      `#[non_exhaustive]` on new enums: yes (or per-enum escape per
+      `docs/api-stability.md`)
       `cargo public-api --diff`: <output, advisory pre-Phase-6, gating
       from Phase 6>
       `cargo-semver-checks`: <status, gating from Phase 6>

--- a/.github/workflows/non-exhaustive.yml
+++ b/.github/workflows/non-exhaustive.yml
@@ -1,0 +1,116 @@
+# Mango #[non_exhaustive] policy gate
+#
+# Runs the two-layer enforcement from docs/api-stability.md on every
+# PR and push that touches public-enum territory:
+#
+#   1. scripts/non-exhaustive-check.sh — structural backstop. Asserts
+#      the workspace `clippy::exhaustive_enums = "deny"` lint entry
+#      is present and every publishable crate's `pub enum` carries
+#      `#[non_exhaustive]` or a documented `// reason:` escape.
+#
+#   2. scripts/non-exhaustive-scripts-test.sh — self-test harness
+#      (10 assertions). Exercises the backstop's awk state machine
+#      via synthetic tmpdir fixtures and runs
+#      `cargo clippy -- -D clippy::exhaustive_enums` against the
+#      tests/fixtures/non-exhaustive/ workspace (compliant / bad /
+#      allowed). Locks clippy's behavior on the restriction-category
+#      lint against point-release drift.
+#
+# Primary enforcement (workspace-wide `clippy::exhaustive_enums =
+# "deny"`) runs inside the main `cargo clippy` job in ci.yml. This
+# workflow is the defense-in-depth layer: it makes the invariant
+# visible and auditable independently of clippy, so a silent lint
+# regression (clippy point release, accidental table removal) can't
+# sneak through unnoticed.
+#
+# Why a dedicated workflow:
+#   - Narrow path filter keeps every other PR from paying the cost
+#     of installing the fixture's rustc + clippy artifacts.
+#   - Matches the one-workflow-per-gate convention (geiger, madsim,
+#     miri, public-api, semver-checks, ct-comparison, etc.).
+#   - Independent status check for branch protection.
+#
+# Security: no `github.event.*` values are interpolated into run:
+# blocks. All run: inputs are static script paths. The only dynamic
+# expression is `github.ref` in `concurrency.group`, which GitHub
+# sanitizes. Matches the hardening pattern in ct-comparison.yml /
+# dependabot-selftest.yml.
+#
+# In CI (`CI` env set by GitHub Actions), both scripts treat missing
+# `cargo` / `jq` as hard failures. Locally they skip with install
+# hints — see the script headers.
+
+name: non-exhaustive
+
+on:
+  pull_request:
+    paths:
+      - "crates/**/src/**"
+      - "crates/**/Cargo.toml"
+      - "Cargo.toml"
+      - "docs/api-stability.md"
+      - "tests/fixtures/non-exhaustive/**"
+      - "scripts/non-exhaustive-check.sh"
+      - "scripts/non-exhaustive-scripts-test.sh"
+      - ".github/workflows/non-exhaustive.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/**/src/**"
+      - "crates/**/Cargo.toml"
+      - "Cargo.toml"
+      - "docs/api-stability.md"
+      - "tests/fixtures/non-exhaustive/**"
+      - "scripts/non-exhaustive-check.sh"
+      - "scripts/non-exhaustive-scripts-test.sh"
+      - ".github/workflows/non-exhaustive.yml"
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  non-exhaustive:
+    name: non-exhaustive (policy gate)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      # Stable toolchain + clippy component. The fixture oracle runs
+      # `cargo clippy -- -D clippy::exhaustive_enums` against three
+      # fixture members; the backstop's cargo-metadata call also needs
+      # a working cargo.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: clippy
+
+      # Separate cache scope: the fixture workspace is outside mango's
+      # target/ and pulls no deps, but we still want the stable rustc
+      # sysroot cached across runs. Prefix-keyed to avoid collision
+      # with ci.yml's default cache.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          prefix-key: v0-non-exhaustive
+          shared-key: ""
+          workspaces: |
+            .
+            tests/fixtures/non-exhaustive
+
+      # Fail fast if the backstop regresses before the self-test runs.
+      - name: non-exhaustive backstop
+        run: bash scripts/non-exhaustive-check.sh
+
+      # Full self-test: 10 assertions including the three fixture
+      # clippy oracles and two synthetic-tmpdir negative tests.
+      - name: non-exhaustive scripts self-test
+        run: bash scripts/non-exhaustive-scripts-test.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,6 +285,18 @@ with worked examples: [`docs/arithmetic-policy.md`][arith].
   merge. **Gating from Phase 6** (first stable public API). Full
   policy, including the advisory→gating flip procedure:
   [`docs/semver-policy.md`](./docs/semver-policy.md).
+- **`#[non_exhaustive]` on public enums.** Every `pub enum` in a
+  publishable crate must carry `#[non_exhaustive]` or a documented
+  per-enum escape (a `// reason: …` line-comment immediately
+  preceding `#[allow(clippy::exhaustive_enums)]` — MSRV-1.80 form).
+  Enforced primarily by the workspace lint
+  `clippy::exhaustive_enums = "deny"` at `cargo clippy` time and
+  defense-in-depth by `.github/workflows/non-exhaustive.yml`
+  (`scripts/non-exhaustive-check.sh` + self-test + a 3-member
+  clippy-oracle fixture). Non-publishable crates opt out
+  crate-wide at `lib.rs` top. Full policy, exceptions, and
+  struct-like-variant guidance:
+  [`docs/api-stability.md`](./docs/api-stability.md).
 - **MSRV.** Workspace MSRV is **1.80** (see
   `rust-version` in [`Cargo.toml`](./Cargo.toml) and the `msrv`
   CI job). MSRV bumps are deliberate, land in their own PR, and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,16 @@ disallowed_methods = { level = "warn", priority = 1 }
 # call newer than MSRV at PR time, complementing the `cargo check
 # @ 1.80` job that catches it at compile time.
 incompatible_msrv = { level = "deny", priority = 1 }
+# `#[non_exhaustive]` policy on public enums. Every `pub enum` in a
+# publishable (non-`publish = false`) crate must carry
+# `#[non_exhaustive]` or a documented per-enum escape. Escape hatch:
+# `// reason: ...` line-comment immediately preceding
+# `#[allow(clippy::exhaustive_enums)]` on the specific enum. Non-
+# publishable crates carry a crate-level `#![allow(...)]` at lib.rs
+# top — same pattern as `unsafe_code = "forbid"` + per-crate
+# `#![allow(unsafe_code)]`. See `docs/api-stability.md` for the
+# policy; `scripts/non-exhaustive-check.sh` is the structural backstop.
+exhaustive_enums = { level = "deny", priority = 1 }
 
 # Release profile. overflow-checks = true is the runtime backstop for
 # the compile-time clippy::arithmetic_side_effects lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,18 @@ members = [
 # deliberately-unsafe source under mango's `unsafe_code = "forbid"`
 # lint and from walking its `[workspace]` table as if it were a
 # nested member. See docs/unsafe-policy.md.
-exclude = ["tests/fixtures/geiger-toy-workspace"]
+#
+# tests/fixtures/non-exhaustive is a self-contained workspace used
+# by scripts/non-exhaustive-scripts-test.sh as a real-clippy
+# oracle for the `clippy::exhaustive_enums` lint. Its `bad/`
+# member contains a deliberately-non-exhaustive `pub enum` that
+# would fire the workspace lint; excluding the directory keeps
+# the mango workspace clippy run clean. See
+# docs/api-stability.md.
+exclude = [
+    "tests/fixtures/geiger-toy-workspace",
+    "tests/fixtures/non-exhaustive",
+]
 
 # Miri curated-subset opt-in (see docs/miri.md). Any crate that ships
 # `unsafe` (and therefore carries a `#![allow(unsafe_code)]` escape

--- a/crates/mango-loom-demo/src/lib.rs
+++ b/crates/mango-loom-demo/src/lib.rs
@@ -17,6 +17,10 @@
 //! See `docs/miri.md`.
 
 #![deny(missing_docs)]
+// `publish = false` pedagogical demo — opted out of the workspace
+// `clippy::exhaustive_enums = "deny"` policy. See
+// `docs/api-stability.md` for the scope definition.
+#![allow(clippy::exhaustive_enums)]
 
 use std::sync::atomic::Ordering;
 

--- a/crates/mango-madsim-demo/src/lib.rs
+++ b/crates/mango-madsim-demo/src/lib.rs
@@ -13,6 +13,10 @@
 //! policy.
 
 #![deny(missing_docs)]
+// `publish = false` scaffolding crate — opted out of the workspace
+// `clippy::exhaustive_enums = "deny"` policy. See
+// `docs/api-stability.md` for the scope definition.
+#![allow(clippy::exhaustive_enums)]
 
 use tokio::sync::mpsc;
 use tokio::task;

--- a/crates/mango-proto/src/lib.rs
+++ b/crates/mango-proto/src/lib.rs
@@ -8,6 +8,13 @@
 //! real `mango.*.v1` proto lands.
 
 #![deny(missing_docs)]
+// `publish = false` and forward-looking: prost-emitted enums are
+// never `#[non_exhaustive]`, and retrofitting post-codegen is
+// brittle. Opt the whole crate out of the workspace
+// `clippy::exhaustive_enums = "deny"` policy. When `mango-proto`
+// becomes publishable in Phase 6+, this allow stays (generated-
+// code exception in `docs/api-stability.md`).
+#![allow(clippy::exhaustive_enums)]
 
 /// Namespace root for `mango.hello.*` protobuf services. Phase-0
 /// smoke surface only; real versioned namespaces (`mango.kv.v1`,

--- a/crates/xtask-vet-ttl/src/lib.rs
+++ b/crates/xtask-vet-ttl/src/lib.rs
@@ -13,6 +13,11 @@
 // from `allow` to `warn` for `missing_docs` cannot retroactively red
 // the `doc` CI job. One line of cheap insurance.
 #![allow(missing_docs)]
+// `publish = false` internal xtask — opted out of the workspace
+// `clippy::exhaustive_enums = "deny"` policy. `ParseError` below
+// is the one `pub enum` in this crate; it stays closed because
+// xtask-vet-ttl is not a library. See `docs/api-stability.md`.
+#![allow(clippy::exhaustive_enums)]
 
 use std::fmt;
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -1,0 +1,239 @@
+# API stability policy — `#[non_exhaustive]` on public enums
+
+Mango commits to **semver-safe surface evolution** on every published
+`crates/mango-*` crate. Today no crate is published; when Phase 6
+opens (first stable public API), adding a variant to a non-
+`#[non_exhaustive]` `pub enum` becomes a silent major-version break
+that downstream exhaustive `match` callers hit at compile time.
+
+This policy closes that failure mode before it can ship.
+
+Cross-refs:
+
+- [`docs/public-api-policy.md`](public-api-policy.md) — `cargo-public-api`
+  diffs the full surface (symbol set).
+- [`docs/semver-policy.md`](semver-policy.md) — `cargo-semver-checks`
+  diagnoses individual lints (including `#[non_exhaustive]` **flips**,
+  but not the _missing-on-creation_ case this policy covers).
+
+The three policies are layered: this one prevents the regression at
+PR time; `public-api` catches the surface change; `semver-checks`
+classifies it.
+
+## The rule
+
+**Every `pub enum` in a publishable crate MUST carry
+`#[non_exhaustive]`** unless a documented exception applies. The
+exception inventory is this doc's §"Exceptions" section. Per-enum
+exceptions live on the enum itself as a `// reason:` line-comment
+followed by `#[allow(clippy::exhaustive_enums)]`; crate-wide
+exceptions live at lib.rs root.
+
+Error enums are the **canonical case _for_ `#[non_exhaustive]`**,
+not an exception. Adding an error variant is the single most
+common semver-silent break for downstream users.
+
+## Scope — which crates the policy applies to
+
+A crate is **publishable** iff its `Cargo.toml` does **not** set
+`publish = false`. This matches the predicate used by
+`scripts/public-api-scripts-test.sh` and the `public-api.yml`
+workflow's jq filter — one oracle for three policies, one source of
+drift to watch.
+
+Today: `crates/mango` is the only publishable crate. The other four
+(`mango-proto`, `mango-loom-demo`, `mango-madsim-demo`,
+`xtask-vet-ttl`) set `publish = false` and carry a crate-level
+`#![allow(clippy::exhaustive_enums)]` escape at lib.rs top — see the
+precedent shape in [`crates/mango-proto/src/lib.rs`](../crates/mango-proto/src/lib.rs).
+
+When Phase 1+ adds a publishable crate, the workspace lint is
+inherited automatically. No per-crate deny needed — the default is
+safe.
+
+## Enforcement
+
+Two layers, defense-in-depth:
+
+1. **Primary gate — `clippy::exhaustive_enums`**. Enabled at
+   `deny` level in `[workspace.lints.clippy]` at
+   [`Cargo.toml`](../Cargo.toml). Clippy parses the AST; no regex
+   false-positives. Fires at PR time via the existing workspace
+   clippy step in `ci.yml` — no new CI wiring needed for the lint
+   itself.
+
+2. **Structural backstop — `scripts/non-exhaustive-check.sh`**.
+   Runs in
+   [`.github/workflows/non-exhaustive.yml`](../.github/workflows/non-exhaustive.yml).
+   Asserts (a) the workspace lint entry is present in `Cargo.toml`,
+   (b) each `pub enum` in each publishable crate either has
+   `#[non_exhaustive]` or an `#[allow(clippy::exhaustive_enums)]`
+   preceded by a `// reason:` comment. Catches the failure mode
+   where someone removes the workspace lint entry — clippy would
+   go silent; this backstop would not.
+
+The workflow also runs a fixture-based clippy regression test
+against
+[`tests/fixtures/non-exhaustive/`](../tests/fixtures/non-exhaustive/),
+locking in clippy's behavior on this lint against restriction-
+category drift across clippy point releases.
+
+## Exceptions
+
+Four narrow cases:
+
+### 1. Exhaustive-by-contract enums
+
+Variant sets that are load-bearing contracts with downstream
+exhaustive pattern-matching and where adding a variant is _always_
+a major semver break by design — e.g. `Direction { Ingress,
+Egress }`, `Parity { Even, Odd }`, `Role { Leader, Follower,
+Candidate }`.
+
+```rust
+// reason: exhaustive-by-contract — Raft roles are a closed set; adding
+// a variant is a major protocol break by design.
+#[allow(clippy::exhaustive_enums)]
+pub enum Role {
+    Leader,
+    Follower,
+    Candidate,
+}
+```
+
+### 2. C-repr / FFI enums
+
+Enums with a fixed `#[repr(u8/u16/i32/...)]` that round-trip across
+a wire protocol, kernel ioctl, or FFI boundary. Adding a variant
+would silently reinterpret existing data.
+
+```rust
+// reason: C-repr wire type — variants match kernel TCP_INFO states;
+// adding one would misread a live socket.
+#[allow(clippy::exhaustive_enums)]
+#[repr(u8)]
+pub enum TcpState {
+    Established = 1,
+    SynSent = 2,
+    // ...
+}
+```
+
+### 3. Enums from generated code
+
+`prost` / `tonic` / `proto3` codegen does not emit
+`#[non_exhaustive]`, and retrofitting post-codegen is brittle. The
+escape is a **crate-level** `#![allow(clippy::exhaustive_enums)]` at
+the generated crate's lib.rs root.
+
+Today: `mango-proto` sets `publish = false` and already carries the
+crate-level allow. When `mango-proto` becomes publishable (Phase 6+),
+the allow stays — the "generated code" exception is the
+justification.
+
+### 4. Non-publishable crates
+
+Crates that set `publish = false` are **out of scope** for this
+policy. They carry a crate-level `#![allow(clippy::exhaustive_enums)]`
+at lib.rs top with a one-line comment citing this section. Removing
+`publish = false` MUST be paired with removing the allow in the same
+PR.
+
+## How to add a per-enum exception at MSRV 1.80
+
+`#[allow(foo, reason = "...")]` (the inline `reason` field) is
+stable from rustc 1.81+. Mango MSRV is 1.80 and `clippy::incompatible_msrv`
+is denied workspace-wide, so the inline `reason = "..."` form would
+fail CI.
+
+**Convention**: put a `// reason: ...` line-comment _immediately
+preceding_ the `#[allow]` attribute.
+
+```rust
+// reason: <one-sentence justification citing which §1–§4 exception applies>
+#[allow(clippy::exhaustive_enums)]
+pub enum Foo {
+    A,
+    B,
+}
+```
+
+- Line-comment only (not `///` doc-comment — those leak into
+  rustdoc output).
+- The backstop script asserts `^\s*// reason:` appears on the line
+  immediately before each `#[allow(clippy::exhaustive_enums)]`.
+- When mango's MSRV bumps to 1.81+, `docs/msrv.md`'s MSRV-bump
+  checklist covers migrating `// reason:` comments to inline
+  `reason = "..."` attribute fields.
+
+## Struct-like enum variants
+
+`#[non_exhaustive]` on the outer enum only covers the **variant set**.
+If a variant has named or tuple fields expected to grow, the variant
+itself also needs `#[non_exhaustive]`:
+
+```rust
+#[non_exhaustive]
+pub enum Event {
+    #[non_exhaustive]
+    Message { body: String, timestamp: u64 },
+    Disconnect,
+}
+```
+
+Without the inner attribute, adding `priority: u8` to `Message` is a
+semver break even though the outer enum permits adding a new variant.
+Clippy does not catch this; reviewers do on the PR.
+
+## Interaction with other workspace lints
+
+### `unreachable_pub = "warn"`
+
+If clippy fires both `unreachable_pub` and `exhaustive_enums` on the
+same item, the **primary fix is reducing visibility**
+(`pub(crate) enum ...`), not adding `#[non_exhaustive]`. Crate-
+private enums are not subject to this policy — `#[non_exhaustive]`
+only earns its keep when the type crosses the crate boundary.
+
+### `disallowed_types` / other workspace lints
+
+This policy is one of several orthogonal lint-table gates. See
+[`Cargo.toml`](../Cargo.toml) `[workspace.lints.clippy]` for the full
+set — `unwrap_used`, `expect_used`, `disallowed_types`,
+`arithmetic_side_effects`, etc.
+
+## Removing `#[non_exhaustive]` is a major-version break
+
+Once `mango-*` is published, dropping `#[non_exhaustive]` from an
+enum is a major-version break: downstream code that had fallback
+arms in `match` can now be flagged as unreachable, and the API
+contract has shifted from "may grow" to "is frozen."
+
+`cargo-public-api` surfaces the change; `cargo-semver-checks`
+classifies it. Document the break in the release notes.
+
+## Reviewer checklist for a PR adding a `pub enum`
+
+- [ ] Enum carries `#[non_exhaustive]`, OR
+- [ ] Enum carries `// reason:` + `#[allow(clippy::exhaustive_enums)]`
+      and the reason cites a documented exception (§1–§4).
+- [ ] If the enum has variants with struct/tuple fields that may
+      grow, each such variant also carries `#[non_exhaustive]`.
+- [ ] `cargo clippy --workspace --all-targets` passes locally.
+- [ ] The `non-exhaustive` CI job is green on the PR.
+
+## See also
+
+- [`ROADMAP.md:804`](../ROADMAP.md) — item this policy lands
+- [`Cargo.toml`](../Cargo.toml) `[workspace.lints.clippy]` —
+  `exhaustive_enums = "deny"`
+- [`scripts/non-exhaustive-check.sh`](../scripts/non-exhaustive-check.sh)
+  — structural backstop
+- [`scripts/non-exhaustive-scripts-test.sh`](../scripts/non-exhaustive-scripts-test.sh)
+  — self-test
+- [`tests/fixtures/non-exhaustive/`](../tests/fixtures/non-exhaustive/)
+  — clippy regression fixture
+- [`.github/workflows/non-exhaustive.yml`](../.github/workflows/non-exhaustive.yml)
+  — CI workflow
+- [`docs/msrv.md`](msrv.md) — MSRV-bump checklist (migrates
+  `// reason:` comments when MSRV reaches 1.81)

--- a/docs/msrv.md
+++ b/docs/msrv.md
@@ -95,12 +95,24 @@ process:
    in the PR body.
 4. Verify locally with the "Validating MSRV locally" command
    above, substituting the new toolchain version.
-5. rust-expert adversarial review.
-6. Merge.
+5. **When bumping to 1.81 or later**, migrate every `// reason:`
+   line-comment preceding `#[allow(clippy::exhaustive_enums)]` to
+   the inline `#[allow(clippy::exhaustive_enums, reason = "...")]`
+   form. The line-comment convention is a MSRV-1.80 workaround
+   (the attribute's `reason = ...` field stabilized in 1.81);
+   dropping it keeps the rationale attached to the attribute
+   rather than on a preceding line where refactors can separate
+   them. See [`docs/api-stability.md`](api-stability.md)
+   §"How to add a per-enum exception at MSRV 1.80" and update
+   `scripts/non-exhaustive-check.sh`'s awk state machine in the
+   same PR.
+6. rust-expert adversarial review.
+7. Merge.
 
 ### Ecosystem floors to be aware of
 
 Current dep graph on the Linux target:
+
 - `wit-bindgen 0.49` (last edition2021 version before 0.57) requires Rust **1.82**.
 - `wasip2 1.0.3` declares `rust-version = "1.87"` (only enforced on
   wasi targets — not a Linux constraint today).

--- a/scripts/non-exhaustive-check.sh
+++ b/scripts/non-exhaustive-check.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# scripts/non-exhaustive-check.sh
+#
+# Structural backstop for the `#[non_exhaustive]` policy on public
+# enums (ROADMAP.md:804, docs/api-stability.md).
+#
+# Primary enforcement is `clippy::exhaustive_enums = "deny"` in
+# `[workspace.lints.clippy]` — clippy catches every `pub enum` in
+# every publishable crate at PR time. This script is a
+# defense-in-depth backstop that catches the failure mode where
+# someone removes the workspace lint entry (clippy silently stops
+# firing; this script keeps the invariant visible).
+#
+# What it asserts:
+#   1. `[workspace.lints.clippy]` in `Cargo.toml` carries
+#      `exhaustive_enums = "deny"`.
+#   2. For every publishable crate (as reported by `cargo metadata`
+#      + the jq filter shared with public-api / semver-checks),
+#      every `pub enum` in `src/**/*.rs` either:
+#      (a) has `#[non_exhaustive]` on the enum, OR
+#      (b) has `#[allow(clippy::exhaustive_enums)]` preceded
+#          immediately by a `// reason: ...` line-comment, OR
+#      (c) is covered by a crate-level
+#          `#![allow(clippy::exhaustive_enums)]` in lib.rs.
+#
+# Predicate for "publishable": `publish != []` AND `source == null`.
+# Same shape used by `scripts/public-api-scripts-test.sh` and
+# `public-api.yml`'s jq filter — keeping it identical across the
+# three callers prevents drift.
+#
+# Exit codes:
+#   0  PASS
+#   1  FAIL — workspace lint entry missing
+#   2  FAIL — pub enum without attribute or escape
+#   3  FAIL — escape present but `// reason:` comment missing
+#
+# CI vs local:
+#   When $CI is set, missing `cargo` or `jq` is a hard failure
+#   (silent pass in CI would miss regressions). Locally, the
+#   script prints an install hint and skips only the specific
+#   assertion requiring the missing tool.
+#
+# Invocation:
+#   bash scripts/non-exhaustive-check.sh
+#   (run from any CWD; script cd's to repo root)
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+pass() {
+    printf 'PASS  %s\n' "$1"
+    pass_count=$((pass_count + 1))
+}
+fail() {
+    printf 'FAIL  %s\n' "$1" >&2
+    fail_count=$((fail_count + 1))
+}
+skip() {
+    printf 'SKIP  %s\n' "$1"
+    skip_count=$((skip_count + 1))
+}
+
+missing_tool() {
+    local scenario="$1"
+    local tool="$2"
+    local hint="$3"
+    if [ -n "${CI:-}" ]; then
+        fail "$scenario ($tool missing in CI — $hint)"
+    else
+        skip "$scenario ($tool missing locally — $hint)"
+    fi
+}
+
+cargo_toml="Cargo.toml"
+policy_doc="docs/api-stability.md"
+
+# --- 1. workspace lint entry present --------------------------------
+# Match the TOML line `exhaustive_enums = { level = "deny", ... }`
+# inside `[workspace.lints.clippy]`. We look for the specific level
+# = "deny" shape rather than any `exhaustive_enums =` to avoid
+# accidentally accepting a `"warn"` or `"allow"` downgrade.
+scenario="Cargo.toml declares clippy::exhaustive_enums at deny level"
+if grep -qE '^[[:space:]]*exhaustive_enums[[:space:]]*=[[:space:]]*\{[[:space:]]*level[[:space:]]*=[[:space:]]*"deny"' "$cargo_toml"; then
+    pass "$scenario"
+else
+    fail "$scenario (expected \`exhaustive_enums = { level = \"deny\", priority = 1 }\` in [workspace.lints.clippy])"
+fi
+
+# --- 2. policy doc exists -------------------------------------------
+scenario="policy doc exists at $policy_doc"
+if [ -f "$policy_doc" ]; then
+    pass "$scenario"
+else
+    fail "$scenario"
+fi
+
+# --- 3. enumerate publishable crates --------------------------------
+# Uses `cargo metadata --no-deps` (stays inside workspace members,
+# doesn't fetch dependency metadata) + jq to filter to publishable
+# paths. Predicate: `publish != []` AND `source == null`.
+#
+# Guard with CI-vs-local semantics: if either tool is missing,
+# CI fails hard and local skips.
+publishable_crates=""
+have_tools=1
+if ! command -v cargo >/dev/null 2>&1; then
+    missing_tool "enumerate publishable crates" "cargo" "install rustup + cargo"
+    have_tools=0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    missing_tool "enumerate publishable crates" "jq" "brew install jq or apt-get install jq"
+    have_tools=0
+fi
+
+if [ "$have_tools" = "1" ]; then
+    # One line per publishable crate: "<name>\t<manifest_dir>"
+    # Each path is absolute. The `manifest_path` returned by cargo
+    # metadata points at Cargo.toml; we strip the filename with
+    # parameter expansion in awk to keep jq-style filters simple.
+    publishable_crates="$(
+        cargo metadata --no-deps --format-version=1 2>/dev/null \
+        | jq -r '.packages[]
+                 | select(.source == null)
+                 | select(.publish != [])
+                 | "\(.name)\t\(.manifest_path)"' \
+        | awk -F'\t' '{
+            mp = $2
+            sub(/\/Cargo\.toml$/, "", mp)
+            printf "%s\t%s\n", $1, mp
+        }'
+    )"
+    count=$(printf '%s' "$publishable_crates" | grep -c . || true)
+    pass "enumerated $count publishable crate(s)"
+fi
+
+# --- 4. scan each publishable crate for pub enum compliance ---------
+# For each publishable crate, walk every `.rs` file under `src/`
+# and for every `pub enum` line, assert one of:
+#   (a) the enum has `#[non_exhaustive]` on the preceding non-blank,
+#       non-comment line;
+#   (b) the enum has `#[allow(clippy::exhaustive_enums)]` on the
+#       preceding non-blank line, and the line immediately before
+#       that `#[allow]` is a `// reason:` line-comment;
+#   (c) the crate's lib.rs (or main.rs) carries a crate-level
+#       `#![allow(clippy::exhaustive_enums)]`.
+#
+# The awk below implements (a) and (b) via a small state machine
+# that remembers the last 2 non-blank, non-test-mode-boundary lines.
+# (c) is tested per-crate before entering the scan.
+#
+# Note: this is a backstop. If clippy is doing its job the scan
+# is vacuously satisfied on the publishable set. The script's job
+# is to make the invariant visible at the repository level —
+# "I can audit the gate without running rustc."
+scan_crate() {
+    # $1 = crate name, $2 = crate dir
+    local name="$1"
+    local dir="$2"
+    local src_dir="$dir/src"
+    if [ ! -d "$src_dir" ]; then
+        return 0
+    fi
+
+    # Check for crate-level allow in lib.rs OR main.rs.
+    local root=""
+    if [ -f "$src_dir/lib.rs" ]; then
+        root="$src_dir/lib.rs"
+    elif [ -f "$src_dir/main.rs" ]; then
+        root="$src_dir/main.rs"
+    fi
+    if [ -n "$root" ] \
+        && grep -qE '^[[:space:]]*#!\[allow\(clippy::exhaustive_enums\)\]' "$root"; then
+        pass "crate-level escape at $root (crate $name)"
+        return 0
+    fi
+
+    # Walk every .rs file under src/. For each `pub enum` line,
+    # run the state-machine check.
+    local files
+    files="$(find "$src_dir" -type f -name '*.rs' -print | sort)"
+    local file
+    for file in $files; do
+        awk -v FNAME="$file" '
+            function emit_fail(msg) {
+                printf "FAIL_LINE %s:%d: %s\n", FNAME, NR, msg
+                fails++
+            }
+            function is_non_exhaustive(s) {
+                return (s ~ /^[[:space:]]*#\[non_exhaustive\][[:space:]]*$/)
+            }
+            function is_exhaustive_allow(s) {
+                return (s ~ /^[[:space:]]*#\[allow\([^)]*clippy::exhaustive_enums[^)]*\)\][[:space:]]*$/)
+            }
+            function is_reason_comment(s) {
+                return (s ~ /^[[:space:]]*\/\/[[:space:]]*reason:/)
+            }
+            BEGIN { prev1 = ""; prev2 = ""; fails = 0 }
+            # Track only `pub enum <Ident>` — not `pub(crate) enum`,
+            # not `enum` (crate-private), not enum variant field
+            # refs. The lint only fires on truly public enums.
+            {
+                if ($0 ~ /^[[:space:]]*pub[[:space:]]+enum[[:space:]]+[A-Za-z_]/) {
+                    # Match option (a)
+                    if (is_non_exhaustive(prev1)) {
+                        # ok
+                    } else if (is_exhaustive_allow(prev1)) {
+                        # Match option (b): reason comment must be
+                        # the line before the #[allow].
+                        if (is_reason_comment(prev2)) {
+                            # ok
+                        } else {
+                            emit_fail("#[allow(clippy::exhaustive_enums)] without `// reason:` line-comment on preceding line")
+                        }
+                    } else {
+                        emit_fail("pub enum without #[non_exhaustive] or documented escape")
+                    }
+                }
+                prev2 = prev1
+                prev1 = $0
+            }
+            END { exit (fails > 0) ? 1 : 0 }
+        ' "$file"
+    done
+}
+
+if [ -n "$publishable_crates" ]; then
+    # Split publishable_crates on newline, iterate.
+    OLDIFS="$IFS"
+    IFS='
+'
+    all_clean=1
+    for row in $publishable_crates; do
+        name=$(printf '%s' "$row" | cut -f1)
+        path=$(printf '%s' "$row" | cut -f2)
+        out="$(scan_crate "$name" "$path" 2>&1)"
+        if printf '%s' "$out" | grep -q '^FAIL_LINE '; then
+            fail "crate $name has pub enum(s) without #[non_exhaustive] or escape:"
+            printf '%s\n' "$out" | grep '^FAIL_LINE ' | sed 's/^FAIL_LINE /    /'
+            all_clean=0
+        else
+            # Echo any PASS lines emitted for crate-level escapes.
+            printf '%s\n' "$out" | grep -E '^PASS  ' || true
+        fi
+    done
+    IFS="$OLDIFS"
+    if [ "$all_clean" = "1" ]; then
+        pass "all publishable crates satisfy #[non_exhaustive] policy"
+    fi
+fi
+
+# --- summary --------------------------------------------------------
+echo
+echo "$pass_count passed, $fail_count failed, $skip_count skipped"
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/scripts/non-exhaustive-scripts-test.sh
+++ b/scripts/non-exhaustive-scripts-test.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# scripts/non-exhaustive-scripts-test.sh
+#
+# Self-test harness for the `#[non_exhaustive]` policy gate.
+#
+# Two layers under test:
+#
+#   1. Structural backstop — `scripts/non-exhaustive-check.sh`
+#      asserts workspace lint entry + per-enum escape discipline on
+#      every publishable crate. This script runs the backstop and
+#      verifies it both passes on the real tree AND fails on a bad
+#      fixture (negative test).
+#
+#   2. Clippy regression fixture —
+#      `tests/fixtures/non-exhaustive/` is a self-contained
+#      3-member workspace (`compliant`, `bad`, `allowed`). This
+#      script runs `cargo clippy -- -D clippy::exhaustive_enums`
+#      against each member and asserts the expected outcome. Locks
+#      in clippy's behavior on the lint against restriction-
+#      category drift across clippy point releases.
+#
+# CI vs local:
+#   $CI: missing `cargo` fails hard. Locally: skip with install hint.
+#
+# Invocation:
+#   bash scripts/non-exhaustive-scripts-test.sh
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+pass() {
+    printf 'PASS  %s\n' "$1"
+    pass_count=$((pass_count + 1))
+}
+fail() {
+    printf 'FAIL  %s\n' "$1" >&2
+    fail_count=$((fail_count + 1))
+}
+skip() {
+    printf 'SKIP  %s\n' "$1"
+    skip_count=$((skip_count + 1))
+}
+
+missing_tool() {
+    local scenario="$1"
+    local tool="$2"
+    local hint="$3"
+    if [ -n "${CI:-}" ]; then
+        fail "$scenario ($tool missing in CI — $hint)"
+    else
+        skip "$scenario ($tool missing locally — $hint)"
+    fi
+}
+
+# --- 1. policy doc exists -------------------------------------------
+scenario="policy doc exists at docs/api-stability.md"
+if [ -f "docs/api-stability.md" ]; then
+    pass "$scenario"
+else
+    fail "$scenario"
+fi
+
+# --- 2. workspace lint entry in Cargo.toml --------------------------
+scenario="Cargo.toml declares exhaustive_enums = deny"
+if grep -qE '^[[:space:]]*exhaustive_enums[[:space:]]*=[[:space:]]*\{[[:space:]]*level[[:space:]]*=[[:space:]]*"deny"' Cargo.toml; then
+    pass "$scenario"
+else
+    fail "$scenario"
+fi
+
+# --- 3. backstop script is executable -------------------------------
+scenario="scripts/non-exhaustive-check.sh is executable"
+if [ -x "scripts/non-exhaustive-check.sh" ]; then
+    pass "$scenario"
+else
+    fail "$scenario"
+fi
+
+# --- 4. backstop passes on the real tree ----------------------------
+scenario="scripts/non-exhaustive-check.sh passes on current tree"
+if bash scripts/non-exhaustive-check.sh >/dev/null 2>&1; then
+    pass "$scenario"
+else
+    fail "$scenario"
+    # Re-run to surface output for debugging.
+    bash scripts/non-exhaustive-check.sh || true
+fi
+
+# --- 5. fixture workspace exists ------------------------------------
+scenario="fixture workspace at tests/fixtures/non-exhaustive/"
+fixture_root="tests/fixtures/non-exhaustive"
+if [ -d "$fixture_root" ] \
+    && [ -f "$fixture_root/Cargo.toml" ] \
+    && [ -f "$fixture_root/compliant/src/lib.rs" ] \
+    && [ -f "$fixture_root/bad/src/lib.rs" ] \
+    && [ -f "$fixture_root/allowed/src/lib.rs" ]; then
+    pass "$scenario"
+else
+    fail "$scenario (expected Cargo.toml + compliant/bad/allowed members)"
+fi
+
+# --- 6. fixture oracle: clippy accepts `compliant` ------------------
+# Uses `-D clippy::exhaustive_enums` directly on the command line
+# rather than relying on the fixture's own lint table (the fixture
+# has none). This matches how the upstream workspace uses the lint
+# via `[workspace.lints.clippy]` but keeps the fixture dependency-
+# free. See tests/fixtures/non-exhaustive/Cargo.toml.
+scenario="fixture oracle: clippy accepts compliant (#[non_exhaustive])"
+if ! command -v cargo >/dev/null 2>&1; then
+    missing_tool "$scenario" "cargo" "install rustup + cargo"
+else
+    if ( cd "$fixture_root" && cargo clippy --package compliant --quiet -- -D clippy::exhaustive_enums >/dev/null 2>&1 ); then
+        pass "$scenario"
+    else
+        fail "$scenario"
+    fi
+fi
+
+# --- 7. fixture oracle: clippy accepts `allowed` --------------------
+scenario="fixture oracle: clippy accepts allowed (escape with // reason:)"
+if ! command -v cargo >/dev/null 2>&1; then
+    missing_tool "$scenario" "cargo" "install rustup + cargo"
+else
+    if ( cd "$fixture_root" && cargo clippy --package allowed --quiet -- -D clippy::exhaustive_enums >/dev/null 2>&1 ); then
+        pass "$scenario"
+    else
+        fail "$scenario"
+    fi
+fi
+
+# --- 8. fixture oracle: clippy rejects `bad` ------------------------
+# If this ever starts passing, either the lint is not firing (point-
+# release regression) or the fixture's `bad/src/lib.rs` got silently
+# edited. Both are exactly what the self-test is here to catch.
+scenario="fixture oracle: clippy rejects bad (bare pub enum)"
+if ! command -v cargo >/dev/null 2>&1; then
+    missing_tool "$scenario" "cargo" "install rustup + cargo"
+else
+    if ( cd "$fixture_root" && cargo clippy --package bad --quiet -- -D clippy::exhaustive_enums >/dev/null 2>&1 ); then
+        fail "$scenario (clippy accepted a bare pub enum — lint regression!)"
+    else
+        pass "$scenario"
+    fi
+fi
+
+# --- 9. backstop negative test --------------------------------------
+# The backstop script must reject a publishable crate with a naked
+# pub enum. We don't touch the real tree — we construct a synthetic
+# mini-workspace in a tmpdir and point the script at it.
+#
+# This exercises the `awk` state machine that the on-tree test in
+# step 4 cannot reach (because the real tree is clean today). If
+# someone breaks the state machine, this test catches it.
+scenario="backstop negative test: rejects naked pub enum"
+tmpdir="$(mktemp -d)"
+cleanup_tmp() { rm -rf "$tmpdir"; }
+trap cleanup_tmp EXIT
+
+cat > "$tmpdir/Cargo.toml" <<'TOML'
+[workspace]
+resolver = "2"
+members = ["naked"]
+
+[workspace.lints.clippy]
+exhaustive_enums = { level = "deny", priority = 1 }
+TOML
+mkdir -p "$tmpdir/naked/src"
+cat > "$tmpdir/naked/Cargo.toml" <<'TOML'
+[package]
+name = "naked"
+version = "0.0.0"
+edition = "2021"
+# No publish=false on purpose — this crate must count as publishable.
+
+[lib]
+path = "src/lib.rs"
+TOML
+cat > "$tmpdir/naked/src/lib.rs" <<'RS'
+pub enum Naked { A, B }
+RS
+
+# Clone the backstop and repoint its cd to the tmpdir. Simplest
+# portable way: copy the script, replace the `cd "$repo_root"` line
+# with `cd "$tmpdir"`.
+cp scripts/non-exhaustive-check.sh "$tmpdir/check.sh"
+# Substitute the cd-to-repo-root line with an explicit tmpdir cd.
+awk -v TMP="$tmpdir" '
+    /^cd "\$repo_root"$/ { print "cd \"" TMP "\""; next }
+    { print }
+' "$tmpdir/check.sh" > "$tmpdir/check.sh.new"
+mv "$tmpdir/check.sh.new" "$tmpdir/check.sh"
+chmod +x "$tmpdir/check.sh"
+
+# Expect the check to exit non-zero with a FAIL_LINE mention.
+if bash "$tmpdir/check.sh" 2>&1 | grep -q 'pub enum without #\[non_exhaustive\]'; then
+    pass "$scenario"
+else
+    fail "$scenario (backstop did not flag the synthetic naked enum)"
+    bash "$tmpdir/check.sh" 2>&1 || true
+fi
+
+# --- 10. backstop negative test: allow without reason ---------------
+# `#[allow(clippy::exhaustive_enums)]` without a preceding
+# `// reason:` comment must be rejected. Distinct code path from #9.
+scenario="backstop negative test: rejects #[allow] without // reason:"
+cat > "$tmpdir/naked/src/lib.rs" <<'RS'
+#[allow(clippy::exhaustive_enums)]
+pub enum NoReason { A, B }
+RS
+
+if bash "$tmpdir/check.sh" 2>&1 | grep -q 'line-comment on preceding line'; then
+    pass "$scenario"
+else
+    fail "$scenario (backstop accepted an #[allow] without // reason:)"
+    bash "$tmpdir/check.sh" 2>&1 || true
+fi
+
+# --- summary --------------------------------------------------------
+echo
+echo "$pass_count passed, $fail_count failed, $skip_count skipped"
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/tests/fixtures/non-exhaustive/.gitignore
+++ b/tests/fixtures/non-exhaustive/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/tests/fixtures/non-exhaustive/Cargo.toml
+++ b/tests/fixtures/non-exhaustive/Cargo.toml
@@ -1,0 +1,19 @@
+# Toy workspace used by `scripts/non-exhaustive-scripts-test.sh`.
+# NOT part of mango's workspace — the root `Cargo.toml` excludes
+# this path.
+#
+# Purpose: lock in clippy's behavior on the
+# `clippy::exhaustive_enums` lint against restriction-category
+# drift across clippy point releases. Each member exercises one of
+# three outcomes the script asserts on:
+#
+#   - `compliant`: `#[non_exhaustive] pub enum ...` → clippy clean
+#   - `allowed`:   `// reason: ...` + `#[allow(...)]` → clippy clean
+#   - `bad`:       bare `pub enum ...` → clippy must fail with
+#                  `-D clippy::exhaustive_enums`
+#
+# Keep dependency-free so the test doesn't drag the registry on
+# every CI run. Precedent: `tests/fixtures/geiger-toy-workspace/`.
+[workspace]
+resolver = "2"
+members = ["compliant", "bad", "allowed"]

--- a/tests/fixtures/non-exhaustive/allowed/Cargo.toml
+++ b/tests/fixtures/non-exhaustive/allowed/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "allowed"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"

--- a/tests/fixtures/non-exhaustive/allowed/src/lib.rs
+++ b/tests/fixtures/non-exhaustive/allowed/src/lib.rs
@@ -1,0 +1,12 @@
+//! Fixture: a `pub enum` with a per-enum escape: a `// reason:`
+//! line-comment followed by `#[allow(clippy::exhaustive_enums)]`.
+//! This is the MSRV-1.80-compatible shape of the escape hatch
+//! documented in `docs/api-stability.md`. clippy must accept it at
+//! `-D clippy::exhaustive_enums`.
+
+// reason: exhaustive-by-contract — closed set by design, adding a variant is a major break.
+#[allow(clippy::exhaustive_enums)]
+pub enum Parity {
+    Even,
+    Odd,
+}

--- a/tests/fixtures/non-exhaustive/bad/Cargo.toml
+++ b/tests/fixtures/non-exhaustive/bad/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "bad"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"

--- a/tests/fixtures/non-exhaustive/bad/src/lib.rs
+++ b/tests/fixtures/non-exhaustive/bad/src/lib.rs
@@ -1,0 +1,8 @@
+//! Fixture: a bare `pub enum` without `#[non_exhaustive]` and
+//! without an escape. clippy::exhaustive_enums must reject this at
+//! `-D` level — that rejection is what the self-test asserts on.
+
+pub enum Bad {
+    A,
+    B,
+}

--- a/tests/fixtures/non-exhaustive/compliant/Cargo.toml
+++ b/tests/fixtures/non-exhaustive/compliant/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "compliant"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"

--- a/tests/fixtures/non-exhaustive/compliant/src/lib.rs
+++ b/tests/fixtures/non-exhaustive/compliant/src/lib.rs
@@ -1,0 +1,8 @@
+//! Fixture: a `pub enum` annotated with `#[non_exhaustive]`.
+//! clippy::exhaustive_enums must accept this at `-D` level.
+
+#[non_exhaustive]
+pub enum Direction {
+    Ingress,
+    Egress,
+}


### PR DESCRIPTION
## Summary

Ships ROADMAP.md item 0.5 — the `#[non_exhaustive]` policy on
public enums — as a two-layer gate: workspace-wide
`clippy::exhaustive_enums = "deny"` (primary) + a structural
backstop (`scripts/non-exhaustive-check.sh`) that audits the
workspace invariant independently of clippy. Publishable crates
opt-in-by-default; non-publishable crates (`mango-proto`,
`mango-loom-demo`, `mango-madsim-demo`, `xtask-vet-ttl`) carry a
crate-level `#![allow(clippy::exhaustive_enums)]` at lib.rs top
with per-crate justification comments, mirroring the existing
`unsafe_code = "forbid"` + per-crate `#![allow(unsafe_code)]`
pattern. Per-enum escape hatch is a `// reason: …` line-comment
immediately preceding `#[allow(clippy::exhaustive_enums)]` (the
MSRV-1.80 form; moves to inline `reason = "..."` when MSRV lands
at 1.81+).

Defense-in-depth: a 3-member fixture workspace
(`tests/fixtures/non-exhaustive/{compliant,bad,allowed}`) locks in
clippy's behavior on the restriction-category lint against
point-release drift. A 10-assertion self-test
(`scripts/non-exhaustive-scripts-test.sh`) exercises the fixture
clippy oracle plus two synthetic-tmpdir negative tests that cover
the backstop's awk state machine.

Cross-refs added to `docs/msrv.md` (MSRV-bump checklist step for
migrating the `// reason:` convention at 1.81+), `CONTRIBUTING.md`
(§"Other policies" pointer), and `.github/pull_request_template.md`
(§9 "New public API" link).

## Classification

- [x] **Plumbing** (#1) — no north-star axis moves. Policy
      infrastructure for public-enum evolution; enforces a gate
      rather than shipping runtime behavior.
      Verification strategy: `bash scripts/non-exhaustive-scripts-test.sh`
      (10/10 pass), `bash scripts/non-exhaustive-check.sh` (PASS on
      the real tree), `cargo clippy --workspace --all-targets --locked
      -- -D warnings` (No issues found).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo nextest run --workspace --all-targets --locked --profile ci` (21 passed, 1 skipped)
- [x] `bash scripts/non-exhaustive-check.sh` (backstop PASS)
- [x] `bash scripts/non-exhaustive-scripts-test.sh` (10/10 PASS)
- [x] Fixture oracle: `cargo clippy --package compliant/allowed --
      -D clippy::exhaustive_enums` passes; `--package bad` fails
      (assertions #6–#8 in the self-test)
- [x] Synthetic-tmpdir backstop negative tests (assertions #9, #10)
- [x] No new `TODO` / `FIXME` / `unimplemented!` introduced
- [ ] rust-expert adversarial review (final gate)

## Rollback

Revert the five commits on this branch. The workspace `Cargo.toml`
lint entry is the only load-bearing change — removing it disables
the gate immediately. Per-crate `#![allow]`s become no-ops when
the workspace deny is removed.

## Refs

- `ROADMAP.md:804`
- `.planning/0-5-non-exhaustive-policy.plan.md`
- `docs/api-stability.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
