### PR TITLE
chore(non-exhaustive): PR #40 follow-up nits (cluster awk + MSRV tripwire + fixture + docs)

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -87,17 +87,22 @@ Four narrow cases:
 Variant sets that are load-bearing contracts with downstream
 exhaustive pattern-matching and where adding a variant is _always_
 a major semver break by design — e.g. `Direction { Ingress,
-Egress }`, `Parity { Even, Odd }`, `Role { Leader, Follower,
-Candidate }`.
+Egress }`, `Parity { Even, Odd }`.
+
+Be strict about what qualifies. Raft `Role { Leader, Follower,
+Candidate }` is _not_ a good example — real Raft implementations
+legitimately grow roles (`PreCandidate`, `Learner`, etc.) and the
+right shape for such an enum is `#[non_exhaustive]`. Reserve the
+exhaustive-by-contract escape for enums where the mathematical or
+protocol-level closure is load-bearing.
 
 ```rust
-// reason: exhaustive-by-contract — Raft roles are a closed set; adding
-// a variant is a major protocol break by design.
+// reason: exhaustive-by-contract — parity is a closed two-element set
+// (mod 2); adding a variant would be ill-formed, not just a break.
 #[allow(clippy::exhaustive_enums)]
-pub enum Role {
-    Leader,
-    Follower,
-    Candidate,
+pub enum Parity {
+    Even,
+    Odd,
 }
 ```
 
@@ -136,8 +141,10 @@ justification.
 Crates that set `publish = false` are **out of scope** for this
 policy. They carry a crate-level `#![allow(clippy::exhaustive_enums)]`
 at lib.rs top with a one-line comment citing this section. Removing
-`publish = false` MUST be paired with removing the allow in the same
-PR.
+`publish = false` MUST be paired with **replacing** the crate-level
+allow with either `#[non_exhaustive]` on every public enum or per-enum
+`// reason:` escapes — dropping the crate-level allow alone would
+red-light clippy on every enum in the crate at once.
 
 ## How to add a per-enum exception at MSRV 1.80
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -97,14 +97,19 @@ exhaustive-by-contract escape for enums where the mathematical or
 protocol-level closure is load-bearing.
 
 ```rust
-// reason: exhaustive-by-contract — parity is a closed two-element set
-// (mod 2); adding a variant would be ill-formed, not just a break.
+// reason: exhaustive-by-contract — parity mod 2 is mathematically closed; a third variant would be ill-formed, not merely a break.
 #[allow(clippy::exhaustive_enums)]
 pub enum Parity {
     Even,
     Odd,
 }
 ```
+
+The `// reason:` comment is on a **single line**. The backstop
+(`scripts/non-exhaustive-check.sh`) requires the line _immediately_
+before `#[allow(clippy::exhaustive_enums)]` to be a `// reason:`
+line-comment; a wrapped two-line reason fails the backstop because
+the continuation line is not itself a `reason:` marker.
 
 ### 2. C-repr / FFI enums
 
@@ -113,8 +118,7 @@ a wire protocol, kernel ioctl, or FFI boundary. Adding a variant
 would silently reinterpret existing data.
 
 ```rust
-// reason: C-repr wire type — variants match kernel TCP_INFO states;
-// adding one would misread a live socket.
+// reason: C-repr wire type — variants match kernel TCP_INFO states; adding one would misread a live socket.
 #[allow(clippy::exhaustive_enums)]
 #[repr(u8)]
 pub enum TcpState {

--- a/scripts/non-exhaustive-check.sh
+++ b/scripts/non-exhaustive-check.sh
@@ -46,7 +46,16 @@
 
 set -u
 
-repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+# Repo root discovery. Default: resolve from the script's own location,
+# so `bash scripts/non-exhaustive-check.sh` works from any CWD. The
+# $NON_EXHAUSTIVE_REPO_ROOT env var overrides for the self-test's
+# synthetic-tmpdir negative tests — see
+# scripts/non-exhaustive-scripts-test.sh tests #9/#10.
+if [ -n "${NON_EXHAUSTIVE_REPO_ROOT:-}" ]; then
+    repo_root="$NON_EXHAUSTIVE_REPO_ROOT"
+else
+    repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+fi
 cd "$repo_root"
 
 pass_count=0
@@ -142,17 +151,32 @@ fi
 # --- 4. scan each publishable crate for pub enum compliance ---------
 # For each publishable crate, walk every `.rs` file under `src/`
 # and for every `pub enum` line, assert one of:
-#   (a) the enum has `#[non_exhaustive]` on the preceding non-blank,
-#       non-comment line;
-#   (b) the enum has `#[allow(clippy::exhaustive_enums)]` on the
-#       preceding non-blank line, and the line immediately before
-#       that `#[allow]` is a `// reason:` line-comment;
+#   (a) any line in the attribute/comment cluster immediately above
+#       the `pub enum` is `#[non_exhaustive]`;
+#   (b) any line in that cluster is
+#       `#[allow(clippy::exhaustive_enums)]` AND the line immediately
+#       preceding it in the cluster is a `// reason:` line-comment;
 #   (c) the crate's lib.rs (or main.rs) carries a crate-level
 #       `#![allow(clippy::exhaustive_enums)]`.
 #
-# The awk below implements (a) and (b) via a small state machine
-# that remembers the last 2 non-blank, non-test-mode-boundary lines.
-# (c) is tested per-crate before entering the scan.
+# Cluster definition (for (a) and (b)):
+#   A cluster is a run of consecutive lines matching any of:
+#     - `#[...]` outer attribute
+#     - `///` or `//!` doc-comment
+#     - `//` line-comment (including the `// reason:` form)
+#   The cluster ends (resets) on:
+#     - a blank line
+#     - any non-attribute, non-comment content (item, brace, etc.)
+#
+# Cluster is stored in source order: cluster[0] is the top of the
+# cluster (farthest from `pub enum`); cluster[n-1] is the line
+# immediately above `pub enum`. The reason↔allow adjacency rule reads
+# `cluster[i]` (the allow) and `cluster[i-1]` (the reason).
+#
+# Rationale for rewriting away from the prev1/prev2 scheme: that
+# scheme false-rejected `#[derive(Debug)]\n#[non_exhaustive]\npub enum`,
+# because `#[non_exhaustive]` landed on `prev2` behind `#[derive]` on
+# `prev1` and prev2 was only checked as a `// reason:` candidate.
 #
 # Note: this is a backstop. If clippy is doing its job the scan
 # is vacuously satisfied on the publishable set. The script's job
@@ -181,7 +205,7 @@ scan_crate() {
     fi
 
     # Walk every .rs file under src/. For each `pub enum` line,
-    # run the state-machine check.
+    # run the cluster-buffer check.
     local files
     files="$(find "$src_dir" -type f -name '*.rs' -print | sort)"
     local file
@@ -194,35 +218,73 @@ scan_crate() {
             function is_non_exhaustive(s) {
                 return (s ~ /^[[:space:]]*#\[non_exhaustive\][[:space:]]*$/)
             }
+            # Accepts multi-lint allow forms like
+            # `#[allow(clippy::exhaustive_enums, dead_code)]` — the
+            # `[^)]*` on either side of `clippy::exhaustive_enums` lets
+            # other lint names share the attribute call. Intentional:
+            # real-world escapes often group related lints.
             function is_exhaustive_allow(s) {
                 return (s ~ /^[[:space:]]*#\[allow\([^)]*clippy::exhaustive_enums[^)]*\)\][[:space:]]*$/)
             }
             function is_reason_comment(s) {
                 return (s ~ /^[[:space:]]*\/\/[[:space:]]*reason:/)
             }
-            BEGIN { prev1 = ""; prev2 = ""; fails = 0 }
+            function is_attr(s) {
+                return (s ~ /^[[:space:]]*#\[/)
+            }
+            function is_line_comment(s) {
+                # Matches `//`, `///`, `//!`, and `// reason:` — any
+                # line-comment form. Not `/* */` block comments; those
+                # would break the cluster in rustc too (well, partially
+                # — but we keep it simple).
+                return (s ~ /^[[:space:]]*\/\//)
+            }
+            function is_blank(s) {
+                return (s ~ /^[[:space:]]*$/)
+            }
+            function cluster_reset() {
+                ncluster = 0
+                delete cluster
+            }
+            function cluster_push(s) {
+                cluster[ncluster] = s
+                ncluster++
+            }
+            function cluster_scan_pub_enum() {
+                # Returns 1 on accept, 0 on reject. Emits fail on 0.
+                for (i = 0; i < ncluster; i++) {
+                    if (is_non_exhaustive(cluster[i])) return 1
+                }
+                # No #[non_exhaustive] in the cluster; look for an
+                # exhaustive_allow escape with a reason immediately
+                # preceding it in the cluster (source-adjacent).
+                for (i = 0; i < ncluster; i++) {
+                    if (is_exhaustive_allow(cluster[i])) {
+                        if (i >= 1 && is_reason_comment(cluster[i-1])) {
+                            return 1
+                        }
+                        emit_fail("#[allow(clippy::exhaustive_enums)] without `// reason:` line-comment on preceding line")
+                        return 0
+                    }
+                }
+                emit_fail("pub enum without #[non_exhaustive] or documented escape")
+                return 0
+            }
+            BEGIN { ncluster = 0; fails = 0 }
             # Track only `pub enum <Ident>` — not `pub(crate) enum`,
             # not `enum` (crate-private), not enum variant field
             # refs. The lint only fires on truly public enums.
             {
                 if ($0 ~ /^[[:space:]]*pub[[:space:]]+enum[[:space:]]+[A-Za-z_]/) {
-                    # Match option (a)
-                    if (is_non_exhaustive(prev1)) {
-                        # ok
-                    } else if (is_exhaustive_allow(prev1)) {
-                        # Match option (b): reason comment must be
-                        # the line before the #[allow].
-                        if (is_reason_comment(prev2)) {
-                            # ok
-                        } else {
-                            emit_fail("#[allow(clippy::exhaustive_enums)] without `// reason:` line-comment on preceding line")
-                        }
-                    } else {
-                        emit_fail("pub enum without #[non_exhaustive] or documented escape")
-                    }
+                    cluster_scan_pub_enum()
+                    cluster_reset()
+                } else if (is_blank($0)) {
+                    cluster_reset()
+                } else if (is_attr($0) || is_line_comment($0)) {
+                    cluster_push($0)
+                } else {
+                    cluster_reset()
                 }
-                prev2 = prev1
-                prev1 = $0
             }
             END { exit (fails > 0) ? 1 : 0 }
         ' "$file"
@@ -251,6 +313,61 @@ if [ -n "$publishable_crates" ]; then
     IFS="$OLDIFS"
     if [ "$all_clean" = "1" ]; then
         pass "all publishable crates satisfy #[non_exhaustive] policy"
+    fi
+fi
+
+# --- 5. MSRV tripwire for `// reason:` line-comments ----------------
+# The `// reason:` line-comment convention exists because the inline
+# `#[allow(lint, reason = "...")]` form is stable only from rustc 1.81.
+# Mango MSRV is pinned at 1.80 today (workspace.package.rust-version
+# in root Cargo.toml). The moment MSRV advances to 1.81+, the inline
+# form becomes available and the line-comment workaround is obsolete.
+#
+# This tripwire enforces the migration: when the workspace
+# rust-version minor is >= 81 (or any major > 1), any surviving
+# `// reason:` line-comment in a publishable crate's `src/**/*.rs`
+# fails the check. The MSRV-bump PR is then forced to migrate them in
+# the same change-set.
+#
+# Scope is intentionally narrow: publishable `<manifest_dir>/src/**`
+# only. Not `tests/`, not `examples/`, not `benches/`, not fixture
+# workspaces (which are separate workspaces `cargo metadata --no-deps`
+# on the root won't enumerate), not `docs/`.
+#
+# Inert today at MSRV=1.80.
+msrv_raw=$(grep -E '^[[:space:]]*rust-version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+' "$cargo_toml" 2>/dev/null | head -1 || true)
+if [ -n "$msrv_raw" ] && [ -n "$publishable_crates" ]; then
+    # Extract major.minor with sed. Handles both "1.80" and "1.80.0".
+    msrv_major=$(printf '%s' "$msrv_raw" | sed -nE 's/.*"([0-9]+)\.([0-9]+).*/\1/p')
+    msrv_minor=$(printf '%s' "$msrv_raw" | sed -nE 's/.*"([0-9]+)\.([0-9]+).*/\2/p')
+    if [ -n "$msrv_major" ] && [ -n "$msrv_minor" ]; then
+        if [ "$msrv_major" -gt 1 ] || { [ "$msrv_major" -eq 1 ] && [ "$msrv_minor" -ge 81 ]; }; then
+            scenario="MSRV tripwire: no \`// reason:\` line-comments in publishable src/ at MSRV >= 1.81"
+            tripwire_hits=""
+            OLDIFS="$IFS"
+            IFS='
+'
+            for row in $publishable_crates; do
+                path=$(printf '%s' "$row" | cut -f2)
+                src="$path/src"
+                if [ -d "$src" ]; then
+                    hits=$(grep -rEn '^[[:space:]]*//[[:space:]]*reason:' "$src" 2>/dev/null || true)
+                    if [ -n "$hits" ]; then
+                        tripwire_hits="${tripwire_hits}${hits}
+"
+                    fi
+                fi
+            done
+            IFS="$OLDIFS"
+            if [ -n "$tripwire_hits" ]; then
+                fail "$scenario"
+                echo "    MSRV has advanced to 1.${msrv_minor}; the inline" >&2
+                echo "    \`#[allow(lint, reason = \"...\")]\` form is stable — migrate:" >&2
+                printf '%s' "$tripwire_hits" | sed 's/^/        /' >&2
+            else
+                pass "$scenario"
+            fi
+        fi
     fi
 fi
 

--- a/scripts/non-exhaustive-check.sh
+++ b/scripts/non-exhaustive-check.sh
@@ -234,9 +234,11 @@ scan_crate() {
             }
             function is_line_comment(s) {
                 # Matches `//`, `///`, `//!`, and `// reason:` — any
-                # line-comment form. Not `/* */` block comments; those
-                # would break the cluster in rustc too (well, partially
-                # — but we keep it simple).
+                # line-comment form. Block comments `/* */` reset the
+                # cluster here even though rustc tolerates them between
+                # attributes; backstops are allowed to be stricter than
+                # the compiler, and no one writes block-comments in an
+                # attribute cluster in practice.
                 return (s ~ /^[[:space:]]*\/\//)
             }
             function is_blank(s) {
@@ -361,7 +363,7 @@ if [ -n "$msrv_raw" ] && [ -n "$publishable_crates" ]; then
             IFS="$OLDIFS"
             if [ -n "$tripwire_hits" ]; then
                 fail "$scenario"
-                echo "    MSRV has advanced to 1.${msrv_minor}; the inline" >&2
+                echo "    MSRV has advanced to ${msrv_major}.${msrv_minor}; the inline" >&2
                 echo "    \`#[allow(lint, reason = \"...\")]\` form is stable — migrate:" >&2
                 printf '%s' "$tripwire_hits" | sed 's/^/        /' >&2
             else

--- a/scripts/non-exhaustive-scripts-test.sh
+++ b/scripts/non-exhaustive-scripts-test.sh
@@ -134,6 +134,22 @@ else
     fi
 fi
 
+# --- 7.5. fixture oracle: clippy accepts `allowed-derive-after` -----
+# Covers the attribute-cluster case: #[derive(...)] immediately above
+# #[non_exhaustive] above pub enum. Clippy accepts (attribute order on
+# the enum is semantically free). The backstop's awk must also accept
+# — the pre-cluster prev1/prev2 scheme false-rejected this shape.
+scenario="fixture oracle: clippy accepts allowed-derive-after (#[derive] + #[non_exhaustive])"
+if ! command -v cargo >/dev/null 2>&1; then
+    missing_tool "$scenario" "cargo" "install rustup + cargo"
+else
+    if ( cd "$fixture_root" && cargo clippy --package allowed-derive-after --quiet -- -D clippy::exhaustive_enums >/dev/null 2>&1 ); then
+        pass "$scenario"
+    else
+        fail "$scenario"
+    fi
+fi
+
 # --- 8. fixture oracle: clippy rejects `bad` ------------------------
 # If this ever starts passing, either the lint is not firing (point-
 # release regression) or the fixture's `bad/src/lib.rs` got silently
@@ -152,11 +168,12 @@ fi
 # --- 9. backstop negative test --------------------------------------
 # The backstop script must reject a publishable crate with a naked
 # pub enum. We don't touch the real tree — we construct a synthetic
-# mini-workspace in a tmpdir and point the script at it.
+# mini-workspace in a tmpdir and point the script at it via the
+# $NON_EXHAUSTIVE_REPO_ROOT env var (see scripts/non-exhaustive-check.sh).
 #
-# This exercises the `awk` state machine that the on-tree test in
+# This exercises the awk cluster buffer that the on-tree test in
 # step 4 cannot reach (because the real tree is clean today). If
-# someone breaks the state machine, this test catches it.
+# someone breaks the cluster scan, this test catches it.
 scenario="backstop negative test: rejects naked pub enum"
 tmpdir="$(mktemp -d)"
 cleanup_tmp() { rm -rf "$tmpdir"; }
@@ -181,28 +198,22 @@ edition = "2021"
 [lib]
 path = "src/lib.rs"
 TOML
+# Stub policy doc so the check script's "policy doc exists" assertion
+# is satisfied. Orthogonal to the awk cluster scan we're testing here.
+mkdir -p "$tmpdir/docs"
+: > "$tmpdir/docs/api-stability.md"
+
 cat > "$tmpdir/naked/src/lib.rs" <<'RS'
 pub enum Naked { A, B }
 RS
 
-# Clone the backstop and repoint its cd to the tmpdir. Simplest
-# portable way: copy the script, replace the `cd "$repo_root"` line
-# with `cd "$tmpdir"`.
-cp scripts/non-exhaustive-check.sh "$tmpdir/check.sh"
-# Substitute the cd-to-repo-root line with an explicit tmpdir cd.
-awk -v TMP="$tmpdir" '
-    /^cd "\$repo_root"$/ { print "cd \"" TMP "\""; next }
-    { print }
-' "$tmpdir/check.sh" > "$tmpdir/check.sh.new"
-mv "$tmpdir/check.sh.new" "$tmpdir/check.sh"
-chmod +x "$tmpdir/check.sh"
-
-# Expect the check to exit non-zero with a FAIL_LINE mention.
-if bash "$tmpdir/check.sh" 2>&1 | grep -q 'pub enum without #\[non_exhaustive\]'; then
+# Expect the check to flag the naked enum with a FAIL_LINE mention.
+if NON_EXHAUSTIVE_REPO_ROOT="$tmpdir" bash scripts/non-exhaustive-check.sh 2>&1 \
+    | grep -q 'pub enum without #\[non_exhaustive\]'; then
     pass "$scenario"
 else
     fail "$scenario (backstop did not flag the synthetic naked enum)"
-    bash "$tmpdir/check.sh" 2>&1 || true
+    NON_EXHAUSTIVE_REPO_ROOT="$tmpdir" bash scripts/non-exhaustive-check.sh 2>&1 || true
 fi
 
 # --- 10. backstop negative test: allow without reason ---------------
@@ -214,11 +225,51 @@ cat > "$tmpdir/naked/src/lib.rs" <<'RS'
 pub enum NoReason { A, B }
 RS
 
-if bash "$tmpdir/check.sh" 2>&1 | grep -q 'line-comment on preceding line'; then
+if NON_EXHAUSTIVE_REPO_ROOT="$tmpdir" bash scripts/non-exhaustive-check.sh 2>&1 \
+    | grep -q 'line-comment on preceding line'; then
     pass "$scenario"
 else
     fail "$scenario (backstop accepted an #[allow] without // reason:)"
-    bash "$tmpdir/check.sh" 2>&1 || true
+    NON_EXHAUSTIVE_REPO_ROOT="$tmpdir" bash scripts/non-exhaustive-check.sh 2>&1 || true
+fi
+
+# --- 11. backstop positive test: #[derive] + #[non_exhaustive] ------
+# The cluster rewrite must accept `#[derive(Debug)] #[non_exhaustive]
+# pub enum X` — the shape the pre-cluster prev1/prev2 scheme false-
+# rejected. Positive oracle for the awk cluster buffer rewrite. Without
+# this assertion, the rewrite is only dynamically verified by "the real
+# tree still passes", which is a weak oracle (the real tree's enums are
+# all bare `#[non_exhaustive]` today).
+scenario="backstop positive test: accepts #[derive] + #[non_exhaustive]"
+cat > "$tmpdir/naked/src/lib.rs" <<'RS'
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum OkAfter { A, B }
+RS
+
+if NON_EXHAUSTIVE_REPO_ROOT="$tmpdir" bash scripts/non-exhaustive-check.sh >/dev/null 2>&1; then
+    pass "$scenario"
+else
+    fail "$scenario (backstop rejected a valid attribute-cluster shape)"
+    NON_EXHAUSTIVE_REPO_ROOT="$tmpdir" bash scripts/non-exhaustive-check.sh 2>&1 || true
+fi
+
+# --- 12. backstop positive test: #[non_exhaustive] + #[derive] ------
+# Reverse attribute order. Rustc accepts attributes in any order on an
+# item; the backstop must too. Asymmetric acceptance would mean the
+# backstop flags code clippy is happy with.
+scenario="backstop positive test: accepts #[non_exhaustive] + #[derive]"
+cat > "$tmpdir/naked/src/lib.rs" <<'RS'
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum OkBefore { A, B }
+RS
+
+if NON_EXHAUSTIVE_REPO_ROOT="$tmpdir" bash scripts/non-exhaustive-check.sh >/dev/null 2>&1; then
+    pass "$scenario"
+else
+    fail "$scenario (backstop rejected reverse-order attribute cluster)"
+    NON_EXHAUSTIVE_REPO_ROOT="$tmpdir" bash scripts/non-exhaustive-check.sh 2>&1 || true
 fi
 
 # --- summary --------------------------------------------------------

--- a/tests/fixtures/non-exhaustive/Cargo.toml
+++ b/tests/fixtures/non-exhaustive/Cargo.toml
@@ -7,13 +7,16 @@
 # drift across clippy point releases. Each member exercises one of
 # three outcomes the script asserts on:
 #
-#   - `compliant`: `#[non_exhaustive] pub enum ...` → clippy clean
-#   - `allowed`:   `// reason: ...` + `#[allow(...)]` → clippy clean
-#   - `bad`:       bare `pub enum ...` → clippy must fail with
-#                  `-D clippy::exhaustive_enums`
+#   - `compliant`:           `#[non_exhaustive] pub enum ...` → clippy clean
+#   - `allowed`:             `// reason: ...` + `#[allow(...)]` → clippy clean
+#   - `allowed-derive-after`: `#[derive(...)] #[non_exhaustive] pub enum`
+#                             → clippy clean (tests attribute-cluster
+#                             awareness in the backstop's awk)
+#   - `bad`:                 bare `pub enum ...` → clippy must fail with
+#                             `-D clippy::exhaustive_enums`
 #
 # Keep dependency-free so the test doesn't drag the registry on
 # every CI run. Precedent: `tests/fixtures/geiger-toy-workspace/`.
 [workspace]
 resolver = "2"
-members = ["compliant", "bad", "allowed"]
+members = ["compliant", "bad", "allowed", "allowed-derive-after"]

--- a/tests/fixtures/non-exhaustive/allowed-derive-after/Cargo.toml
+++ b/tests/fixtures/non-exhaustive/allowed-derive-after/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "allowed-derive-after"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"

--- a/tests/fixtures/non-exhaustive/allowed-derive-after/src/lib.rs
+++ b/tests/fixtures/non-exhaustive/allowed-derive-after/src/lib.rs
@@ -1,0 +1,12 @@
+//! Fixture: `#[derive(Debug)]` followed by `#[non_exhaustive]` on the
+//! same enum. clippy::exhaustive_enums must accept (attribute order is
+//! semantically free); the backstop's awk cluster scan must also accept
+//! — the pre-cluster prev1/prev2 state machine false-rejected this
+//! shape because `#[non_exhaustive]` landed on prev2 behind `#[derive]`.
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Mode {
+    Read,
+    Write,
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #40 (the `#[non_exhaustive]` policy gate) applying
rust-expert's 7 APPROVE_WITH_NITS items. All non-blocking; bundled
into one atomic PR so the awk cluster rewrite ships with its
matching fixture, self-test oracles, and documentation.

### What changed

**`scripts/non-exhaustive-check.sh`** — four related nits:

- **Nit #1 — awk cluster rewrite.** The pre-existing `prev1`/`prev2`
  state machine false-rejected `#[derive(Debug)] #[non_exhaustive]
pub enum X`, because `#[non_exhaustive]` landed on `prev2` behind
  `#[derive]` on `prev1` and `prev2` was only checked as a `//
reason:` candidate. Replaced with a source-order cluster buffer
  that collects consecutive attribute / doc-comment / `// reason:`
  lines and scans the whole cluster for the `#[non_exhaustive]`
  marker. The reason-immediately-before-allow adjacency rule is
  preserved via a `cluster[i-1]` check relative to the `#[allow]`
  position. Blank lines and non-attribute/non-comment content reset
  the cluster.
- **Nit #2 — env var override.** Added `NON_EXHAUSTIVE_REPO_ROOT`
  env var handling so the self-test can run the real script against
  a synthetic tmpdir without cloning and awk-substituting the `cd`
  line. Default behavior (resolve from script's own location)
  unchanged.
- **Nit #3 — inline comment** on the `is_exhaustive_allow` regex
  noting it accepts multi-lint forms like
  `#[allow(clippy::exhaustive_enums, dead_code)]`.
- **Nit #7 — MSRV tripwire.** Parses `rust-version` from root
  `Cargo.toml`; if minor ≥ 81 (or major > 1), grep-fails on any `//
reason:` line-comment in publishable crate
  `<manifest_dir>/src/**`. The inline `#[allow(lint, reason =
"...")]` form is stable from 1.81, so the line-comment workaround
  becomes obsolete the moment MSRV advances. Inert today at
  MSRV=1.80. Scope is intentionally narrow: library `src/` only,
  never `tests/` / `examples/` / `benches/` / docs / fixture
  workspaces.

**`scripts/non-exhaustive-scripts-test.sh`** — three changes:

- Negative tests #9/#10 drop the `cp` + awk substitution and use
  `NON_EXHAUSTIVE_REPO_ROOT="$tmpdir"` directly. Added a stub
  `$tmpdir/docs/api-stability.md` touch so the orthogonal
  policy-doc-exists assertion doesn't fail.
- New clippy oracle #7.5 for the `allowed-derive-after/` fixture.
- New positive backstop tests #11 and #12 directly exercising the
  cluster rewrite:
  - #11: `#[derive] + #[non_exhaustive]` (the shape the rewrite
    fixes)
  - #12: reverse order `#[non_exhaustive] + #[derive]` (attribute
    order is semantically free in rustc; the backstop must agree or
    it red-flags code clippy accepts)

Total assertions: 10 → 13.

**`tests/fixtures/non-exhaustive/allowed-derive-after/`** — new
fixture member exercising `#[derive(Debug)] #[non_exhaustive] pub
enum Mode`. Added to workspace `members`.

**`docs/api-stability.md`** — two rewrites:

- **Nit #5** — §1 swap. Raft `Role { Leader, Follower, Candidate }`
  was a misleading example of "exhaustive-by-contract" (real Raft
  impls grow roles: `PreCandidate`, `Learner`, etc.). Replaced with
  `Parity { Even, Odd }` and added an explicit callout that Role is
  the wrong shape for this exception.
- **Nit #4** — §4 migration wording. "Removing `publish = false`
  MUST be paired with removing the allow" reworded to "**replacing**
  the crate-level allow with either `#[non_exhaustive]` on every
  public enum or per-enum `// reason:` escapes" — the migration path
  is to push the exception down to per-enum scope, not yank it
  entirely.

**Nit #6** — audit-only. Swatinem/rust-cache keys on `rustc -vV` + host
triple + both Cargo.lock hashes. No risk of a stale sysroot masking a
rustc upgrade. No code change.

## Test plan

- [x] `bash scripts/non-exhaustive-scripts-test.sh` — all 13
      assertions pass.
- [x] `bash scripts/non-exhaustive-check.sh` — still passes on tree.
- [x] Manual: temporarily flipped `rust-version` to `"1.81"` and
      added a `// reason:` comment to `crates/mango/src/lib.rs` →
      tripwire fires with a migration message pointing at the exact
      line, script exits 1. Reverted.
- [x] Manual: `cd tests/fixtures/non-exhaustive && cargo clippy
    --package allowed-derive-after -- -D clippy::exhaustive_enums`
      accepts.

Refs: Task #31 (rust-expert PR #40 APPROVE_WITH_NITS follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)