### PR TITLE
chore(vet,ci): PR #38 follow-up nits

### DIFF
--- a/.github/workflows/madsim.yml
+++ b/.github/workflows/madsim.yml
@@ -46,9 +46,11 @@ on:
     paths:
       - "crates/**/src/**"
       - "crates/**/tests/**"
+      - "crates/**/build.rs"
       - "crates/**/Cargo.toml"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/madsim.yml"
       - "scripts/madsim-crates.sh"
       - "scripts/madsim-scripts-test.sh"
@@ -59,9 +61,11 @@ on:
     paths:
       - "crates/**/src/**"
       - "crates/**/tests/**"
+      - "crates/**/build.rs"
       - "crates/**/Cargo.toml"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/madsim.yml"
       - "scripts/madsim-crates.sh"
       - "scripts/madsim-scripts-test.sh"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -16,22 +16,22 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [policy.mango]
 audit-as-crates-io = false
 criteria = "safe-to-deploy"
-notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+notes = "first-party workspace crate; audit-as-crates-io=false so cargo-vet does not require third-party audits for mango's own code. safe-to-deploy is governed by in-tree review (CODEOWNERS + PR review)."
 
 [policy.mango-loom-demo]
 audit-as-crates-io = false
 criteria = "safe-to-deploy"
-notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+notes = "first-party workspace crate; audit-as-crates-io=false so cargo-vet does not require third-party audits for mango's own code. safe-to-deploy is governed by in-tree review (CODEOWNERS + PR review)."
 
 [policy.mango-proto]
 audit-as-crates-io = false
 criteria = "safe-to-deploy"
-notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+notes = "first-party workspace crate; audit-as-crates-io=false so cargo-vet does not require third-party audits for mango's own code. safe-to-deploy is governed by in-tree review (CODEOWNERS + PR review)."
 
 [policy.xtask-vet-ttl]
 audit-as-crates-io = false
 criteria = "safe-to-deploy"
-notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+notes = "first-party workspace crate; audit-as-crates-io=false so cargo-vet does not require third-party audits for mango's own code. safe-to-deploy is governed by in-tree review (CODEOWNERS + PR review)."
 
 [[exemptions.ahash]]
 version = "0.8.12"


### PR DESCRIPTION
## Summary

Follow-up to PR #38 (cargo-vet supply-chain audit gate) addressing two substantive rust-expert nits.

Nit #1 — **stale cargo-vet notes on first-party `[policy.*]` blocks.** The cargo-vet regenerate pass in PR #38 accidentally copied the third-party exemption boilerplate (`"madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"`) into all four first-party policy blocks:

- `[policy.mango]`
- `[policy.mango-loom-demo]`
- `[policy.mango-proto]`
- `[policy.xtask-vet-ttl]`

That text describes an audit-pending third-party crate. It is wrong for first-party crates where the policy is intentional (`audit-as-crates-io = false`, `safe-to-deploy` via in-tree review). Rewritten to explain the actual policy.

Nit #2 — **madsim.yml path filter gaps.** The filter triggered on `crates/**/src/**` and `Cargo.toml` but not on:

- `crates/**/build.rs` — build scripts affect compilation; a change touching only a build.rs would silently skip madsim until the next unrelated source edit.
- `rust-toolchain.toml` — not currently present in-repo, but added preemptively so the moment someone adds one, toolchain edits trigger madsim (toolchain version flips can affect madsim's `--cfg madsim` resolution).

Both added symmetrically in `pull_request.paths` and `push.paths`.

## Test plan

- [x] `cargo vet --locked` — passes (26 fully audited, 2 partially, 101 exempted).
- [x] `yamllint .github/workflows/madsim.yml` — no change in structure, only list additions.
- [x] CI — no behavior change; the madsim workflow remains green on this PR since it touches `.github/workflows/madsim.yml` (which is itself in the filter).

## Note on commit message accuracy

The commit message for the madsim.yml change references "loom.yml and miri.yml precedent" — on closer inspection, loom.yml uses a broader `crates/mango-loom-demo/**` filter that covers build.rs implicitly. The madsim.yml filter is path-by-path and needs explicit `build.rs` entries. The commit reasoning is correct; the precedent framing is imprecise. Not worth amending.

Refs: Task #29 (rust-expert PR #38 review follow-up nits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
