### PR TITLE
feat(storage): implement Backend against redb (ROADMAP:817)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,8 +620,12 @@ name = "mango-storage"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "madsim",
+ "madsim-tokio",
+ "parking_lot",
  "raft-engine",
  "redb",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ crates = ["mango-loom-demo"]
 # (Cargo does not validate metadata contents) — the regression
 # test is `scripts/madsim-scripts-test.sh`.
 [workspace.metadata.mango.madsim]
-crates = ["mango-madsim-demo"]
+crates = ["mango-madsim-demo", "mango-storage"]
 
 # Exact-version pin for loom. Env-var semantics (LOOM_MAX_PREEMPTIONS,
 # LOOM_MAX_BRANCHES, etc.) and model behavior can drift between minor
@@ -169,6 +169,13 @@ authors = ["mango contributors"]
 [workspace.lints.rust]
 unsafe_code = "forbid"
 unreachable_pub = "warn"
+# `--cfg madsim` is the ecosystem-standard activation mechanism
+# (see docs/madsim.md). Registering it at the workspace level lets
+# any crate carry `#[cfg(madsim)]` / `#[cfg(not(madsim))]` gates
+# without tripping `unexpected_cfgs`. No-op for crates that do not
+# reference the cfg. mango-madsim-demo opts out of workspace lints
+# entirely and declares this locally; every other crate inherits.
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(madsim)"] }
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,18 @@ bytes = "1.11"
 # Already in the transitive graph; exemption already present.
 thiserror = "2"
 
+# Phase 1 Backend-impl deps (ROADMAP:817).
+#
+# parking_lot: sync-path Mutex/RwLock — the blessed alternative to
+# std::sync per clippy.toml's `disallowed-types` ban (std's lock
+# poisoning is a footgun we deliberately don't adopt). Used by
+# RedbBackend to serialize `Database::compact(&mut self)` against
+# concurrent `&self` operations — redb 4.x's compact takes `&mut`,
+# so the backend wraps the Database in `parking_lot::RwLock` and
+# upgrades to a write-guard only in `defragment`. cargo-vet
+# exemption already present (parking_lot@0.12.5, parking_lot_core@0.9.12).
+parking_lot = "0.12"
+
 [workspace.package]
 version = "0.1.0"
 edition = "2021"

--- a/crates/mango-storage/Cargo.toml
+++ b/crates/mango-storage/Cargo.toml
@@ -23,6 +23,15 @@ raft-engine.workspace = true
 # thiserror derives BackendError.
 bytes.workspace = true
 thiserror.workspace = true
+# ROADMAP:817 (Backend impl): parking_lot for the Database RwLock.
+# See Cargo.toml workspace entry for the ban-override rationale.
+parking_lot.workspace = true
+
+[dev-dependencies]
+# ROADMAP:817 integration tests open a real redb on disk in a
+# tempdir; tempfile is the workspace-standard primitive. Exemption
+# already present in supply-chain/config.toml (tempfile@3.27.0).
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/mango-storage/Cargo.toml
+++ b/crates/mango-storage/Cargo.toml
@@ -26,12 +26,32 @@ thiserror.workspace = true
 # ROADMAP:817 (Backend impl): parking_lot for the Database RwLock.
 # See Cargo.toml workspace entry for the ban-override rationale.
 parking_lot.workspace = true
+# ROADMAP:817: tokio::task::spawn_blocking is required so async commit
+# methods do NOT block tokio worker threads with redb's synchronous
+# fsync. `rt` alone covers spawn_blocking — `rt-multi-thread` is
+# deliberately NOT listed because the caller owns their runtime
+# flavor. Workspace entry renames to madsim-tokio; under default
+# build it re-exports real tokio, under --cfg madsim it substitutes
+# the deterministic simulator. See docs/madsim.md.
+tokio = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
 # ROADMAP:817 integration tests open a real redb on disk in a
 # tempdir; tempfile is the workspace-standard primitive. Exemption
 # already present in supply-chain/config.toml (tempfile@3.27.0).
 tempfile = "3"
+# ROADMAP:817: madsim `#[madsim::test]` macro for the smoke test
+# under `--cfg madsim`. mango-storage joins the curated subset in
+# this PR (see [workspace.metadata.mango.madsim].crates).
+madsim = { workspace = true }
+# ROADMAP:817 integration tests drive the async commit API through
+# `#[tokio::test]`; the concurrent-committer test needs a real
+# multi-thread runtime. Features here are ADDITIVE to the main
+# `tokio = { features = ["rt"] }` dep; cargo merges them in the test
+# target. Under `--cfg madsim` these features are a no-op (the sim
+# runtime ignores them) but the test file itself is gated
+# `#![cfg(not(madsim))]`.
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/mango-storage/src/backend.rs
+++ b/crates/mango-storage/src/backend.rs
@@ -89,9 +89,8 @@ pub enum BackendError {
     Closed,
 
     /// A [`Backend::register_bucket`] call tried to bind an id that
-    /// is already bound to a different name (or bind a name to a
-    /// different id). Structured rather than stringly-typed so
-    /// operators can route on the fields.
+    /// is already bound to a different name. Structured rather than
+    /// stringly-typed so operators can route on the fields.
     #[error("bucket id {id:?} already bound to {existing:?}; cannot rebind to {requested:?}")]
     BucketConflict {
         /// The [`BucketId`] being registered.
@@ -100,6 +99,22 @@ pub enum BackendError {
         existing: String,
         /// The name the caller supplied.
         requested: String,
+    },
+
+    /// A [`Backend::register_bucket`] call tried to bind a name that
+    /// is already bound to a different [`BucketId`]. Structured so
+    /// operators can route on the fields — same shape rationale as
+    /// [`Self::BucketConflict`] (the id-rebind variant).
+    #[error(
+        "bucket name {name:?} already bound to {existing_id:?}; cannot rebind to {requested_id:?}"
+    )]
+    BucketNameConflict {
+        /// The name being registered.
+        name: String,
+        /// The [`BucketId`] currently bound to `name`.
+        existing_id: BucketId,
+        /// The [`BucketId`] the caller supplied.
+        requested_id: BucketId,
     },
 
     /// Any other engine-defined error, wrapped as a string so

--- a/crates/mango-storage/src/lib.rs
+++ b/crates/mango-storage/src/lib.rs
@@ -95,6 +95,14 @@ mod tests {
                 },
                 "bar",
             ),
+            (
+                BackendError::BucketNameConflict {
+                    name: "kv".into(),
+                    existing_id: BucketId::new(1),
+                    requested_id: BucketId::new(2),
+                },
+                "kv",
+            ),
             (BackendError::Other("engine boom".into()), "engine boom"),
         ];
         for (err, needle) in cases {

--- a/crates/mango-storage/src/lib.rs
+++ b/crates/mango-storage/src/lib.rs
@@ -15,6 +15,11 @@
 
 pub mod backend;
 
+// ROADMAP:817 redb-backed Backend impl. Public surface re-exported
+// below once the impl types land; this initial commit contains only
+// the internal registry module.
+mod redb;
+
 pub use backend::{
     Backend, BackendConfig, BackendError, BucketId, CommitStamp, HardState, RaftEntry,
     RaftEntryType, RaftLogStore, RaftSnapshotMetadata, RangeIter, ReadSnapshot, WriteBatch,

--- a/crates/mango-storage/src/lib.rs
+++ b/crates/mango-storage/src/lib.rs
@@ -16,14 +16,15 @@
 pub mod backend;
 
 // ROADMAP:817 redb-backed Backend impl. Public surface re-exported
-// below once the impl types land; this initial commit contains only
-// the internal registry module.
+// below. The module is private; only the named types below are
+// public API.
 mod redb;
 
 pub use backend::{
     Backend, BackendConfig, BackendError, BucketId, CommitStamp, HardState, RaftEntry,
     RaftEntryType, RaftLogStore, RaftSnapshotMetadata, RangeIter, ReadSnapshot, WriteBatch,
 };
+pub use redb::{batch::RedbBatch, snapshot::RedbSnapshot, RedbBackend};
 
 /// The package version string, captured at build time from
 /// `CARGO_PKG_VERSION`. Kept as a crate-level constant so downstream

--- a/crates/mango-storage/src/redb/batch.rs
+++ b/crates/mango-storage/src/redb/batch.rs
@@ -1,0 +1,194 @@
+//! [`WriteBatch`] impl for the redb backend.
+//!
+//! A [`RedbBatch`] is a pure staging buffer: `put`/`delete`/`delete_range`
+//! calls append a [`StagedOp`] to an in-memory `Vec` with no redb
+//! involvement. The buffer is replayed into a single
+//! `redb::WriteTransaction` at commit time by the backend's
+//! `apply_staged` / `commit_staged` helpers (see `super`).
+//!
+//! Why staging instead of a live `WriteTransaction`: a live txn
+//! holds redb's write-lock for the batch's entire lifetime, which
+//! would serialize *every* concurrent writer behind an uncommitted
+//! batch. Staging decouples batch construction from the disk
+//! critical section — the only time the redb write-lock is held is
+//! inside `commit_batch` / `commit_group`, for the duration of
+//! fsync.
+//!
+//! # Send-ness
+//!
+//! [`RedbBatch`] is deliberately `!Send` and `!Sync` (carries a
+//! `PhantomData<*const ()>` marker). The trait contract in
+//! `mango_storage::WriteBatch` explicitly permits `!Send`; making
+//! the batch non-shareable documents the invariant "one batch per
+//! logical writer" at the type system level. A `compile_fail`
+//! doctest below pins this invariant against accidental removal.
+//!
+//! ```compile_fail
+//! fn needs_send<T: Send>() {}
+//! needs_send::<mango_storage::RedbBatch>();
+//! ```
+//!
+//! Downstream commit paths extract the staging `Vec<StagedOp>` (which
+//! *is* `Send`) synchronously before constructing any `Future`, so
+//! the `!Send` marker on the batch never blocks the `Future + Send`
+//! trait return type.
+
+use std::marker::PhantomData;
+
+use crate::backend::{BackendError, BucketId, WriteBatch};
+
+/// A single staged mutation. Carries owned byte vectors so the
+/// batch outlives the caller's buffer references (the trait
+/// methods take `&[u8]`; staging copies).
+#[derive(Debug, Clone)]
+pub(super) enum StagedOp {
+    /// Insert-or-overwrite a key in `bucket`.
+    Put {
+        /// Target bucket id.
+        bucket: BucketId,
+        /// Owned key bytes.
+        key: Vec<u8>,
+        /// Owned value bytes.
+        value: Vec<u8>,
+    },
+    /// Remove a single key. No-op at apply time if absent.
+    Delete {
+        /// Target bucket id.
+        bucket: BucketId,
+        /// Owned key bytes.
+        key: Vec<u8>,
+    },
+    /// Remove every key in the half-open interval `[start, end)`.
+    /// Range validation happens at apply time; staging is
+    /// unconditional so `delete_range` stays infallible on the
+    /// hot path (symmetric with `put`/`delete`).
+    DeleteRange {
+        /// Target bucket id.
+        bucket: BucketId,
+        /// Owned start-bound bytes (inclusive).
+        start: Vec<u8>,
+        /// Owned end-bound bytes (exclusive).
+        end: Vec<u8>,
+    },
+}
+
+/// Staging-buffer write batch for the redb backend. Produced by
+/// [`crate::Backend::begin_batch`]; consumed by
+/// [`crate::Backend::commit_batch`] or
+/// [`crate::Backend::commit_group`].
+///
+/// See the module-level docs for the Send-ness rationale.
+#[derive(Debug, Default)]
+pub struct RedbBatch {
+    staged: Vec<StagedOp>,
+    /// `PhantomData<*const ()>` is the canonical `!Send + !Sync`
+    /// marker: raw pointers are neither `Send` nor `Sync`, and
+    /// `PhantomData` inherits those auto-trait bounds without any
+    /// runtime footprint.
+    _not_send_sync: PhantomData<*const ()>,
+}
+
+impl RedbBatch {
+    /// Construct an empty batch. Called only from
+    /// [`crate::Backend::begin_batch`]; user code does not
+    /// construct batches directly.
+    #[must_use]
+    pub(super) fn new() -> Self {
+        Self {
+            staged: Vec::new(),
+            _not_send_sync: PhantomData,
+        }
+    }
+
+    /// Consume the batch and return its staged ops. Called by the
+    /// commit paths in the sync prologue of
+    /// `commit_batch` / `commit_group`, *before* any future is
+    /// constructed, so the `!Send` marker on [`RedbBatch`] does
+    /// not propagate into the `Future + Send` return type.
+    pub(super) fn into_staged(self) -> Vec<StagedOp> {
+        self.staged
+    }
+
+    /// Observability for tests. Counts staged ops without
+    /// revealing the op variant.
+    #[cfg(test)]
+    pub(super) fn staged_len(&self) -> usize {
+        self.staged.len()
+    }
+}
+
+impl WriteBatch for RedbBatch {
+    fn put(&mut self, bucket: BucketId, key: &[u8], value: &[u8]) -> Result<(), BackendError> {
+        self.staged.push(StagedOp::Put {
+            bucket,
+            key: key.to_vec(),
+            value: value.to_vec(),
+        });
+        Ok(())
+    }
+
+    fn delete(&mut self, bucket: BucketId, key: &[u8]) -> Result<(), BackendError> {
+        self.staged.push(StagedOp::Delete {
+            bucket,
+            key: key.to_vec(),
+        });
+        Ok(())
+    }
+
+    fn delete_range(
+        &mut self,
+        bucket: BucketId,
+        start: &[u8],
+        end: &[u8],
+    ) -> Result<(), BackendError> {
+        self.staged.push(StagedOp::DeleteRange {
+            bucket,
+            start: start.to_vec(),
+            end: end.to_vec(),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing
+    )]
+
+    use super::*;
+
+    #[test]
+    fn empty_batch_has_no_staged_ops() {
+        let b = RedbBatch::new();
+        assert_eq!(b.staged_len(), 0);
+    }
+
+    #[test]
+    fn put_delete_delete_range_all_stage_without_io() {
+        let mut b = RedbBatch::new();
+        b.put(BucketId::new(1), b"k", b"v").unwrap();
+        b.delete(BucketId::new(1), b"k").unwrap();
+        b.delete_range(BucketId::new(1), b"a", b"z").unwrap();
+        assert_eq!(b.staged_len(), 3);
+    }
+
+    #[test]
+    fn into_staged_consumes_and_returns() {
+        let mut b = RedbBatch::new();
+        b.put(BucketId::new(1), b"k", b"v").unwrap();
+        let ops = b.into_staged();
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            StagedOp::Put { bucket, key, value } => {
+                assert_eq!(*bucket, BucketId::new(1));
+                assert_eq!(key, b"k");
+                assert_eq!(value, b"v");
+            }
+            other => panic!("expected Put, got {other:?}"),
+        }
+    }
+}

--- a/crates/mango-storage/src/redb/mod.rs
+++ b/crates/mango-storage/src/redb/mod.rs
@@ -1,0 +1,16 @@
+//! `redb`-backed [`crate::Backend`] impl (ROADMAP:817).
+//!
+//! Internal module root. The public surface of the impl lands in
+//! subsequent commits; this initial commit carries only the
+//! in-memory [`registry::Registry`] for the bucket-name/id mapping.
+//!
+//! The external `::redb` crate is referenced via absolute path
+//! (`::redb::Database`, `::redb::TableDefinition`, etc.) so the
+//! internal `redb` module name does not shadow it inside this tree.
+
+// Removed in the next commit, which consumes every item in
+// `registry`. Scoped to this module so nothing else in the crate
+// is silently allowed to accumulate dead code.
+#![allow(dead_code)]
+
+pub(crate) mod registry;

--- a/crates/mango-storage/src/redb/mod.rs
+++ b/crates/mango-storage/src/redb/mod.rs
@@ -23,10 +23,11 @@
 //!   `commit_group`: staged ops are grouped by `BucketId` (via a
 //!   `BTreeMap` — deterministic ordering is helpful for testing and
 //!   never hurts) so each redb `Table` is opened exactly once per
-//!   commit. redb's `WriteTransaction::open_table` uses an internal
-//!   `Mutex`; opening the same table twice in one txn is a panic, not
-//!   an error, so grouping is correctness-load-bearing, not just
-//!   performance.
+//!   commit. redb 4.x's `WriteTransaction::open_table` returns
+//!   `TableError::TableAlreadyOpen` (not a panic) when the same
+//!   table is opened twice in one txn; grouping is
+//!   correctness-load-bearing because the recovery path from that
+//!   error is uglier than pre-sorting the ops.
 //! - **Close** flips an `AtomicBool` via `compare_exchange`
 //!   (idempotent) and drops the `Database` handle by replacing the
 //!   `Option<Database>` with `None`. Subsequent methods see
@@ -61,6 +62,13 @@ pub(crate) mod snapshot;
 use batch::{RedbBatch, StagedOp};
 use registry::{physical_table_name, RegisterOutcome, Registry, REGISTRY_TABLE_NAME};
 use snapshot::RedbSnapshot;
+
+/// Map a `tokio::task::JoinError` into [`BackendError`]. Used by
+/// every `spawn_blocking`-based commit path; factored so the
+/// rendered message is identical across them.
+fn map_join_error(e: &tokio::task::JoinError) -> BackendError {
+    BackendError::Other(format!("spawn_blocking join: {e}"))
+}
 
 /// Name of the single redb file inside the user-supplied data
 /// directory. Kept as a constant rather than a config knob — the
@@ -172,6 +180,17 @@ fn map_database_error(e: ::redb::DatabaseError) -> BackendError {
         ::redb::DatabaseError::Storage(se) => map_storage_error(se),
         ::redb::DatabaseError::DatabaseAlreadyOpen => {
             BackendError::Other("database file already locked by another process".to_owned())
+        }
+        // The file's on-disk format is unreadable by this binary —
+        // either it was written by a newer redb, or its header is
+        // damaged. Callers routing on `Corruption` (operator alert,
+        // restore from snapshot, etc.) want to see this, not a
+        // generic `Other`.
+        ::redb::DatabaseError::UpgradeRequired(v) => {
+            BackendError::Corruption(format!("redb upgrade required (file format v{v})"))
+        }
+        ::redb::DatabaseError::RepairAborted => {
+            BackendError::Corruption("redb repair aborted by callback".to_owned())
         }
         other => BackendError::Other(format!("database error: {other}")),
     }
@@ -348,11 +367,16 @@ impl Backend for RedbBackend {
     fn register_bucket(&self, name: &str, id: BucketId) -> Result<(), BackendError> {
         self.inner.check_open()?;
 
-        // Hold the registry write-lock across the disk write so a
-        // concurrent caller cannot see the in-memory state update
-        // before the on-disk mirror lands.
+        // Two-phase: (1) `check_only` decides the outcome WITHOUT
+        // mutating the in-memory registry; (2) on `Inserted` we
+        // persist to disk; (3) only after the commit succeeds do we
+        // apply the in-memory insert. A failed commit therefore
+        // leaves the registry identical to the on-disk mirror — the
+        // backend remains usable after an `Err(Io)`. The write-lock
+        // is held across all three phases so a concurrent caller
+        // cannot observe the half-applied state.
         let mut reg = self.inner.registry.write();
-        match reg.check_and_insert(name, id)? {
+        match reg.check_only(name, id)? {
             RegisterOutcome::AlreadyRegistered => Ok(()),
             RegisterOutcome::Inserted => {
                 let db_guard = self.inner.db.read();
@@ -363,6 +387,7 @@ impl Backend for RedbBackend {
                     table.insert(name, id.raw).map_err(map_storage_error)?;
                 }
                 txn.commit().map_err(map_commit_error)?;
+                reg.force_insert(name.to_owned(), id);
                 Ok(())
             }
         }
@@ -405,7 +430,7 @@ impl Backend for RedbBackend {
                 commit_staged(&inner, staged)
             })
             .await
-            .map_err(|e| BackendError::Other(format!("spawn_blocking join: {e}")))?
+            .map_err(|e| map_join_error(&e))?
         }
     }
 
@@ -428,7 +453,7 @@ impl Backend for RedbBackend {
                 commit_staged(&inner, staged)
             })
             .await
-            .map_err(|e| BackendError::Other(format!("spawn_blocking join: {e}")))?
+            .map_err(|e| map_join_error(&e))?
         }
     }
 
@@ -442,6 +467,12 @@ impl Backend for RedbBackend {
         Ok(meta.len())
     }
 
+    // NOTE: `defragment` holds `Inner::db.write()` across the
+    // blocking `db.compact()` call. Every concurrent commit,
+    // snapshot, and register_bucket will block on that guard for
+    // the compact's duration (seconds → minutes on multi-GiB
+    // files). Acceptable for Phase 1; the Phase 6 operability
+    // bars will want online compaction that yields.
     fn defragment(&self) -> impl core::future::Future<Output = Result<(), BackendError>> + Send {
         let inner = Arc::clone(&self.inner);
         async move {
@@ -453,7 +484,7 @@ impl Backend for RedbBackend {
                 Ok(())
             })
             .await
-            .map_err(|e| BackendError::Other(format!("spawn_blocking join: {e}")))?
+            .map_err(|e| map_join_error(&e))?
         }
     }
 }

--- a/crates/mango-storage/src/redb/mod.rs
+++ b/crates/mango-storage/src/redb/mod.rs
@@ -1,16 +1,483 @@
 //! `redb`-backed [`crate::Backend`] impl (ROADMAP:817).
 //!
-//! Internal module root. The public surface of the impl lands in
-//! subsequent commits; this initial commit carries only the
-//! in-memory [`registry::Registry`] for the bucket-name/id mapping.
+//! # Design
 //!
-//! The external `::redb` crate is referenced via absolute path
-//! (`::redb::Database`, `::redb::TableDefinition`, etc.) so the
-//! internal `redb` module name does not shadow it inside this tree.
+//! The backend is a thin adapter on top of `::redb::Database`:
+//!
+//! - **State** lives in [`Inner`] behind `Arc<Inner>`; [`RedbBackend`]
+//!   is a handle that clones this `Arc`. This gives us `Send + Sync +
+//!   'static` for the whole handle, which is what the `Backend` trait
+//!   requires and what the `impl Future<..> + Send` commit methods
+//!   need.
+//! - **Durability** is always `Durability::Immediate` for now. The
+//!   `force_fsync` parameter on [`Backend::commit_batch`] is currently
+//!   unused; wiring `Durability::None` (or coalesced fsync) for the
+//!   `false` case is a ROADMAP:817 follow-up — the correctness bar is
+//!   "at least as strong as etcd" and always-fsync is strictly
+//!   stronger than the batch-tx model.
+//! - **Registry** lives in-memory as [`registry::Registry`] with a
+//!   mirror in the on-disk `__mango_bucket_registry` table. At open
+//!   time, we hydrate the in-memory view from disk; at
+//!   `register_bucket` time, we write through to disk.
+//! - **Write-path ordering** inside a single `commit_batch` /
+//!   `commit_group`: staged ops are grouped by `BucketId` (via a
+//!   `BTreeMap` — deterministic ordering is helpful for testing and
+//!   never hurts) so each redb `Table` is opened exactly once per
+//!   commit. redb's `WriteTransaction::open_table` uses an internal
+//!   `Mutex`; opening the same table twice in one txn is a panic, not
+//!   an error, so grouping is correctness-load-bearing, not just
+//!   performance.
+//! - **Close** flips an `AtomicBool` via `compare_exchange`
+//!   (idempotent) and drops the `Database` handle by replacing the
+//!   `Option<Database>` with `None`. Subsequent methods see
+//!   `closed = true` and return [`BackendError::Closed`] before
+//!   touching the option.
+//!
+//! # Send-ness of the write path
+//!
+//! [`RedbBatch`] is `!Send`; the trait contract in
+//! [`crate::WriteBatch`] permits this. The commit methods extract the
+//! staged `Vec<StagedOp>` synchronously (via `batch.into_staged()`)
+//! BEFORE constructing the `async` block, so the `!Send` marker never
+//! flows into the returned `Future`.
 
-// Removed in the next commit, which consumes every item in
-// `registry`. Scoped to this module so nothing else in the crate
-// is silently allowed to accumulate dead code.
-#![allow(dead_code)]
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 
+use parking_lot::RwLock;
+// Traits in scope for `Database::begin_read` and
+// `ReadOnlyTable::iter`/`get`/`range` — redb 4.1 hangs these on
+// `ReadableDatabase` / `ReadableTable` so the read-only and
+// read-write database types can share them.
+use ::redb::{ReadableDatabase, ReadableTable};
+
+use crate::backend::{Backend, BackendConfig, BackendError, BucketId, CommitStamp};
+
+pub(crate) mod batch;
 pub(crate) mod registry;
+pub(crate) mod snapshot;
+
+use batch::{RedbBatch, StagedOp};
+use registry::{physical_table_name, RegisterOutcome, Registry, REGISTRY_TABLE_NAME};
+use snapshot::RedbSnapshot;
+
+/// Name of the single redb file inside the user-supplied data
+/// directory. Kept as a constant rather than a config knob — the
+/// file layout is our implementation detail, not part of the public
+/// surface.
+const DB_FILENAME: &str = "mango.redb";
+
+/// Typed handle for the bucket-name ⇄ id table persisted on disk.
+/// `&str` keys are stable under redb's default UTF-8 encoding;
+/// `u16` values match [`BucketId::raw`].
+const REGISTRY_TABLE: ::redb::TableDefinition<'_, &str, u16> =
+    ::redb::TableDefinition::new(REGISTRY_TABLE_NAME);
+
+/// Shared state. Everything in the backend sits behind `Arc<Inner>`
+/// so clones of [`RedbBackend`], read snapshots, and `spawn_blocking`
+/// closures can all share the same state cheaply.
+#[derive(Debug)]
+pub(crate) struct Inner {
+    /// The redb `Database`. Wrapped in `Option` so `close` can
+    /// deterministically drop it (and release the file lock) without
+    /// needing unique ownership of the backend. `RwLock` because
+    /// [`::redb::Database::compact`] takes `&mut self`; every other
+    /// path takes a read guard.
+    db: RwLock<Option<::redb::Database>>,
+    /// Bucket-name ⇄ id registry. Mutated on `register_bucket`;
+    /// read-only on every other hot path.
+    pub(super) registry: RwLock<Registry>,
+    /// `true` once `close` has returned `Ok(())`. Checked via
+    /// `load(Acquire)` at the top of every public method so
+    /// in-flight operations see a single consistent "closed" cut.
+    closed: AtomicBool,
+    /// Monotonically non-decreasing commit sequence. `fetch_add(1,
+    /// Release)` on every successful commit — including empty
+    /// `commit_group` calls, so the returned [`CommitStamp`] is
+    /// *strictly* monotonic. `Release` (not `SeqCst`) is sufficient:
+    /// readers of a stamp only need to observe the effects of the
+    /// commit that produced it, and `Acquire` on the read side
+    /// completes the pair.
+    commit_seq: AtomicU64,
+    /// Filesystem path of the single redb file. Captured at open
+    /// time — redb 4.x does not expose its backing path through the
+    /// `Database` handle, so `size_on_disk` has to stat the file we
+    /// recorded ourselves.
+    db_path: PathBuf,
+}
+
+impl Inner {
+    /// Fail fast if the backend is closed. Centralized so every
+    /// public method gets the same ordering.
+    fn check_open(&self) -> Result<(), BackendError> {
+        if self.closed.load(Ordering::Acquire) {
+            Err(BackendError::Closed)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Translate [`::redb::StorageError`] into [`BackendError`]. The
+/// trait contract forbids leaking engine types (ADR 0002 §6 design
+/// point 1), so every redb error flows through a translator.
+pub(crate) fn map_storage_error(e: ::redb::StorageError) -> BackendError {
+    match e {
+        ::redb::StorageError::Io(err) => BackendError::Io(err),
+        ::redb::StorageError::Corrupted(msg) => BackendError::Corruption(msg),
+        ::redb::StorageError::ValueTooLarge(n) => {
+            BackendError::Other(format!("value too large ({n} bytes)"))
+        }
+        ::redb::StorageError::DatabaseClosed => BackendError::Closed,
+        ::redb::StorageError::PreviousIo => BackendError::Corruption(
+            "a prior I/O error left the database in an inconsistent state".to_owned(),
+        ),
+        ::redb::StorageError::LockPoisoned(loc) => {
+            BackendError::Other(format!("lock poisoned at {loc}"))
+        }
+        // `StorageError` is `#[non_exhaustive]`; render future
+        // variants as `Other` so a redb minor bump does not silently
+        // mis-classify a new failure mode.
+        other => BackendError::Other(format!("storage error: {other}")),
+    }
+}
+
+/// Translate [`::redb::TableError`]. Callers that handle
+/// `TableDoesNotExist` specifically (snapshot read path) peel it off
+/// before calling this; anything reaching here is propagated.
+pub(crate) fn map_table_error(e: ::redb::TableError) -> BackendError {
+    match e {
+        ::redb::TableError::Storage(se) => map_storage_error(se),
+        other => BackendError::Other(format!("table error: {other}")),
+    }
+}
+
+fn map_txn_error(e: ::redb::TransactionError) -> BackendError {
+    match e {
+        ::redb::TransactionError::Storage(se) => map_storage_error(se),
+        other => BackendError::Other(format!("transaction error: {other}")),
+    }
+}
+
+fn map_commit_error(e: ::redb::CommitError) -> BackendError {
+    match e {
+        ::redb::CommitError::Storage(se) => map_storage_error(se),
+        other => BackendError::Other(format!("commit error: {other}")),
+    }
+}
+
+fn map_database_error(e: ::redb::DatabaseError) -> BackendError {
+    match e {
+        ::redb::DatabaseError::Storage(se) => map_storage_error(se),
+        ::redb::DatabaseError::DatabaseAlreadyOpen => {
+            BackendError::Other("database file already locked by another process".to_owned())
+        }
+        other => BackendError::Other(format!("database error: {other}")),
+    }
+}
+
+fn map_compaction_error(e: ::redb::CompactionError) -> BackendError {
+    match e {
+        ::redb::CompactionError::Storage(se) => map_storage_error(se),
+        other => BackendError::Other(format!("compaction error: {other}")),
+    }
+}
+
+/// Read the on-disk registry table into `registry`. If the table
+/// does not exist, the registry is left empty (fresh database case).
+/// Duplicate names on disk are flagged as corruption — the writer
+/// path never produces them, so their presence indicates on-disk
+/// damage or a bug in an earlier version.
+fn hydrate_registry(db: &::redb::Database, registry: &mut Registry) -> Result<(), BackendError> {
+    let txn = db.begin_read().map_err(map_txn_error)?;
+    let table = match txn.open_table(REGISTRY_TABLE) {
+        Ok(t) => t,
+        Err(::redb::TableError::TableDoesNotExist(_)) => return Ok(()),
+        Err(e) => return Err(map_table_error(e)),
+    };
+    let iter = table.iter().map_err(map_storage_error)?;
+    for row in iter {
+        let (k, v) = row.map_err(map_storage_error)?;
+        let name = k.value().to_owned();
+        let id = BucketId::new(v.value());
+        if let Some(prior) = registry.force_insert(name.clone(), id) {
+            return Err(BackendError::Corruption(format!(
+                "registry table has duplicate entries for {name:?}: prior={prior:?}, current={id:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Extract the [`BucketId`] from any [`StagedOp`] variant. Keeps the
+/// bucket-validation loop readable.
+fn op_bucket(op: &StagedOp) -> BucketId {
+    match *op {
+        StagedOp::Put { bucket, .. }
+        | StagedOp::Delete { bucket, .. }
+        | StagedOp::DeleteRange { bucket, .. } => bucket,
+    }
+}
+
+/// Validate every op's bucket against the in-memory registry and
+/// pre-validate every `DeleteRange` op's bounds. Runs synchronously
+/// in the commit prologue so user errors surface *before* we pay
+/// for a write transaction.
+fn validate_ops(registry: &Registry, ops: &[StagedOp]) -> Result<(), BackendError> {
+    for op in ops {
+        let b = op_bucket(op);
+        if !registry.contains_id(b) {
+            return Err(BackendError::UnknownBucket(b));
+        }
+        if let StagedOp::DeleteRange { start, end, .. } = op {
+            if start > end {
+                return Err(BackendError::InvalidRange("start > end"));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Replay staged ops into an open [`::redb::WriteTransaction`].
+/// Groups by [`BucketId`] via `BTreeMap` so each redb `Table` is
+/// opened exactly once per commit — see the module doc for why this
+/// is correctness-load-bearing, not just a perf trick.
+fn apply_staged(txn: &::redb::WriteTransaction, ops: Vec<StagedOp>) -> Result<(), BackendError> {
+    use std::collections::BTreeMap;
+
+    let mut by_bucket: BTreeMap<u16, Vec<StagedOp>> = BTreeMap::new();
+    for op in ops {
+        by_bucket.entry(op_bucket(&op).raw).or_default().push(op);
+    }
+
+    for (raw, group) in by_bucket {
+        let name = physical_table_name(BucketId::new(raw));
+        let td: ::redb::TableDefinition<&[u8], &[u8]> = ::redb::TableDefinition::new(&name);
+        let mut table = txn.open_table(td).map_err(map_table_error)?;
+        for op in group {
+            match op {
+                StagedOp::Put { key, value, .. } => {
+                    table
+                        .insert(key.as_slice(), value.as_slice())
+                        .map_err(map_storage_error)?;
+                }
+                StagedOp::Delete { key, .. } => {
+                    table.remove(key.as_slice()).map_err(map_storage_error)?;
+                }
+                StagedOp::DeleteRange { start, end, .. } => {
+                    // `retain_in` keeps items for which the predicate
+                    // returns `true`; a constant-`false` predicate
+                    // deletes the whole half-open range in one pass.
+                    table
+                        .retain_in::<&[u8], _>(start.as_slice()..end.as_slice(), |_, _| false)
+                        .map_err(map_storage_error)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Flatten multiple batches' staged ops into one vector, consuming
+/// each batch. Order is preserved: `batches[0]`'s ops come first.
+/// The `Send`-ness of the returned `Vec` is what lets the `async`
+/// block in `commit_group` stay `Send`.
+fn flatten_batches(batches: Vec<RedbBatch>) -> Vec<StagedOp> {
+    let mut out = Vec::new();
+    for b in batches {
+        out.extend(b.into_staged());
+    }
+    out
+}
+
+/// The public handle. Cheap to clone (just an `Arc` bump).
+#[derive(Debug, Clone)]
+pub struct RedbBackend {
+    inner: Arc<Inner>,
+}
+
+impl Backend for RedbBackend {
+    type Snapshot = RedbSnapshot;
+    type Batch = RedbBatch;
+
+    fn open(config: BackendConfig) -> Result<Self, BackendError> {
+        if config.read_only {
+            return Err(BackendError::Other(
+                "read-only not yet supported; see ROADMAP:817 follow-up".to_owned(),
+            ));
+        }
+        std::fs::create_dir_all(&config.data_dir).map_err(BackendError::Io)?;
+        let db_path: PathBuf = config.data_dir.join(DB_FILENAME);
+        let db = ::redb::Database::create(&db_path).map_err(map_database_error)?;
+
+        let mut registry = Registry::default();
+        hydrate_registry(&db, &mut registry)?;
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                db: RwLock::new(Some(db)),
+                registry: RwLock::new(registry),
+                closed: AtomicBool::new(false),
+                commit_seq: AtomicU64::new(0),
+                db_path,
+            }),
+        })
+    }
+
+    fn close(&self) -> Result<(), BackendError> {
+        // `compare_exchange` rather than `swap`: we only want to run
+        // the drop once, even under concurrent `close` calls. The
+        // subsequent `Ok(())` return from repeat callers is the
+        // trait's idempotence contract.
+        if self
+            .inner
+            .closed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            // Drop the database handle, releasing the file lock.
+            // Any in-flight write-txn references will already have
+            // been dropped — `Database::drop` blocks otherwise.
+            let mut guard = self.inner.db.write();
+            *guard = None;
+        }
+        Ok(())
+    }
+
+    fn register_bucket(&self, name: &str, id: BucketId) -> Result<(), BackendError> {
+        self.inner.check_open()?;
+
+        // Hold the registry write-lock across the disk write so a
+        // concurrent caller cannot see the in-memory state update
+        // before the on-disk mirror lands.
+        let mut reg = self.inner.registry.write();
+        match reg.check_and_insert(name, id)? {
+            RegisterOutcome::AlreadyRegistered => Ok(()),
+            RegisterOutcome::Inserted => {
+                let db_guard = self.inner.db.read();
+                let db = db_guard.as_ref().ok_or(BackendError::Closed)?;
+                let txn = db.begin_write().map_err(map_txn_error)?;
+                {
+                    let mut table = txn.open_table(REGISTRY_TABLE).map_err(map_table_error)?;
+                    table.insert(name, id.raw).map_err(map_storage_error)?;
+                }
+                txn.commit().map_err(map_commit_error)?;
+                Ok(())
+            }
+        }
+    }
+
+    fn snapshot(&self) -> Result<Self::Snapshot, BackendError> {
+        self.inner.check_open()?;
+        let db_guard = self.inner.db.read();
+        let db = db_guard.as_ref().ok_or(BackendError::Closed)?;
+        let txn = db.begin_read().map_err(map_txn_error)?;
+        Ok(RedbSnapshot::new(txn, Arc::clone(&self.inner)))
+    }
+
+    fn begin_batch(&self) -> Result<Self::Batch, BackendError> {
+        self.inner.check_open()?;
+        Ok(RedbBatch::new())
+    }
+
+    fn commit_batch(
+        &self,
+        batch: Self::Batch,
+        force_fsync: bool,
+    ) -> impl core::future::Future<Output = Result<CommitStamp, BackendError>> + Send {
+        // Sync prologue: extract staged ops, validate bucket ids and
+        // ranges. Doing this BEFORE the async block keeps the `!Send`
+        // `RedbBatch` off the future's capture set.
+        let prologue: Result<Vec<StagedOp>, BackendError> = (|| {
+            self.inner.check_open()?;
+            let staged = batch.into_staged();
+            let reg = self.inner.registry.read();
+            validate_ops(&reg, &staged)?;
+            Ok(staged)
+        })();
+        let inner = Arc::clone(&self.inner);
+        let _ = force_fsync; // reserved — see module doc
+
+        async move {
+            let staged = prologue?;
+            tokio::task::spawn_blocking(move || -> Result<CommitStamp, BackendError> {
+                commit_staged(&inner, staged)
+            })
+            .await
+            .map_err(|e| BackendError::Other(format!("spawn_blocking join: {e}")))?
+        }
+    }
+
+    fn commit_group(
+        &self,
+        batches: Vec<Self::Batch>,
+    ) -> impl core::future::Future<Output = Result<CommitStamp, BackendError>> + Send {
+        let prologue: Result<Vec<StagedOp>, BackendError> = (|| {
+            self.inner.check_open()?;
+            let merged = flatten_batches(batches);
+            let reg = self.inner.registry.read();
+            validate_ops(&reg, &merged)?;
+            Ok(merged)
+        })();
+        let inner = Arc::clone(&self.inner);
+
+        async move {
+            let staged = prologue?;
+            tokio::task::spawn_blocking(move || -> Result<CommitStamp, BackendError> {
+                commit_staged(&inner, staged)
+            })
+            .await
+            .map_err(|e| BackendError::Other(format!("spawn_blocking join: {e}")))?
+        }
+    }
+
+    fn size_on_disk(&self) -> Result<u64, BackendError> {
+        self.inner.check_open()?;
+        // redb 4.x does not expose a size accessor on the Database
+        // handle, so we stat the file we recorded at open time.
+        // Advisory only per the trait contract — the value may lag
+        // an uncommitted in-flight write-txn.
+        let meta = std::fs::metadata(&self.inner.db_path).map_err(BackendError::Io)?;
+        Ok(meta.len())
+    }
+
+    fn defragment(&self) -> impl core::future::Future<Output = Result<(), BackendError>> + Send {
+        let inner = Arc::clone(&self.inner);
+        async move {
+            tokio::task::spawn_blocking(move || -> Result<(), BackendError> {
+                inner.check_open()?;
+                let mut guard = inner.db.write();
+                let db = guard.as_mut().ok_or(BackendError::Closed)?;
+                db.compact().map_err(map_compaction_error)?;
+                Ok(())
+            })
+            .await
+            .map_err(|e| BackendError::Other(format!("spawn_blocking join: {e}")))?
+        }
+    }
+}
+
+/// The work performed inside `spawn_blocking` for both
+/// `commit_batch` and `commit_group`. Opens a write transaction,
+/// replays staged ops, sets `Immediate` durability, commits, and
+/// bumps the commit sequence. Runs on a blocking thread because
+/// `WriteTransaction::commit` calls `fsync` synchronously and we
+/// MUST NOT block a tokio worker.
+fn commit_staged(inner: &Inner, staged: Vec<StagedOp>) -> Result<CommitStamp, BackendError> {
+    inner.check_open()?;
+    let guard = inner.db.read();
+    let db = guard.as_ref().ok_or(BackendError::Closed)?;
+    let mut txn = db.begin_write().map_err(map_txn_error)?;
+    txn.set_durability(::redb::Durability::Immediate)
+        .map_err(|e| BackendError::Other(format!("set_durability: {e}")))?;
+    apply_staged(&txn, staged)?;
+    txn.commit().map_err(map_commit_error)?;
+    drop(guard);
+    // Strictly monotonic. `Release` pairs with callers that observe
+    // the stamp and then `Acquire`-read the committed state.
+    let prev = inner.commit_seq.fetch_add(1, Ordering::Release);
+    Ok(CommitStamp::new(prev.checked_add(1).ok_or_else(|| {
+        BackendError::Other("commit_seq overflow".to_owned())
+    })?))
+}

--- a/crates/mango-storage/src/redb/registry.rs
+++ b/crates/mango-storage/src/redb/registry.rs
@@ -32,7 +32,7 @@ pub(crate) fn physical_table_name(id: BucketId) -> String {
     format!("bucket_{:04x}", id.raw)
 }
 
-/// Outcome of [`Registry::check_and_insert`]. Distinguishes
+/// Outcome of [`Registry::check_only`]. Distinguishes
 /// idempotent re-registration (no disk write required) from a
 /// genuine insert (caller must persist).
 #[derive(Debug, PartialEq, Eq)]
@@ -66,8 +66,16 @@ impl Registry {
     /// const table). Ordering is documented rather than load-
     /// bearing; a caller that exercises both simultaneously gets
     /// one of the two variants deterministically.
-    pub(crate) fn check_and_insert(
-        &mut self,
+    ///
+    /// Read-only: does NOT mutate the registry. The caller is
+    /// responsible for persisting the new row to the on-disk
+    /// mirror AND then applying the in-memory insert via
+    /// [`Registry::force_insert`]. This two-phase split lets the
+    /// backend roll back the in-memory state when the on-disk
+    /// commit fails (otherwise the registry would diverge from the
+    /// file on I/O errors).
+    pub(crate) fn check_only(
+        &self,
         name: &str,
         id: BucketId,
     ) -> Result<RegisterOutcome, BackendError> {
@@ -88,8 +96,6 @@ impl Registry {
                 requested_id: id,
             });
         }
-        self.by_name.insert(name.to_owned(), id);
-        self.by_id.insert(id.raw, name.to_owned());
         Ok(RegisterOutcome::Inserted)
     }
 
@@ -165,27 +171,57 @@ mod tests {
         assert!(!r.contains_id(BucketId::new(42)));
     }
 
+    /// Helper: the old `check_and_insert` semantic, expressed in
+    /// terms of the new two-phase split. Preserves the existing
+    /// unit-test shape.
+    fn check_and_insert(
+        r: &mut Registry,
+        name: &str,
+        id: BucketId,
+    ) -> Result<RegisterOutcome, BackendError> {
+        match r.check_only(name, id)? {
+            RegisterOutcome::AlreadyRegistered => Ok(RegisterOutcome::AlreadyRegistered),
+            RegisterOutcome::Inserted => {
+                r.force_insert(name.to_owned(), id);
+                Ok(RegisterOutcome::Inserted)
+            }
+        }
+    }
+
     #[test]
     fn insert_is_inserted_then_already_registered() {
         let mut r = Registry::default();
         assert_eq!(
-            r.check_and_insert("kv", BucketId::new(1)).unwrap(),
+            check_and_insert(&mut r, "kv", BucketId::new(1)).unwrap(),
             RegisterOutcome::Inserted
         );
         assert_eq!(r.len(), 1);
         assert!(r.contains_id(BucketId::new(1)));
         assert_eq!(
-            r.check_and_insert("kv", BucketId::new(1)).unwrap(),
+            check_and_insert(&mut r, "kv", BucketId::new(1)).unwrap(),
             RegisterOutcome::AlreadyRegistered
         );
         assert_eq!(r.len(), 1);
     }
 
     #[test]
+    fn check_only_does_not_mutate_on_inserted_outcome() {
+        // Load-bearing for the commit-failure rollback story in
+        // `register_bucket`: if `check_only` returned `Inserted`
+        // but also mutated, a failing on-disk commit would leave
+        // the in-memory registry ahead of the file.
+        let r = Registry::default();
+        let outcome = r.check_only("kv", BucketId::new(1)).unwrap();
+        assert_eq!(outcome, RegisterOutcome::Inserted);
+        assert_eq!(r.len(), 0);
+        assert!(!r.contains_id(BucketId::new(1)));
+    }
+
+    #[test]
     fn id_rebind_returns_bucket_conflict() {
         let mut r = Registry::default();
-        r.check_and_insert("kv", BucketId::new(1)).unwrap();
-        match r.check_and_insert("meta", BucketId::new(1)) {
+        check_and_insert(&mut r, "kv", BucketId::new(1)).unwrap();
+        match check_and_insert(&mut r, "meta", BucketId::new(1)) {
             Err(BackendError::BucketConflict {
                 id,
                 existing,
@@ -202,8 +238,8 @@ mod tests {
     #[test]
     fn name_rebind_returns_bucket_name_conflict() {
         let mut r = Registry::default();
-        r.check_and_insert("kv", BucketId::new(1)).unwrap();
-        match r.check_and_insert("kv", BucketId::new(2)) {
+        check_and_insert(&mut r, "kv", BucketId::new(1)).unwrap();
+        match check_and_insert(&mut r, "kv", BucketId::new(2)) {
             Err(BackendError::BucketNameConflict {
                 name,
                 existing_id,
@@ -224,9 +260,9 @@ mod tests {
         // name ("a" → 1) are rebind conflicts; the registry
         // documents that id-rebind wins.
         let mut r = Registry::default();
-        r.check_and_insert("a", BucketId::new(1)).unwrap();
-        r.check_and_insert("b", BucketId::new(2)).unwrap();
-        match r.check_and_insert("a", BucketId::new(2)) {
+        check_and_insert(&mut r, "a", BucketId::new(1)).unwrap();
+        check_and_insert(&mut r, "b", BucketId::new(2)).unwrap();
+        match check_and_insert(&mut r, "a", BucketId::new(2)) {
             Err(BackendError::BucketConflict { existing, .. }) => {
                 assert_eq!(existing, "b");
             }

--- a/crates/mango-storage/src/redb/registry.rs
+++ b/crates/mango-storage/src/redb/registry.rs
@@ -1,0 +1,249 @@
+//! Bucket-name ⇄ [`BucketId`] registry for the redb backend.
+//!
+//! The registry is the single source of truth for bucket naming at
+//! runtime. Persistence to disk is handled by the outer backend
+//! (`super::backend` lands in a later commit in this PR); this
+//! module owns only the in-memory structure and the conflict-
+//! resolution logic.
+//!
+//! Physical table names inside redb are derived from [`BucketId`]
+//! via [`physical_table_name`] — user-supplied bucket names never
+//! flow into redb's namespace, so (a) user-facing names can use
+//! any byte sequence we later choose to allow without coupling to
+//! redb's identifier rules, and (b) the registry's own metadata
+//! table cannot collide with a user-named bucket.
+
+use std::collections::HashMap;
+
+use crate::backend::{BackendError, BucketId};
+
+/// The name of the redb table the registry is persisted to. The
+/// `__mango_` prefix is reserved for internal mango tables;
+/// [`physical_table_name`] never emits a name with that prefix, so
+/// no collision is possible.
+pub(crate) const REGISTRY_TABLE_NAME: &str = "__mango_bucket_registry";
+
+/// Compute the redb table name that a [`BucketId`] maps to. Hex-
+/// encoded so the table listing is sorted by id and the encoding
+/// is unambiguous (decimal `10` would collide visually with the
+/// 2-digit range `1..=10`; hex does not).
+#[must_use]
+pub(crate) fn physical_table_name(id: BucketId) -> String {
+    format!("bucket_{:04x}", id.raw)
+}
+
+/// Outcome of [`Registry::check_and_insert`]. Distinguishes
+/// idempotent re-registration (no disk write required) from a
+/// genuine insert (caller must persist).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RegisterOutcome {
+    /// The `(name, id)` pair was already present. Caller skips
+    /// the registry-table write.
+    AlreadyRegistered,
+    /// The pair is newly inserted into the in-memory view. Caller
+    /// MUST persist it to the registry table before returning
+    /// success to the user.
+    Inserted,
+}
+
+/// In-memory registry. Construct empty with [`Registry::default`];
+/// populate on backend open by reading the registry table.
+#[derive(Debug, Default)]
+pub(crate) struct Registry {
+    by_name: HashMap<String, BucketId>,
+    by_id: HashMap<u16, String>,
+}
+
+impl Registry {
+    /// Try to register `(name, id)`. On conflict, returns the
+    /// appropriate [`BackendError`] variant:
+    ///
+    /// - id already bound to a different name → [`BackendError::BucketConflict`]
+    /// - name already bound to a different id → [`BackendError::BucketNameConflict`]
+    ///
+    /// The id case is checked first because it is the more
+    /// common operator mistake (wiring a duplicate id from a
+    /// const table). Ordering is documented rather than load-
+    /// bearing; a caller that exercises both simultaneously gets
+    /// one of the two variants deterministically.
+    pub(crate) fn check_and_insert(
+        &mut self,
+        name: &str,
+        id: BucketId,
+    ) -> Result<RegisterOutcome, BackendError> {
+        if let Some(existing_name) = self.by_id.get(&id.raw) {
+            if existing_name == name {
+                return Ok(RegisterOutcome::AlreadyRegistered);
+            }
+            return Err(BackendError::BucketConflict {
+                id,
+                existing: existing_name.clone(),
+                requested: name.to_owned(),
+            });
+        }
+        if let Some(existing_id) = self.by_name.get(name) {
+            return Err(BackendError::BucketNameConflict {
+                name: name.to_owned(),
+                existing_id: *existing_id,
+                requested_id: id,
+            });
+        }
+        self.by_name.insert(name.to_owned(), id);
+        self.by_id.insert(id.raw, name.to_owned());
+        Ok(RegisterOutcome::Inserted)
+    }
+
+    /// Insert a `(name, id)` pair unconditionally. Used by the
+    /// open-time hydration path where the on-disk registry table
+    /// is the authoritative source — conflicts there imply
+    /// corruption, not user error.
+    ///
+    /// Returns the previous id for this name if any (used by the
+    /// hydration caller to flag unexpected duplicates as
+    /// corruption).
+    pub(crate) fn force_insert(&mut self, name: String, id: BucketId) -> Option<BucketId> {
+        let prior = self.by_name.insert(name.clone(), id);
+        self.by_id.insert(id.raw, name);
+        prior
+    }
+
+    /// Whether `id` is currently registered. Used by write paths
+    /// to reject puts/deletes against unregistered buckets before
+    /// opening a redb transaction.
+    #[must_use]
+    pub(crate) fn contains_id(&self, id: BucketId) -> bool {
+        self.by_id.contains_key(&id.raw)
+    }
+
+    /// Number of registered buckets. Test-only observability.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.by_id.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing
+    )]
+
+    use super::*;
+
+    #[test]
+    fn physical_table_name_is_hex_four_wide() {
+        assert_eq!(physical_table_name(BucketId::new(0)), "bucket_0000");
+        assert_eq!(physical_table_name(BucketId::new(1)), "bucket_0001");
+        assert_eq!(physical_table_name(BucketId::new(0x10)), "bucket_0010");
+        assert_eq!(physical_table_name(BucketId::new(0xFFFF)), "bucket_ffff");
+    }
+
+    #[test]
+    fn physical_table_name_cannot_collide_with_registry_table() {
+        // The registry table uses a reserved prefix that
+        // `physical_table_name` never emits. This is load-bearing:
+        // if the encoding ever changes to include `__mango_`, the
+        // registry would self-collide.
+        for raw in [0u16, 1, 0x1000, 0xFFFF] {
+            let n = physical_table_name(BucketId::new(raw));
+            assert!(
+                !n.starts_with("__mango_"),
+                "physical name {n:?} leaks into reserved prefix"
+            );
+        }
+        assert!(REGISTRY_TABLE_NAME.starts_with("__mango_"));
+    }
+
+    #[test]
+    fn empty_registry_contains_nothing() {
+        let r = Registry::default();
+        assert_eq!(r.len(), 0);
+        assert!(!r.contains_id(BucketId::new(0)));
+        assert!(!r.contains_id(BucketId::new(42)));
+    }
+
+    #[test]
+    fn insert_is_inserted_then_already_registered() {
+        let mut r = Registry::default();
+        assert_eq!(
+            r.check_and_insert("kv", BucketId::new(1)).unwrap(),
+            RegisterOutcome::Inserted
+        );
+        assert_eq!(r.len(), 1);
+        assert!(r.contains_id(BucketId::new(1)));
+        assert_eq!(
+            r.check_and_insert("kv", BucketId::new(1)).unwrap(),
+            RegisterOutcome::AlreadyRegistered
+        );
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn id_rebind_returns_bucket_conflict() {
+        let mut r = Registry::default();
+        r.check_and_insert("kv", BucketId::new(1)).unwrap();
+        match r.check_and_insert("meta", BucketId::new(1)) {
+            Err(BackendError::BucketConflict {
+                id,
+                existing,
+                requested,
+            }) => {
+                assert_eq!(id, BucketId::new(1));
+                assert_eq!(existing, "kv");
+                assert_eq!(requested, "meta");
+            }
+            other => panic!("expected BucketConflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn name_rebind_returns_bucket_name_conflict() {
+        let mut r = Registry::default();
+        r.check_and_insert("kv", BucketId::new(1)).unwrap();
+        match r.check_and_insert("kv", BucketId::new(2)) {
+            Err(BackendError::BucketNameConflict {
+                name,
+                existing_id,
+                requested_id,
+            }) => {
+                assert_eq!(name, "kv");
+                assert_eq!(existing_id, BucketId::new(1));
+                assert_eq!(requested_id, BucketId::new(2));
+            }
+            other => panic!("expected BucketNameConflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn id_conflict_checked_before_name_conflict() {
+        // Two separate pre-existing rows: ("a", 1) and ("b", 2).
+        // Then attempt ("a", 2). Both the id (2 → "b") and the
+        // name ("a" → 1) are rebind conflicts; the registry
+        // documents that id-rebind wins.
+        let mut r = Registry::default();
+        r.check_and_insert("a", BucketId::new(1)).unwrap();
+        r.check_and_insert("b", BucketId::new(2)).unwrap();
+        match r.check_and_insert("a", BucketId::new(2)) {
+            Err(BackendError::BucketConflict { existing, .. }) => {
+                assert_eq!(existing, "b");
+            }
+            other => panic!("expected BucketConflict (id-rebind priority), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn force_insert_returns_prior_id() {
+        let mut r = Registry::default();
+        assert!(r.force_insert("kv".into(), BucketId::new(1)).is_none());
+        assert!(r.contains_id(BucketId::new(1)));
+        // Simulate a (buggy or corrupt) second row for the same
+        // name with a different id. Caller flags this as
+        // corruption; the helper reports the displaced id.
+        let prior = r.force_insert("kv".into(), BucketId::new(5));
+        assert_eq!(prior, Some(BucketId::new(1)));
+        assert!(r.contains_id(BucketId::new(5)));
+    }
+}

--- a/crates/mango-storage/src/redb/snapshot.rs
+++ b/crates/mango-storage/src/redb/snapshot.rs
@@ -1,0 +1,137 @@
+//! [`ReadSnapshot`] impl for the redb backend.
+//!
+//! A [`RedbSnapshot`] wraps a `redb::ReadTransaction` plus a shared
+//! handle back to the backend's state (for registry lookups). Read
+//! transactions in redb 4.x are `'static` and `Send + Sync` (see
+//! `redb-4.1.0/src/transactions.rs` for the `ReadTransaction`
+//! declaration); snapshots can therefore move freely across tasks
+//! and outlive the method that produced them.
+//!
+//! Snapshot isolation is redb's guarantee: a `ReadTransaction`
+//! observes the database state as of the moment `begin_read()`
+//! returned, regardless of subsequent commits. Our snapshot does
+//! not need to snapshot the in-memory registry alongside — the
+//! registry only *grows* (bucket ids are never unregistered), so
+//! a read that observes a post-snapshot bucket id against a
+//! pre-snapshot data state correctly returns `None` (the key does
+//! not exist in the snapshot's cut).
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use crate::backend::{BackendError, BucketId, RangeIter, ReadSnapshot};
+use crate::redb::registry::physical_table_name;
+use crate::redb::{map_storage_error, map_table_error, Inner};
+
+/// Point-in-time read snapshot. Produced by
+/// [`crate::Backend::snapshot`]. See [`ReadSnapshot`] for the
+/// contract.
+#[derive(Debug)]
+pub struct RedbSnapshot {
+    txn: ::redb::ReadTransaction,
+    inner: Arc<Inner>,
+}
+
+impl RedbSnapshot {
+    pub(super) fn new(txn: ::redb::ReadTransaction, inner: Arc<Inner>) -> Self {
+        Self { txn, inner }
+    }
+}
+
+impl ReadSnapshot for RedbSnapshot {
+    fn get(&self, bucket: BucketId, key: &[u8]) -> Result<Option<Bytes>, BackendError> {
+        if !self.inner.registry.read().contains_id(bucket) {
+            return Err(BackendError::UnknownBucket(bucket));
+        }
+        let name = physical_table_name(bucket);
+        let td: ::redb::TableDefinition<&[u8], &[u8]> = ::redb::TableDefinition::new(&name);
+        let table = match self.txn.open_table(td) {
+            Ok(t) => t,
+            // A bucket registered in the registry but absent from
+            // redb means no write ever hit it — that's not an
+            // error, it's "no data yet". Return None to match.
+            Err(::redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(map_table_error(e)),
+        };
+        match table.get(key).map_err(map_storage_error)? {
+            Some(v) => Ok(Some(Bytes::copy_from_slice(v.value()))),
+            None => Ok(None),
+        }
+    }
+
+    fn range<'a>(
+        &'a self,
+        bucket: BucketId,
+        start: &'a [u8],
+        end: &'a [u8],
+    ) -> Result<Box<dyn RangeIter<'a> + 'a>, BackendError> {
+        if start > end {
+            return Err(BackendError::InvalidRange("start > end"));
+        }
+        if !self.inner.registry.read().contains_id(bucket) {
+            return Err(BackendError::UnknownBucket(bucket));
+        }
+        let name = physical_table_name(bucket);
+        let td: ::redb::TableDefinition<&[u8], &[u8]> = ::redb::TableDefinition::new(&name);
+        let table = match self.txn.open_table(td) {
+            Ok(t) => t,
+            // No writes have landed into this bucket yet. Return an
+            // empty iterator rather than erroring — this matches
+            // the `get`-on-empty-bucket semantics above.
+            Err(::redb::TableError::TableDoesNotExist(_)) => {
+                return Ok(Box::new(EmptyRangeIter));
+            }
+            Err(e) => return Err(map_table_error(e)),
+        };
+        let iter = table
+            .range::<&[u8]>(start..end)
+            .map_err(map_storage_error)?;
+        Ok(Box::new(RedbRangeIter { inner: iter }))
+    }
+}
+
+/// Iterator adapter wrapping `redb::Range`. The `redb::Range` type
+/// itself is `'static` in 4.x (see the `ReadOnlyTable::range`
+/// signature at `redb-4.1.0/src/table.rs:508-515`), so this struct
+/// has no self-referential lifetime concern: the range holds its
+/// own `Arc<TransactionGuard>` internally, keeping the snapshot
+/// alive.
+struct RedbRangeIter {
+    inner: ::redb::Range<'static, &'static [u8], &'static [u8]>,
+}
+
+impl Iterator for RedbRangeIter {
+    type Item = Result<(Bytes, Bytes), BackendError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner.next()? {
+            Ok((k, v)) => {
+                let kb = Bytes::copy_from_slice(k.value());
+                let vb = Bytes::copy_from_slice(v.value());
+                Some(Ok((kb, vb)))
+            }
+            Err(e) => Some(Err(map_storage_error(e))),
+        }
+    }
+}
+
+// Lifetime `'a` is unused by our concrete type (nothing borrows
+// from the snapshot); the trait requires it for the `dyn` trait
+// object but we satisfy it for any `'a` by not capturing anything.
+impl RangeIter<'_> for RedbRangeIter {}
+
+/// Iterator that yields nothing. Used when the requested bucket
+/// is registered but no writes have created the underlying redb
+/// table yet.
+struct EmptyRangeIter;
+
+impl Iterator for EmptyRangeIter {
+    type Item = Result<(Bytes, Bytes), BackendError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+impl RangeIter<'_> for EmptyRangeIter {}

--- a/crates/mango-storage/src/redb/snapshot.rs
+++ b/crates/mango-storage/src/redb/snapshot.rs
@@ -119,6 +119,7 @@ impl Iterator for RedbRangeIter {
 // Lifetime `'a` is unused by our concrete type (nothing borrows
 // from the snapshot); the trait requires it for the `dyn` trait
 // object but we satisfy it for any `'a` by not capturing anything.
+// The same reasoning applies to `EmptyRangeIter` below.
 impl RangeIter<'_> for RedbRangeIter {}
 
 /// Iterator that yields nothing. Used when the requested bucket

--- a/crates/mango-storage/tests/madsim_smoke.rs
+++ b/crates/mango-storage/tests/madsim_smoke.rs
@@ -1,0 +1,45 @@
+//! Sim-only smoke test — compiled and executed only under
+//! `RUSTFLAGS="--cfg madsim"`, a no-op otherwise.
+//!
+//! Scope: proves that `mango-storage` *compiles* against the
+//! simulator's `tokio` substitute (madsim-tokio) and that the
+//! synchronous registry path runs deterministically inside a
+//! `#[madsim::test]` runtime. We intentionally do NOT drive the
+//! async commit path here — madsim's runtime does not substitute
+//! `std::fs` or the memory-mapped I/O redb uses, and the real
+//! commit path runs `tokio::task::spawn_blocking` which madsim-
+//! tokio implements as a plain-thread shim. The full redb
+//! semantics are covered by `tests/redb_backend.rs` under the
+//! default (non-madsim) build.
+
+#![cfg(madsim)]
+
+use mango_storage::{Backend, BackendConfig, BucketId, RedbBackend};
+use tempfile::TempDir;
+
+const KV: BucketId = BucketId::new(1);
+
+#[madsim::test]
+async fn open_register_close_roundtrips_under_madsim() {
+    let tmp = TempDir::new().expect("tempdir");
+    let b = RedbBackend::open(BackendConfig::new(tmp.path().to_path_buf(), false)).expect("open");
+    b.register_bucket("kv", KV).expect("register_bucket");
+    assert!(b.size_on_disk().expect("size_on_disk") > 0);
+    b.close().expect("close");
+    // Re-opening must see the registered bucket — proves hydration
+    // still works under the simulator's deterministic scheduler.
+    let b2 =
+        RedbBackend::open(BackendConfig::new(tmp.path().to_path_buf(), false)).expect("reopen");
+    // Idempotent re-registration succeeds; name-rebinding to a fresh
+    // id fails with `BucketNameConflict`, proving the registry was
+    // hydrated from disk.
+    b2.register_bucket("kv", KV).expect("idempotent");
+    let err = b2
+        .register_bucket("kv", BucketId::new(99))
+        .expect_err("name conflict");
+    assert!(matches!(
+        err,
+        mango_storage::BackendError::BucketNameConflict { .. }
+    ));
+    b2.close().expect("close");
+}

--- a/crates/mango-storage/tests/redb_backend.rs
+++ b/crates/mango-storage/tests/redb_backend.rs
@@ -37,7 +37,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use mango_storage::{
-    Backend, BackendConfig, BackendError, BucketId, ReadSnapshot, RedbBackend, WriteBatch,
+    Backend, BackendConfig, BackendError, BucketId, CommitStamp, ReadSnapshot, RedbBackend,
+    WriteBatch,
 };
 use tempfile::TempDir;
 
@@ -410,6 +411,33 @@ async fn commit_group_partial_failure_aborts_whole_group() {
     assert_eq!(get(&b, KV, b"k"), None);
 }
 
+#[tokio::test]
+async fn failed_commit_does_not_bump_commit_seq() {
+    // Documented contract: `CommitStamp` is strictly monotonic across
+    // *successful* commits. A commit that aborts in the sync prologue
+    // (here: UnknownBucket) MUST NOT bump the sequence, otherwise
+    // callers observing stamps would see gaps that don't correspond
+    // to real commits. Observed indirectly: the next successful
+    // commit must return stamp #1 (not #2).
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    let mut bad = b.begin_batch().unwrap();
+    bad.put(META, b"k", b"v").unwrap(); // META unregistered
+    assert!(matches!(
+        b.commit_batch(bad, true).await,
+        Err(BackendError::UnknownBucket(_))
+    ));
+    let mut good = b.begin_batch().unwrap();
+    good.put(KV, b"k", b"v").unwrap();
+    let stamp = b.commit_batch(good, true).await.unwrap();
+    assert_eq!(
+        stamp,
+        CommitStamp::new(1),
+        "failed commit bumped commit_seq",
+    );
+}
+
 // ---------- utility --------------------------------------------------
 
 #[tokio::test]
@@ -436,6 +464,14 @@ async fn size_on_disk_grows_after_writes() {
     let _ = b.commit_batch(batch, true).await.unwrap();
     let s1 = b.size_on_disk().unwrap();
     assert!(s1 > s0, "size did not grow: {s0} -> {s1}");
+}
+
+#[tokio::test]
+async fn defragment_on_closed_backend_returns_closed() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.close().unwrap();
+    assert!(matches!(b.defragment().await, Err(BackendError::Closed)));
 }
 
 #[tokio::test]

--- a/crates/mango-storage/tests/redb_backend.rs
+++ b/crates/mango-storage/tests/redb_backend.rs
@@ -1,0 +1,542 @@
+//! Integration tests for [`mango_storage::RedbBackend`] (ROADMAP:817).
+//!
+//! Every test opens a real `redb` database in a `tempfile::TempDir` —
+//! the `TempDir` drops at the end of the test, cleaning up the file.
+//! Tests are organized by behavior surface:
+//!
+//! - lifecycle: open / close / reopen / closed-errors
+//! - registry: `register_bucket` idempotence and conflict paths
+//! - write path: put / delete / `delete_range` round-trips
+//! - read path: snapshot isolation, unknown-bucket, invalid-range
+//! - commit semantics: group atomicity, stamp monotonicity
+//! - utility: `size_on_disk`, defragment, read-only open
+//! - persistence: registry survives reopen
+//! - cross-cutting: mini-oracle against `BTreeMap<Vec<u8>, Vec<u8>>`
+//!
+//! The tests deliberately exercise the `Backend` trait through the
+//! `mango_storage::Backend` import, so the trait contract is what is
+//! verified — not just the impl.
+//!
+//! Under `--cfg madsim` this file is excluded — madsim-tokio does not
+//! expose the multi-thread runtime we use in the concurrency test, and
+//! exercising redb's real mmap+fsync under the simulator's virtual
+//! time would be a category error. The dedicated madsim smoke test
+//! lives in `madsim_backend_smoke.rs`.
+
+#![cfg(not(madsim))]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_truncation
+)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use mango_storage::{
+    Backend, BackendConfig, BackendError, BucketId, ReadSnapshot, RedbBackend, WriteBatch,
+};
+use tempfile::TempDir;
+
+const KV: BucketId = BucketId::new(1);
+const META: BucketId = BucketId::new(2);
+
+fn open(dir: &TempDir) -> RedbBackend {
+    RedbBackend::open(BackendConfig::new(dir.path().to_path_buf(), false)).expect("open")
+}
+
+async fn put(b: &RedbBackend, bucket: BucketId, k: &[u8], v: &[u8]) {
+    let mut batch = b.begin_batch().expect("begin_batch");
+    batch.put(bucket, k, v).expect("put");
+    let _ = b.commit_batch(batch, true).await.expect("commit");
+}
+
+fn get(b: &RedbBackend, bucket: BucketId, k: &[u8]) -> Option<Vec<u8>> {
+    let snap = b.snapshot().expect("snapshot");
+    snap.get(bucket, k)
+        .expect("get")
+        .map(|bytes| bytes.to_vec())
+}
+
+// ---------- lifecycle ------------------------------------------------
+
+#[test]
+fn open_creates_data_dir_if_missing() {
+    let tmp = TempDir::new().unwrap();
+    let nested = tmp.path().join("sub/a/b");
+    assert!(!nested.exists());
+    let b = RedbBackend::open(BackendConfig::new(nested.clone(), false)).unwrap();
+    assert!(nested.is_dir());
+    b.close().unwrap();
+}
+
+#[test]
+fn close_idempotent_then_closed_errors() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.close().unwrap();
+    b.close().unwrap();
+    b.close().unwrap();
+    assert!(matches!(
+        b.register_bucket("kv", KV),
+        Err(BackendError::Closed)
+    ));
+    assert!(matches!(b.snapshot(), Err(BackendError::Closed)));
+    assert!(matches!(b.begin_batch(), Err(BackendError::Closed)));
+}
+
+#[tokio::test]
+async fn reopen_after_close_sees_prior_writes() {
+    let tmp = TempDir::new().unwrap();
+    {
+        let b = open(&tmp);
+        b.register_bucket("kv", KV).unwrap();
+        put(&b, KV, b"alpha", b"1").await;
+        b.close().unwrap();
+    }
+    let b2 = open(&tmp);
+    assert_eq!(get(&b2, KV, b"alpha").as_deref(), Some(&b"1"[..]));
+}
+
+#[test]
+fn read_only_open_returns_other() {
+    let tmp = TempDir::new().unwrap();
+    let res = RedbBackend::open(BackendConfig::new(tmp.path().to_path_buf(), true));
+    match res {
+        Err(BackendError::Other(msg)) => {
+            assert!(
+                msg.contains("read-only"),
+                "unexpected Other message: {msg:?}"
+            );
+        }
+        Ok(_) => panic!("expected Other(read-only ...)"),
+        Err(other) => panic!("expected Other(read-only ...), got {other:?}"),
+    }
+}
+
+// ---------- registry -------------------------------------------------
+
+#[test]
+fn register_bucket_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    b.register_bucket("kv", KV).unwrap();
+    b.register_bucket("kv", KV).unwrap();
+}
+
+#[test]
+fn register_bucket_conflict_rebinding_id() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    match b.register_bucket("meta", KV) {
+        Err(BackendError::BucketConflict {
+            id,
+            existing,
+            requested,
+        }) => {
+            assert_eq!(id, KV);
+            assert_eq!(existing, "kv");
+            assert_eq!(requested, "meta");
+        }
+        other => panic!("expected BucketConflict, got {other:?}"),
+    }
+}
+
+#[test]
+fn register_bucket_conflict_rebinding_name() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    match b.register_bucket("kv", META) {
+        Err(BackendError::BucketNameConflict {
+            name,
+            existing_id,
+            requested_id,
+        }) => {
+            assert_eq!(name, "kv");
+            assert_eq!(existing_id, KV);
+            assert_eq!(requested_id, META);
+        }
+        other => panic!("expected BucketNameConflict, got {other:?}"),
+    }
+}
+
+#[test]
+fn registry_persists_across_reopen() {
+    // Both conflict variants must fire after hydration, proving the
+    // on-disk registry was read back. `BucketConflict` (id-rebind) is
+    // checked before `BucketNameConflict` in the registry, so to fire
+    // the name-conflict path we pick a fresh id (`99`) whose id-slot is
+    // unused and exercise only the name collision.
+    const FRESH_ID: BucketId = BucketId::new(99);
+    let tmp = TempDir::new().unwrap();
+    {
+        let b = open(&tmp);
+        b.register_bucket("kv", KV).unwrap();
+        b.register_bucket("meta", META).unwrap();
+        b.close().unwrap();
+    }
+    let b2 = open(&tmp);
+    assert!(matches!(
+        b2.register_bucket("kv", FRESH_ID),
+        Err(BackendError::BucketNameConflict { .. })
+    ));
+    assert!(matches!(
+        b2.register_bucket("kv2", KV),
+        Err(BackendError::BucketConflict { .. })
+    ));
+    b2.register_bucket("kv", KV).unwrap();
+}
+
+// ---------- write path -----------------------------------------------
+
+#[tokio::test]
+async fn put_get_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    put(&b, KV, b"k", b"v").await;
+    assert_eq!(get(&b, KV, b"k").as_deref(), Some(&b"v"[..]));
+    assert_eq!(get(&b, KV, b"absent"), None);
+}
+
+#[tokio::test]
+async fn delete_removes_key() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    put(&b, KV, b"k", b"v").await;
+    assert_eq!(get(&b, KV, b"k").as_deref(), Some(&b"v"[..]));
+
+    let mut batch = b.begin_batch().unwrap();
+    batch.delete(KV, b"k").unwrap();
+    let _ = b.commit_batch(batch, true).await.unwrap();
+    assert_eq!(get(&b, KV, b"k"), None);
+}
+
+#[tokio::test]
+async fn delete_range_removes_half_open_interval() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    for k in [b"a", b"b", b"c", b"d", b"e"] {
+        put(&b, KV, k, b"v").await;
+    }
+
+    let mut batch = b.begin_batch().unwrap();
+    batch.delete_range(KV, b"b", b"d").unwrap();
+    let _ = b.commit_batch(batch, true).await.unwrap();
+
+    assert_eq!(get(&b, KV, b"a").as_deref(), Some(&b"v"[..]));
+    assert_eq!(get(&b, KV, b"b"), None);
+    assert_eq!(get(&b, KV, b"c"), None);
+    // `d` is the exclusive upper bound — survives.
+    assert_eq!(get(&b, KV, b"d").as_deref(), Some(&b"v"[..]));
+    assert_eq!(get(&b, KV, b"e").as_deref(), Some(&b"v"[..]));
+}
+
+#[tokio::test]
+async fn unknown_bucket_on_put_errors_from_commit() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    // No register_bucket — KV is unknown.
+    let mut batch = b.begin_batch().unwrap();
+    batch.put(KV, b"k", b"v").unwrap();
+    match b.commit_batch(batch, true).await {
+        Err(BackendError::UnknownBucket(id)) => assert_eq!(id, KV),
+        other => panic!("expected UnknownBucket, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn invalid_range_on_delete_range_errors_from_commit() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    let mut batch = b.begin_batch().unwrap();
+    batch.delete_range(KV, b"z", b"a").unwrap();
+    match b.commit_batch(batch, true).await {
+        Err(BackendError::InvalidRange(_)) => {}
+        other => panic!("expected InvalidRange, got {other:?}"),
+    }
+}
+
+// ---------- read path ------------------------------------------------
+
+#[tokio::test]
+async fn snapshot_isolation_observes_pre_commit_state() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    put(&b, KV, b"k", b"old").await;
+
+    let snap = b.snapshot().unwrap();
+    put(&b, KV, b"k", b"new").await;
+
+    assert_eq!(get(&b, KV, b"k").as_deref(), Some(&b"new"[..]));
+    assert_eq!(
+        snap.get(KV, b"k").unwrap().map(|b| b.to_vec()).as_deref(),
+        Some(&b"old"[..])
+    );
+}
+
+#[test]
+fn snapshot_range_on_unregistered_bucket_errors() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    let snap = b.snapshot().unwrap();
+    // `Result<Box<dyn RangeIter>, BackendError>` does not implement
+    // Debug (the Ok variant does not), so the catch-all binds the
+    // error only after splitting Ok first. Semicolon forces temporaries
+    // to drop before `snap`, which the borrow of `snap.range(...)`
+    // otherwise keeps live past end-of-scope.
+    match snap.range(KV, b"a", b"z") {
+        Ok(_) => panic!("expected UnknownBucket"),
+        Err(BackendError::UnknownBucket(id)) => assert_eq!(id, KV),
+        Err(other) => panic!("expected UnknownBucket, got {other:?}"),
+    };
+}
+
+#[test]
+fn snapshot_range_invalid_range_errors() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    let snap = b.snapshot().unwrap();
+    match snap.range(KV, b"z", b"a") {
+        Ok(_) => panic!("expected InvalidRange"),
+        Err(BackendError::InvalidRange(_)) => {}
+        Err(other) => panic!("expected InvalidRange, got {other:?}"),
+    };
+}
+
+#[tokio::test]
+async fn snapshot_range_returns_half_open_interval() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    for (k, v) in [
+        (b"a".as_slice(), b"1".as_slice()),
+        (b"b", b"2"),
+        (b"c", b"3"),
+        (b"d", b"4"),
+    ] {
+        put(&b, KV, k, v).await;
+    }
+    let snap = b.snapshot().unwrap();
+    let iter = snap.range(KV, b"b", b"d").unwrap();
+    let got: Vec<(Vec<u8>, Vec<u8>)> = iter
+        .map(|r| {
+            let (k, v) = r.unwrap();
+            (k.to_vec(), v.to_vec())
+        })
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            (b"b".to_vec(), b"2".to_vec()),
+            (b"c".to_vec(), b"3".to_vec()),
+        ]
+    );
+}
+
+// ---------- commit semantics -----------------------------------------
+
+#[tokio::test]
+async fn commit_stamp_is_monotonic_across_commits() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+
+    let mut prior = None::<mango_storage::CommitStamp>;
+    for i in 0u8..5 {
+        let mut batch = b.begin_batch().unwrap();
+        batch.put(KV, &[i], b"v").unwrap();
+        let stamp = b.commit_batch(batch, true).await.unwrap();
+        if let Some(p) = prior {
+            assert!(p < stamp, "stamp did not advance: {p:?} -> {stamp:?}");
+        }
+        prior = Some(stamp);
+    }
+}
+
+#[tokio::test]
+async fn commit_group_atomic_applies_every_batch() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+
+    let mut a = b.begin_batch().unwrap();
+    a.put(KV, b"a", b"1").unwrap();
+    let mut c = b.begin_batch().unwrap();
+    c.put(KV, b"b", b"2").unwrap();
+    c.delete(KV, b"a").unwrap();
+
+    let _ = b.commit_group(vec![a, c]).await.unwrap();
+
+    // `a`'s put is shadowed by `c`'s delete — group order preserved.
+    assert_eq!(get(&b, KV, b"a"), None);
+    assert_eq!(get(&b, KV, b"b").as_deref(), Some(&b"2"[..]));
+}
+
+#[tokio::test]
+async fn commit_group_empty_still_increments_stamp() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    let s0 = b.commit_group(Vec::new()).await.unwrap();
+    let s1 = b.commit_group(Vec::new()).await.unwrap();
+    assert!(s0 < s1, "empty group did not bump stamp: {s0:?} vs {s1:?}");
+}
+
+#[tokio::test]
+async fn commit_group_partial_failure_aborts_whole_group() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    // META is unregistered; the whole group MUST abort.
+    let mut good = b.begin_batch().unwrap();
+    good.put(KV, b"k", b"v").unwrap();
+    let mut bad = b.begin_batch().unwrap();
+    bad.put(META, b"k", b"v").unwrap();
+
+    let res = b.commit_group(vec![good, bad]).await;
+    assert!(matches!(res, Err(BackendError::UnknownBucket(_))));
+    // No visible effect — `good`'s put must not have landed.
+    assert_eq!(get(&b, KV, b"k"), None);
+}
+
+// ---------- utility --------------------------------------------------
+
+#[tokio::test]
+async fn size_on_disk_grows_after_writes() {
+    // redb pre-allocates an initial region (~1 MiB on current 4.x),
+    // so small writes land inside that reservation without growing
+    // the file. Push enough bytes that growth is unambiguous. The
+    // trait's advisory-only contract means we assert `s1 >= s0` in
+    // the post-small-write case, but require strict growth after a
+    // multi-MiB write so the accessor is actually exercising the
+    // filesystem metadata path.
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    let s0 = b.size_on_disk().unwrap();
+    assert!(s0 > 0, "freshly-opened file has zero size");
+    let mut batch = b.begin_batch().unwrap();
+    // ~4 MiB of values: 2048 * 2048 bytes. Spills past the initial
+    // region regardless of redb's current allocation heuristic.
+    for i in 0u32..2048 {
+        let k = i.to_be_bytes();
+        batch.put(KV, &k, &[0xAB; 2048]).unwrap();
+    }
+    let _ = b.commit_batch(batch, true).await.unwrap();
+    let s1 = b.size_on_disk().unwrap();
+    assert!(s1 > s0, "size did not grow: {s0} -> {s1}");
+}
+
+#[tokio::test]
+async fn defragment_smoke_returns_ok() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    for i in 0u32..64 {
+        let k = i.to_be_bytes();
+        put(&b, KV, &k, &[0u8; 32]).await;
+    }
+    b.defragment().await.unwrap();
+    assert_eq!(get(&b, KV, &0u32.to_be_bytes()).map(|v| v.len()), Some(32));
+}
+
+// ---------- cross-cutting oracle -------------------------------------
+
+#[tokio::test]
+async fn btreemap_oracle_matches_backend_for_mixed_workload() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+
+    let mut oracle: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
+
+    // Deterministic pseudo-random sequence; no proptest yet — that
+    // lives in the differential harness (ROADMAP:819+).
+    for i in 0u16..200 {
+        let k = vec![(i & 0xFF) as u8, ((i >> 8) & 0xFF) as u8];
+        let v = vec![(i.wrapping_mul(31) & 0xFF) as u8; (i as usize & 0x07) + 1];
+        put(&b, KV, &k, &v).await;
+        oracle.insert(k, v);
+    }
+    let to_delete: Vec<Vec<u8>> = oracle.keys().step_by(7).cloned().collect();
+    let mut batch = b.begin_batch().unwrap();
+    for k in &to_delete {
+        batch.delete(KV, k).unwrap();
+    }
+    let _ = b.commit_batch(batch, true).await.unwrap();
+    for k in &to_delete {
+        oracle.remove(k);
+    }
+
+    let snap = b.snapshot().unwrap();
+    for (k, v) in &oracle {
+        let got = snap.get(KV, k).unwrap();
+        assert_eq!(got.as_deref(), Some(v.as_slice()), "mismatch at {k:?}");
+    }
+    for k in &to_delete {
+        assert_eq!(snap.get(KV, k).unwrap(), None);
+    }
+}
+
+// ---------- concurrency sanity --------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_committers_get_distinct_stamps() {
+    // Small, deterministic concurrency sanity test — not a chaos run
+    // (that's Phase 1's 7-day gate). Two tokio tasks both commit; the
+    // stamps MUST differ. The redb write-lock serializes them, which
+    // is exactly the etcd batch-tx serialization this layer mirrors.
+    let tmp = TempDir::new().unwrap();
+    let b = Arc::new(open(&tmp));
+    b.register_bucket("kv", KV).unwrap();
+
+    let b1 = Arc::clone(&b);
+    let b2 = Arc::clone(&b);
+    // RedbBatch is !Send (PhantomData<*const ()>), so it must drop
+    // before the `.await` inside `tokio::spawn`. Constructing the
+    // future in an inner block moves the batch into `commit_batch`
+    // and drops the binding, then awaits the Send future.
+    let t1 = tokio::spawn(async move {
+        let fut = {
+            let mut batch = b1.begin_batch().unwrap();
+            batch.put(KV, b"t1", b"v").unwrap();
+            b1.commit_batch(batch, true)
+        };
+        fut.await.unwrap()
+    });
+    let t2 = tokio::spawn(async move {
+        let fut = {
+            let mut batch = b2.begin_batch().unwrap();
+            batch.put(KV, b"t2", b"v").unwrap();
+            b2.commit_batch(batch, true)
+        };
+        fut.await.unwrap()
+    });
+    let s1 = t1.await.unwrap();
+    let s2 = t2.await.unwrap();
+    assert_ne!(s1, s2, "stamps collided: {s1:?} vs {s2:?}");
+}
+
+#[test]
+fn dropping_uncommitted_batch_is_visible_noop() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    {
+        let mut batch = b.begin_batch().unwrap();
+        batch.put(KV, b"k", b"never").unwrap();
+        // `batch` is dropped here without commit.
+    }
+    assert_eq!(get(&b, KV, b"k"), None);
+}


### PR DESCRIPTION
## Summary

Implements the redb-backed `Backend` (ROADMAP:817 / Phase 1, line 828) — the first real `crate::Backend` impl behind the trait-surface frozen in ADR 0002 §6.

- `Arc<Inner>` shared state; handle is `Send + Sync + 'static`.
- Registry mirrored on-disk at `__mango_bucket_registry`; hydrated at `open`, write-through at `register_bucket`.
- Write path groups staged ops by `BucketId` via `BTreeMap` so each redb `Table` opens exactly once per commit (redb panics on duplicate `open_table` — grouping is correctness-load-bearing).
- `commit_batch` / `commit_group` extract staged ops in a sync prologue (so the `!Send` `RedbBatch` never enters the returned `Future`), then run the fsync'd write inside `tokio::task::spawn_blocking` so no tokio worker is blocked.
- `CommitStamp` is strictly monotonic (`fetch_add(1, Release)` on every commit including empty `commit_group`).
- `close` is idempotent via `compare_exchange`.
- Always-`Immediate` durability for now; `force_fsync=false` / `Durability::None` is a ROADMAP:817 follow-up — always-fsync is strictly stronger than etcd's boltdb batch-tx model.

## Test plan

- [x] `cargo test -p mango-storage --tests` — 26 new integration tests pass under the default runtime.
- [x] `RUSTFLAGS="--cfg madsim" MADSIM_TEST_SEED=1 cargo test -p mango-storage --tests` — sim-only smoke passes.
- [x] `cargo test --workspace` — no regressions (67 passed, 1 ignored).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo doc --no-deps --workspace --document-private-items` — clean.
- [x] `cargo vet check` — clean.
- [x] `cargo deny check` — clean.

Integration coverage (real-runtime, `#![cfg(not(madsim))]`):
- lifecycle — open creates dir, close idempotent + subsequent ops error, reopen sees prior writes, read-only returns `Other(...)`.
- registry — idempotence, both conflict variants (`BucketConflict` id-rebind, `BucketNameConflict` name-rebind), persistence across reopen.
- write path — `put` / `delete` / `delete_range` (half-open), `UnknownBucket` surfaced from commit, `InvalidRange` surfaced from commit.
- read path — snapshot isolation against concurrent commits, `UnknownBucket` and `InvalidRange` on `snapshot.range`, half-open interval correctness.
- commit semantics — strict stamp monotonicity, `commit_group` atomicity including partial-failure rollback, empty-group still bumps stamp, dropping an uncommitted batch is a no-op.
- utility — `size_on_disk` grows after multi-MiB writes, `defragment` smoke.
- cross-cutting — mini `BTreeMap<Vec<u8>, Vec<u8>>` oracle over a deterministic mixed workload.
- concurrency — two `tokio::spawn` committers under `multi_thread` runtime must get distinct stamps.

Sim coverage (`#![cfg(madsim)]`): compile-test + registry-path smoke. The full redb semantics are covered by the real-runtime tests above — madsim doesn't substitute `std::fs` or redb's mmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
