### PR TITLE
feat(storage): implement RaftLogStore against raft-engine (ROADMAP:818)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "autotools"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +277,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,7 +324,7 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -386,6 +404,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +448,18 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -553,7 +592,7 @@ dependencies = [
  "madsim-macros",
  "naive-timer",
  "panic-message",
- "rand",
+ "rand 0.8.6",
  "rand_xoshiro",
  "rustversion",
  "serde",
@@ -623,6 +662,7 @@ dependencies = [
  "madsim",
  "madsim-tokio",
  "parking_lot",
+ "raft",
  "raft-engine",
  "redb",
  "tempfile",
@@ -813,6 +853,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +967,40 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
+name = "protobuf-build"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c852d9625b912c3e50480cdc701f60f49890b5d7ad46198dd583600f15e7c6ec"
+dependencies = [
+ "bitflags 1.3.2",
+ "protobuf",
+ "protobuf-codegen",
+ "protobuf-src",
+ "regex",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
+]
 
 [[package]]
 name = "quote"
@@ -920,6 +1016,20 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "raft"
+version = "0.7.0"
+source = "git+https://github.com/tikv/raft-rs?rev=53cf7a5b0bf08d278ad768a60b77e68fa10f93aa#53cf7a5b0bf08d278ad768a60b77e68fa10f93aa"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "getset",
+ "raft-proto",
+ "rand 0.9.4",
+ "slog",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "raft-engine"
@@ -953,14 +1063,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "raft-proto"
+version = "0.7.0"
+source = "git+https://github.com/tikv/raft-rs?rev=53cf7a5b0bf08d278ad768a60b77e68fa10f93aa#53cf7a5b0bf08d278ad768a60b77e68fa10f93aa"
+dependencies = [
+ "bytes",
+ "protobuf",
+ "protobuf-build",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -970,7 +1100,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -983,12 +1123,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1169,6 +1318,18 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slog"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b8565691b22d2bdfc066426ed48f837fc0c5f2c8cad8d9718f7f99d6995c1"
+dependencies = [
+ "anyhow",
+ "erased-serde",
+ "rustversion",
+ "serde_core",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,37 @@ raft-engine = { version = "0.4.2", git = "https://github.com/humancto/raft-engin
     "internals",
 ] }
 
+# raft (raft-rs) at master SHA — provides `raft::eraftpb::{Entry,
+# HardState, SnapshotMetadata}` used at the `RaftLogStore` conversion
+# boundary in mango-storage (ROADMAP:818). We do NOT depend on raft-rs
+# for its state machine in Phase 1 — only for the protobuf-generated
+# types that raft-engine's `MessageExtTyped` expects. Phase 3
+# `mango-raft` will exercise the state machine properly.
+#
+# Pin shape:
+# - `version = "0.7"` is the matching crates.io version (0.7.0); the
+#   SHA-pin below takes precedence, but the version string is required
+#   by cargo-deny's `wildcards = "deny"` rule for git deps.
+# - `rev = "<SHA>"` — raft-rs master does not publish every commit to
+#   crates.io, and mango workspace policy is SHA-pin for every git dep.
+#   Dependabot does NOT auto-bump git rev pins; rebase is manual.
+# - `default-features = false` drops `default-logger` (slog-stdlog +
+#   slog-envlogger + slog-term — we don't want a global logger config
+#   leaking in from a transitive dep).
+# - `features = ["protobuf-codec"]` keeps the rust-protobuf v2 types
+#   that raft-engine's `internals` feature consumes. `prost-codec`
+#   would produce Entry types that don't satisfy raft-engine's
+#   `Message` bound (rust-protobuf vs prost are separate Message
+#   traits).
+#
+# See .planning/raft-engine-logstore.plan.md §"Dependency surface"
+# for the expert-reviewed rationale and
+# .planning/fork-raft-engine-lz4-verification.md for the
+# sibling-pin (raft-engine fork).
+raft = { version = "0.7", git = "https://github.com/tikv/raft-rs", rev = "53cf7a5b0bf08d278ad768a60b77e68fa10f93aa", default-features = false, features = [
+    "protobuf-codec",
+] }
+
 # Phase 1 trait-surface deps (ROADMAP:816).
 #
 # bytes: ref-counted `Bytes` for Raft entry payloads and snapshot

--- a/crates/mango-storage/Cargo.toml
+++ b/crates/mango-storage/Cargo.toml
@@ -18,6 +18,14 @@ redb.workspace = true
 # C FFI dep (ADR 0002 §W5), and re-enabling `scripting` would pull
 # MPL-2.0 (via rhai/smartstring).
 raft-engine.workspace = true
+# ROADMAP:818: raft-rs SHA-pinned via workspace. Used ONLY for the
+# protobuf type surface (`raft::eraftpb::{Entry, HardState,
+# SnapshotMetadata}`) at the `RaftLogStore` conversion boundary; we do
+# NOT exercise raft-rs's state machine here (that's Phase 3
+# `mango-raft`). The workspace entry sets `default-features = false,
+# features = ["protobuf-codec"]` — local features MUST stay empty to
+# avoid re-enabling `default-logger` (slog transitives).
+raft.workspace = true
 # Trait-surface deps — see ROADMAP:816 and the workspace declarations
 # for rationale. bytes carries Raft entry payloads and snapshot bytes;
 # thiserror derives BackendError.

--- a/crates/mango-storage/src/lib.rs
+++ b/crates/mango-storage/src/lib.rs
@@ -20,10 +20,15 @@ pub mod backend;
 // public API.
 mod redb;
 
+// ROADMAP:818 raft-engine-backed RaftLogStore impl. The module is
+// private; only the named types below are public API.
+mod raft_engine;
+
 pub use backend::{
     Backend, BackendConfig, BackendError, BucketId, CommitStamp, HardState, RaftEntry,
     RaftEntryType, RaftLogStore, RaftSnapshotMetadata, RangeIter, ReadSnapshot, WriteBatch,
 };
+pub use raft_engine::{RaftEngineConfig, RaftEngineLogStore, ReadableSize, RecoveryMode};
 pub use redb::{batch::RedbBatch, snapshot::RedbSnapshot, RedbBackend};
 
 /// The package version string, captured at build time from

--- a/crates/mango-storage/src/raft_engine/config.rs
+++ b/crates/mango-storage/src/raft_engine/config.rs
@@ -1,0 +1,173 @@
+//! Public configuration surface for [`super::RaftEngineLogStore`].
+//!
+//! Wraps the subset of [`::raft_engine::Config`] we intentionally
+//! expose. Fields that affect crash-consistency (`recovery_mode`) and
+//! operational sizing (`target_file_size`, `purge_threshold`) are
+//! first-class; everything else uses upstream defaults.
+//!
+//! Opaque types from raft-engine (`ReadableSize`, `RecoveryMode`) are
+//! re-exported so callers don't need to import the engine crate
+//! directly.
+
+use std::path::PathBuf;
+
+pub use ::raft_engine::{ReadableSize, RecoveryMode};
+
+/// Configuration for opening a [`super::RaftEngineLogStore`].
+///
+/// Construct with [`RaftEngineConfig::new`] and (optionally) chain
+/// the builder methods to override the upstream defaults. The
+/// `#[non_exhaustive]` attribute forces this style so adding a new
+/// field is not a breaking change for downstream crates.
+///
+/// # Defaults
+///
+/// * `target_file_size` — `128 MiB` (upstream default).
+/// * `purge_threshold` — `10 GiB` (upstream default).
+/// * `recovery_mode` — [`RecoveryMode::TolerateTailCorruption`]
+///   (upstream default; tail corruption from dirty shutdown is
+///   recoverable without operator intervention).
+///
+/// # Example
+///
+/// ```ignore
+/// use std::path::PathBuf;
+/// use mango_storage::{RaftEngineConfig, ReadableSize};
+///
+/// let cfg = RaftEngineConfig::new(PathBuf::from("/var/lib/mango/raft"))
+///     .with_target_file_size(ReadableSize::mb(64))
+///     .with_purge_threshold(ReadableSize::gb(4));
+/// ```
+#[derive(Debug, Clone)]
+#[must_use]
+#[non_exhaustive]
+pub struct RaftEngineConfig {
+    /// Directory where raft-engine stores its append-only log files.
+    /// Required. Must exist; raft-engine itself creates missing
+    /// directories on `Engine::open`, but a pre-flight check keeps
+    /// the error surface homogeneous with [`super::super::RedbBackend`].
+    pub data_dir: PathBuf,
+    /// Rollover size for a single log file. Smaller values mean more
+    /// files and faster purge granularity; larger values mean fewer
+    /// files and less per-file overhead.
+    pub target_file_size: ReadableSize,
+    /// Soft ceiling on total log-file bytes before
+    /// [`super::RaftEngineLogStore::purge_expired_files`] is expected
+    /// to reclaim space. Raft-engine does not enforce this as a hard
+    /// cap — callers must drive purge themselves.
+    pub purge_threshold: ReadableSize,
+    /// How raft-engine treats a dirty-shutdown tail during replay.
+    /// Default is [`RecoveryMode::TolerateTailCorruption`]; switch
+    /// to [`RecoveryMode::AbsoluteConsistency`] in tests that want
+    /// every replay mismatch to be an error.
+    pub recovery_mode: RecoveryMode,
+}
+
+impl RaftEngineConfig {
+    /// Construct a config with upstream defaults for every field
+    /// except `data_dir`.
+    pub fn new(data_dir: PathBuf) -> Self {
+        Self {
+            data_dir,
+            target_file_size: ReadableSize::mb(128),
+            purge_threshold: ReadableSize::gb(10),
+            recovery_mode: RecoveryMode::TolerateTailCorruption,
+        }
+    }
+
+    /// Set [`Self::target_file_size`].
+    pub fn with_target_file_size(mut self, size: ReadableSize) -> Self {
+        self.target_file_size = size;
+        self
+    }
+
+    /// Set [`Self::purge_threshold`].
+    pub fn with_purge_threshold(mut self, size: ReadableSize) -> Self {
+        self.purge_threshold = size;
+        self
+    }
+
+    /// Set [`Self::recovery_mode`].
+    pub fn with_recovery_mode(mut self, mode: RecoveryMode) -> Self {
+        self.recovery_mode = mode;
+        self
+    }
+
+    /// Lower this config into a [`::raft_engine::Config`]. Forces
+    /// `batch_compression_threshold = ReadableSize(0)` so the
+    /// `lz4-compression` feature cannot be exercised at runtime —
+    /// the humancto fork feature-gates the C FFI `lz4-sys` dep out
+    /// of the default graph (see ADR 0002 §W5), and the sanitizer
+    /// in `Config::sanitize` also forces it to zero when the cargo
+    /// feature is absent. Setting it explicitly here means a future
+    /// upstream bump that re-enables compression by default cannot
+    /// silently change mango's on-disk posture.
+    pub(crate) fn into_engine_config(self) -> ::raft_engine::Config {
+        ::raft_engine::Config {
+            dir: self.data_dir.to_string_lossy().into_owned(),
+            target_file_size: self.target_file_size,
+            purge_threshold: self.purge_threshold,
+            recovery_mode: self.recovery_mode,
+            batch_compression_threshold: ReadableSize(0),
+            ..::raft_engine::Config::default()
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_upstream() {
+        let cfg = RaftEngineConfig::new(PathBuf::from("/tmp/r"));
+        assert_eq!(cfg.target_file_size, ReadableSize::mb(128));
+        assert_eq!(cfg.purge_threshold, ReadableSize::gb(10));
+        assert!(matches!(
+            cfg.recovery_mode,
+            RecoveryMode::TolerateTailCorruption
+        ));
+    }
+
+    #[test]
+    fn into_engine_config_forces_compression_off() {
+        let cfg = RaftEngineConfig::new(PathBuf::from("/tmp/r"));
+        let lowered = cfg.into_engine_config();
+        assert_eq!(
+            lowered.batch_compression_threshold,
+            ReadableSize(0),
+            "batch_compression_threshold must be zero — lz4 FFI is \
+             gated out of the build by the humancto fork (ADR 0002 §W5), \
+             and forcing 0 here means a future default flip cannot \
+             silently re-enable it"
+        );
+    }
+
+    #[test]
+    fn into_engine_config_propagates_sizes() {
+        let cfg = RaftEngineConfig::new(PathBuf::from("/tmp/r"))
+            .with_target_file_size(ReadableSize::mb(32))
+            .with_purge_threshold(ReadableSize::gb(2));
+        let lowered = cfg.into_engine_config();
+        assert_eq!(lowered.target_file_size, ReadableSize::mb(32));
+        assert_eq!(lowered.purge_threshold, ReadableSize::gb(2));
+    }
+
+    #[test]
+    fn into_engine_config_propagates_data_dir() {
+        let cfg = RaftEngineConfig::new(PathBuf::from("/var/lib/mango/raft"));
+        let lowered = cfg.into_engine_config();
+        assert_eq!(lowered.dir, "/var/lib/mango/raft");
+    }
+
+    #[test]
+    fn builder_overrides_recovery_mode() {
+        let cfg = RaftEngineConfig::new(PathBuf::from("/tmp/r"))
+            .with_recovery_mode(RecoveryMode::AbsoluteConsistency);
+        assert!(matches!(
+            cfg.recovery_mode,
+            RecoveryMode::AbsoluteConsistency
+        ));
+    }
+}

--- a/crates/mango-storage/src/raft_engine/convert.rs
+++ b/crates/mango-storage/src/raft_engine/convert.rs
@@ -1,0 +1,276 @@
+//! Type conversions at the `raft-engine` / `raft-rs` boundary.
+//!
+//! raft-engine stores entries as `raft::eraftpb::Entry` (rust-protobuf
+//! v2 types, generated with `carllerche_bytes_for_bytes_all = true`
+//! so `data` and `context` fields are `bytes::Bytes`). The public
+//! [`super::super::backend::RaftLogStore`] trait exposes the engine-
+//! agnostic [`RaftEntry`] / [`HardState`] / [`RaftSnapshotMetadata`]
+//! surface. This module converts in both directions.
+//!
+//! Conversions are infallible except for `EntryType` narrowing:
+//! `EntryConfChangeV2` is folded to [`RaftEntryType::ConfChange`]
+//! per the backend contract (see `backend.rs` docstring on
+//! [`RaftEntryType`] — "config changes ride as normal entries").
+//!
+//! # Cost
+//!
+//! `bytes::Bytes` is reference-counted so the `data` / `context`
+//! field clones are refcount bumps, not buffer copies. The `ConfState`
+//! for `RaftSnapshotMetadata` IS serialized to bytes on the way down
+//! (rust-protobuf `write_to_bytes`) and parsed on the way up — that
+//! is a real allocation, but snapshot installs are rare.
+
+use bytes::Bytes;
+// Re-export path `::raft::protocompat::PbMessage` is the stable
+// `Message` surface for the protobuf codec regardless of whether
+// raft-rs is built with `protobuf-codec` or `prost-codec`. We consume
+// raft-rs with `features = ["protobuf-codec"]` in `Cargo.toml`; this
+// import shape means a future switch would fail to compile here
+// rather than in every call site.
+use ::raft::protocompat::PbMessage as _;
+
+use crate::backend::{BackendError, HardState, RaftEntry, RaftEntryType, RaftSnapshotMetadata};
+
+/// Convert a mango [`RaftEntry`] into the protobuf `Entry` raft-engine
+/// expects. The `data` and `context` `Bytes` are consumed by value —
+/// no deep copy.
+pub(super) fn entry_to_proto(e: RaftEntry) -> ::raft::eraftpb::Entry {
+    let mut proto = ::raft::eraftpb::Entry::default();
+    proto.set_entry_type(entry_type_to_proto(e.entry_type));
+    proto.term = e.term;
+    proto.index = e.index;
+    // `data` / `context` on the proto side are already `bytes::Bytes`
+    // (see module docstring re: `carllerche_bytes_for_bytes_all`).
+    proto.data = e.data;
+    proto.context = e.context;
+    proto
+}
+
+/// Convert a raft-engine-returned `Entry` into the mango
+/// [`RaftEntry`] shape. Consumes the proto — all bytes fields are
+/// `Bytes` already, so this is refcount-only.
+pub(super) fn entry_from_proto(mut p: ::raft::eraftpb::Entry) -> RaftEntry {
+    // `take_data` / `take_context` drain the field (leave Bytes::new()
+    // behind) and hand us ownership without a clone.
+    let data = p.take_data();
+    let context = p.take_context();
+    RaftEntry::new(
+        p.index,
+        p.term,
+        entry_type_from_proto(p.get_entry_type()),
+        data,
+        context,
+    )
+}
+
+fn entry_type_to_proto(t: RaftEntryType) -> ::raft::eraftpb::EntryType {
+    // `RaftEntryType` is `#[non_exhaustive]` (see backend.rs). A
+    // future variant reaching this path would mean the caller
+    // constructed an entry type the storage layer has no mapping
+    // for; we fall through to `EntryNormal` as a defensive default.
+    // Silent mis-persistence is prevented upstream because adding a
+    // new variant breaks exhaustiveness here at compile time in
+    // this crate (the `#[non_exhaustive]` only hides variants from
+    // *external* crates).
+    match t {
+        RaftEntryType::Normal => ::raft::eraftpb::EntryType::EntryNormal,
+        RaftEntryType::ConfChange => ::raft::eraftpb::EntryType::EntryConfChange,
+    }
+}
+
+fn entry_type_from_proto(t: ::raft::eraftpb::EntryType) -> RaftEntryType {
+    match t {
+        ::raft::eraftpb::EntryType::EntryNormal => RaftEntryType::Normal,
+        // Both V1 and V2 config changes collapse to the single
+        // mango `ConfChange` variant per the backend contract.
+        ::raft::eraftpb::EntryType::EntryConfChange
+        | ::raft::eraftpb::EntryType::EntryConfChangeV2 => RaftEntryType::ConfChange,
+    }
+}
+
+/// Convert a mango [`HardState`] to the protobuf `HardState`
+/// raft-engine persists.
+pub(super) fn hard_state_to_proto(hs: HardState) -> ::raft::eraftpb::HardState {
+    ::raft::eraftpb::HardState {
+        term: hs.term,
+        vote: hs.vote,
+        commit: hs.commit,
+        ..::raft::eraftpb::HardState::default()
+    }
+}
+
+/// Convert a protobuf `HardState` (as read from raft-engine) back to
+/// the mango surface.
+pub(super) fn hard_state_from_proto(p: &::raft::eraftpb::HardState) -> HardState {
+    HardState::new(p.term, p.vote, p.commit)
+}
+
+/// Convert a mango [`RaftSnapshotMetadata`] into the protobuf shape.
+/// `conf_state` bytes are parsed as a protobuf `ConfState`; an empty
+/// `Bytes` yields `ConfState::default()` without a parse call.
+///
+/// # Errors
+///
+/// [`BackendError::Corruption`] if the encoded `ConfState` fails to
+/// parse.
+pub(super) fn snapshot_metadata_to_proto(
+    m: &RaftSnapshotMetadata,
+) -> Result<::raft::eraftpb::SnapshotMetadata, BackendError> {
+    let mut p = ::raft::eraftpb::SnapshotMetadata {
+        index: m.index,
+        term: m.term,
+        ..::raft::eraftpb::SnapshotMetadata::default()
+    };
+    if !m.conf_state.is_empty() {
+        let conf_state =
+            <::raft::eraftpb::ConfState as ::raft::protocompat::PbMessage>::parse_from_bytes(
+                &m.conf_state,
+            )
+            .map_err(|e| BackendError::Corruption(format!("ConfState decode: {e}")))?;
+        p.set_conf_state(conf_state);
+    }
+    Ok(p)
+}
+
+/// Convert a protobuf `SnapshotMetadata` back into the mango surface.
+/// Re-encodes `conf_state` to `Bytes` so the public struct stays
+/// engine-agnostic.
+///
+/// Currently exercised only by the unit-test roundtrip; Phase 3
+/// (`mango-raft`) is the first real caller, when the raft-rs
+/// `Storage::snapshot` bridge needs to read back the installed
+/// metadata. Kept in this module so the inverse direction is defined
+/// next to the forward one — the conversions must stay symmetric to
+/// avoid a lossy pipeline.
+///
+/// # Errors
+///
+/// [`BackendError::Corruption`] on a protobuf encode failure; in
+/// practice this is impossible for a well-formed value, but
+/// rust-protobuf's API is fallible so we propagate.
+#[allow(dead_code)]
+pub(super) fn snapshot_metadata_from_proto(
+    mut p: ::raft::eraftpb::SnapshotMetadata,
+) -> Result<RaftSnapshotMetadata, BackendError> {
+    let conf_state_bytes: Bytes = if p.has_conf_state() {
+        let cs = p.take_conf_state();
+        let encoded = cs
+            .write_to_bytes()
+            .map_err(|e| BackendError::Corruption(format!("ConfState encode: {e}")))?;
+        Bytes::from(encoded)
+    } else {
+        Bytes::new()
+    };
+    Ok(RaftSnapshotMetadata::new(p.index, p.term, conf_state_bytes))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_roundtrip_normal() {
+        let original = RaftEntry::new(
+            42,
+            7,
+            RaftEntryType::Normal,
+            Bytes::from_static(b"payload"),
+            Bytes::from_static(b"ctx"),
+        );
+        let proto = entry_to_proto(original.clone());
+        let back = entry_from_proto(proto);
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn entry_roundtrip_conf_change() {
+        let original = RaftEntry::new(
+            100,
+            3,
+            RaftEntryType::ConfChange,
+            Bytes::from_static(b"conf-change-payload"),
+            Bytes::new(),
+        );
+        let proto = entry_to_proto(original.clone());
+        let back = entry_from_proto(proto);
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn entry_v2_conf_change_folds_to_conf_change() {
+        // raft-engine can hand us an `EntryConfChangeV2` entry on
+        // read (older logs written by an upstream raft-rs at a
+        // different EntryType). The backend contract collapses V1
+        // and V2 onto the single mango variant.
+        let mut proto = ::raft::eraftpb::Entry::default();
+        proto.set_entry_type(::raft::eraftpb::EntryType::EntryConfChangeV2);
+        proto.term = 1;
+        proto.index = 1;
+        proto.data = Bytes::from_static(b"v2");
+        let mango = entry_from_proto(proto);
+        assert_eq!(mango.entry_type, RaftEntryType::ConfChange);
+    }
+
+    #[test]
+    fn hard_state_roundtrip() {
+        let hs = HardState::new(5, 7, 42);
+        let proto = hard_state_to_proto(hs);
+        let back = hard_state_from_proto(&proto);
+        assert_eq!(back, hs);
+    }
+
+    #[test]
+    fn hard_state_default_roundtrip() {
+        let hs = HardState::default();
+        let proto = hard_state_to_proto(hs);
+        let back = hard_state_from_proto(&proto);
+        assert_eq!(back, HardState::default());
+    }
+
+    #[test]
+    fn snapshot_metadata_roundtrip_empty_conf_state() {
+        let m = RaftSnapshotMetadata::new(100, 9, Bytes::new());
+        let proto = snapshot_metadata_to_proto(&m).unwrap();
+        let back = snapshot_metadata_from_proto(proto).unwrap();
+        assert_eq!(back, m);
+    }
+
+    #[test]
+    fn snapshot_metadata_roundtrip_populated_conf_state() {
+        // Build a real ConfState, encode to bytes, hand it to the
+        // mango surface, roundtrip, and assert the encoded bytes
+        // are semantically identical (proto equality on the decoded
+        // struct — not byte-equality, because rust-protobuf doesn't
+        // guarantee canonical field ordering on re-encode).
+        let mut cs = ::raft::eraftpb::ConfState::default();
+        cs.mut_voters().extend([1_u64, 2, 3]);
+        cs.mut_learners().extend([4_u64]);
+        let encoded = cs.write_to_bytes().unwrap();
+
+        let m = RaftSnapshotMetadata::new(50, 3, Bytes::from(encoded));
+        let proto = snapshot_metadata_to_proto(&m).unwrap();
+        assert_eq!(proto.index, 50);
+        assert_eq!(proto.term, 3);
+        assert_eq!(proto.get_conf_state().get_voters(), &[1, 2, 3]);
+        assert_eq!(proto.get_conf_state().get_learners(), &[4]);
+
+        // Round-trip: proto → mango → proto → decode.
+        let mango = snapshot_metadata_from_proto(proto).unwrap();
+        let re_proto = snapshot_metadata_to_proto(&mango).unwrap();
+        assert_eq!(re_proto.get_conf_state().get_voters(), &[1, 2, 3]);
+        assert_eq!(re_proto.get_conf_state().get_learners(), &[4]);
+    }
+
+    #[test]
+    fn snapshot_metadata_corruption_surfaces_as_backend_error() {
+        // Garbage `conf_state` bytes must produce `Corruption`, not
+        // a panic or silent drop.
+        let m = RaftSnapshotMetadata::new(1, 1, Bytes::from_static(b"\xff\xff\xff\xff"));
+        let err = snapshot_metadata_to_proto(&m).expect_err("garbage bytes must fail to decode");
+        assert!(
+            matches!(err, BackendError::Corruption(_)),
+            "expected Corruption, got {err:?}"
+        );
+    }
+}

--- a/crates/mango-storage/src/raft_engine/mod.rs
+++ b/crates/mango-storage/src/raft_engine/mod.rs
@@ -40,7 +40,7 @@
 
 use std::future::Future;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -126,6 +126,18 @@ struct Inner {
     /// concurrent in-flight operations see one consistent "closed"
     /// cut.
     closed: AtomicBool,
+    /// Index of the most recently installed snapshot (0 when no
+    /// snapshot has been installed). Consulted by [`Self::first_index`]
+    /// and [`Self::last_index`] so the trait's
+    /// "`first_index() == snapshot.index + 1` after install" contract
+    /// holds even when all log entries have been compacted out.
+    ///
+    /// raft-engine itself has no notion of a snapshot cursor — its
+    /// `first_index` / `last_index` only report the bounds of extant
+    /// log entries. We persist the cursor alongside the snapshot
+    /// metadata under [`SNAPSHOT_META_KEY`] and cache it here to keep
+    /// index lookups O(1) on the hot path.
+    snapshot_index: AtomicU64,
     /// Data directory; captured at open time for error messages and
     /// future diagnostics. Intentionally unused on the hot path.
     #[allow(dead_code)]
@@ -145,10 +157,21 @@ impl RaftEngineLogStore {
         let data_dir = cfg.data_dir.clone();
         let engine_cfg = cfg.into_engine_config();
         let engine = ::raft_engine::Engine::open(engine_cfg).map_err(map_engine_error)?;
+
+        // Recover the snapshot cursor from SNAPSHOT_META_KEY so
+        // `first_index` / `last_index` honor the
+        // "install_snapshot → first_index == snap.index+1" invariant
+        // across restarts.
+        let snap_proto: Option<::raft::eraftpb::SnapshotMetadata> = engine
+            .get_message(RAFT_GROUP_ID, SNAPSHOT_META_KEY)
+            .map_err(map_engine_error)?;
+        let snapshot_index = snap_proto.map_or(0, |p| p.index);
+
         Ok(Self {
             inner: Arc::new(Inner {
                 engine: Mutex::new(Some(Arc::new(engine))),
                 closed: AtomicBool::new(false),
+                snapshot_index: AtomicU64::new(snapshot_index),
                 data_dir,
             }),
         })
@@ -236,11 +259,14 @@ impl RaftEngineLogStore {
         };
 
         // Strict consecutivity: first.index == last_index + 1.
-        // Truncation lives in Phase 3 (see module docstring).
-        let expected = engine
-            .last_index(RAFT_GROUP_ID)
-            .unwrap_or(0)
-            .wrapping_add(1);
+        // `last_index` here is the trait-level last_index (max of the
+        // engine's last entry and any installed-snapshot cursor), so
+        // the first post-snapshot append after an empty-log reopen
+        // expects `snapshot.index + 1` rather than `1`. Truncation
+        // lives in Phase 3 (see module docstring).
+        let engine_last = engine.last_index(RAFT_GROUP_ID).unwrap_or(0);
+        let snap_last = self.inner.snapshot_index.load(Ordering::Acquire);
+        let expected = engine_last.max(snap_last).wrapping_add(1);
         if first.index != expected {
             return Err(BackendError::Other(format!(
                 "non-consecutive append: expected index {expected}, got {actual}",
@@ -311,10 +337,14 @@ impl RaftLogStore for RaftEngineLogStore {
         if low == high {
             return Ok(Vec::new());
         }
+        // Range bounds are checked against the engine's actual entry
+        // bounds (NOT the snapshot-adjusted trait-level indices) —
+        // reading entries that have been compacted out must fail
+        // even if `first_index()` reports them as notionally present
+        // (post-snapshot, `first_index() == snap.index + 1` but the
+        // engine may have nothing to return).
         let first = engine.first_index(RAFT_GROUP_ID).unwrap_or(0);
         let last = engine.last_index(RAFT_GROUP_ID).unwrap_or(0);
-        // `first_index` is `None` iff no entries exist; in that case
-        // `first == 0` and any non-empty range is out of bounds.
         if first == 0 || low < first || high > last.wrapping_add(1) {
             return Err(BackendError::InvalidRange(
                 "range outside [first_index, last_index+1]",
@@ -332,12 +362,30 @@ impl RaftLogStore for RaftEngineLogStore {
 
     fn last_index(&self) -> Result<u64, BackendError> {
         let engine = self.engine_handle()?;
-        Ok(engine.last_index(RAFT_GROUP_ID).unwrap_or(0))
+        // Max of the engine's reported last entry and any installed
+        // snapshot cursor, so the
+        // "`last_index() >= snapshot.index` after install" invariant
+        // holds even when all log entries have been compacted out.
+        let engine_last = engine.last_index(RAFT_GROUP_ID).unwrap_or(0);
+        let snap_last = self.inner.snapshot_index.load(Ordering::Acquire);
+        Ok(engine_last.max(snap_last))
     }
 
     fn first_index(&self) -> Result<u64, BackendError> {
         let engine = self.engine_handle()?;
-        Ok(engine.first_index(RAFT_GROUP_ID).unwrap_or(0))
+        // If the engine has any extant entries, its first_index is
+        // authoritative (it is always `>= snap_index + 1` because
+        // install_snapshot compacts through `snap_index`). When the
+        // engine is empty post-snapshot, fall through to
+        // `snap_index + 1` so the trait's
+        // "`first_index() == snapshot.index + 1` after install"
+        // invariant holds.
+        let engine_first = engine.first_index(RAFT_GROUP_ID);
+        if let Some(idx) = engine_first {
+            return Ok(idx);
+        }
+        let snap = self.inner.snapshot_index.load(Ordering::Acquire);
+        Ok(if snap == 0 { 0 } else { snap.wrapping_add(1) })
     }
 
     fn compact(&self, idx: u64) -> impl Future<Output = Result<(), BackendError>> + Send {
@@ -372,6 +420,7 @@ impl RaftLogStore for RaftEngineLogStore {
             let idx = snapshot.index;
             Ok((engine, proto, idx))
         })();
+        let inner = self.inner.clone();
 
         async move {
             let (engine, proto, idx) = prologue?;
@@ -380,9 +429,16 @@ impl RaftLogStore for RaftEngineLogStore {
                 batch
                     .put_message(RAFT_GROUP_ID, SNAPSHOT_META_KEY.to_vec(), &proto)
                     .map_err(map_engine_error)?;
+                // `Command::Compact { index: N }` removes entries with
+                // `idx < N`. To discard every entry AT OR BEFORE
+                // `snapshot.index` (per the trait contract: entries
+                // strictly before `snapshot.index + 1` may be
+                // discarded), pass `snapshot.index + 1`.
                 batch.add_command(
                     RAFT_GROUP_ID,
-                    ::raft_engine::Command::Compact { index: idx },
+                    ::raft_engine::Command::Compact {
+                        index: idx.wrapping_add(1),
+                    },
                 );
                 engine
                     .write(&mut batch, /*sync=*/ true)
@@ -390,7 +446,23 @@ impl RaftLogStore for RaftEngineLogStore {
                     .map_err(map_engine_error)
             })
             .await
-            .map_err(|e| map_join_error(&e))?
+            .map_err(|e| map_join_error(&e))??;
+
+            // Cache the cursor only after the durable write succeeded.
+            // Monotonic update: never regress on a stale install.
+            let mut cur = inner.snapshot_index.load(Ordering::Acquire);
+            while idx > cur {
+                match inner.snapshot_index.compare_exchange_weak(
+                    cur,
+                    idx,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => break,
+                    Err(observed) => cur = observed,
+                }
+            }
+            Ok(())
         }
     }
 

--- a/crates/mango-storage/src/raft_engine/mod.rs
+++ b/crates/mango-storage/src/raft_engine/mod.rs
@@ -1,0 +1,557 @@
+//! `raft-engine`-backed [`RaftLogStore`](crate::RaftLogStore) impl.
+//!
+//! The public entry points are [`RaftEngineLogStore`] and the
+//! companion [`RaftEngineConfig`]. Supporting modules:
+//!
+//! * [`config`] — public configuration surface; re-exports
+//!   [`ReadableSize`] and [`RecoveryMode`] from raft-engine for
+//!   callers that do not want to import the engine crate directly.
+//! * [`convert`] — conversions between mango types
+//!   ([`crate::RaftEntry`], [`crate::HardState`],
+//!   [`crate::RaftSnapshotMetadata`]) and the `raft::eraftpb::*`
+//!   protobuf types raft-engine persists.
+//! * [`EntryMessageExt`] — the single [`::raft_engine::MessageExt`]
+//!   impl used by the engine's `add_entries` / `fetch_entries_to`
+//!   APIs. Supplied locally because raft-engine ships its own impl
+//!   only in its `#[cfg(test)]` tree.
+//!
+//! # Close-always-before-drop invariant
+//!
+//! [`::raft_engine::Engine::drop`](https://docs.rs/raft-engine/0.4.2/raft_engine/engine/struct.Engine.html)
+//! unconditionally joins its background purge/rewrite threads and
+//! panics if any of them errored out (engine.rs:441-446 in the
+//! humancto fork, unchanged from upstream). That is an upstream bug
+//! we cannot fix from here, so **every caller MUST invoke
+//! [`RaftEngineLogStore::close`] before the handle drops**. Tests use
+//! scope-guards to enforce this; production callers in `mango-raft`
+//! will do the same inside their shutdown path.
+//!
+//! # Truncation lives above this layer
+//!
+//! raft-rs's `Storage::append` contract says the storage MUST
+//! truncate already-present entries when a new leader sends entries
+//! at overlapping indices. Phase 1 [`RaftLogStore::append`] REJECTS
+//! non-consecutive appends with [`BackendError::Other`]. The
+//! buffering + `compact + append` adapter that handles truncation
+//! lives in Phase 3 (`mango-raft`). This mirrors `TiKV`'s architecture:
+//! the engine stays pure append-only; the raft-rs adapter owns
+//! truncation. See `.planning/raft-engine-logstore.plan.md`
+//! §"Non-goals" for the full rationale.
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::backend::{BackendError, HardState, RaftEntry, RaftLogStore, RaftSnapshotMetadata};
+
+mod config;
+mod convert;
+
+pub use config::{RaftEngineConfig, ReadableSize, RecoveryMode};
+
+/// Hard-coded Raft group id. Phase 1 runs a single Raft group;
+/// multi-raft fan-out lands in Phase 10 (see ROADMAP). The const is
+/// `pub(crate)` so follow-up modules (e.g. crash-recovery tests)
+/// share the same id without re-declaring it.
+pub(crate) const RAFT_GROUP_ID: u64 = 1;
+
+/// Key under which the current [`HardState`] is persisted.
+/// raft-engine reserves the `__` prefix (`INTERNAL_KEY_PREFIX` in
+/// raft-engine/src/lib.rs); keys outside that range are free. `b"hs"`
+/// is readable in a hexdump and distinct from
+/// [`SNAPSHOT_META_KEY`].
+const HARD_STATE_KEY: &[u8] = b"hs";
+
+/// Key under which the current snapshot metadata is persisted. Same
+/// reserved-prefix rules as [`HARD_STATE_KEY`].
+const SNAPSHOT_META_KEY: &[u8] = b"snap_meta";
+
+/// `MessageExt` impl for `raft::eraftpb::Entry`. raft-engine's
+/// `add_entries<M: MessageExt>` / `fetch_entries_to<M: MessageExt>`
+/// APIs are generic over this trait so they can probe the `index` of
+/// any protobuf-flavored entry type; raft-engine ships the impl only
+/// in its `#[cfg(test)]` tree (raft-engine/src/lib.rs:226), so every
+/// downstream must supply its own.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EntryMessageExt;
+
+impl ::raft_engine::MessageExt for EntryMessageExt {
+    type Entry = ::raft::eraftpb::Entry;
+
+    fn index(e: &Self::Entry) -> u64 {
+        e.index
+    }
+}
+
+/// raft-engine-backed implementation of [`RaftLogStore`]. Cheaply
+/// cloneable (`Arc<Inner>` internally); every clone shares the same
+/// engine handle and `close` state.
+///
+/// See the [module docstring](self) for the
+/// close-always-before-drop invariant and the Phase 3 truncation
+/// deferral.
+#[derive(Clone)]
+pub struct RaftEngineLogStore {
+    inner: Arc<Inner>,
+}
+
+impl std::fmt::Debug for RaftEngineLogStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // raft-engine's `Engine` does not implement `Debug`; surface
+        // the operator-relevant state without leaking engine
+        // internals.
+        f.debug_struct("RaftEngineLogStore")
+            .field("data_dir", &self.inner.data_dir)
+            .field("closed", &self.inner.closed.load(Ordering::Acquire))
+            .finish()
+    }
+}
+
+struct Inner {
+    /// `Arc<Engine>` because every engine method (`write`,
+    /// `fetch_entries_to`, `get_message`, `first_index`,
+    /// `last_index`) takes `&self`. The `Mutex<Option<_>>` wrapper
+    /// exists ONLY so [`RaftEngineLogStore::close`] can
+    /// deterministically drop the last reference in-handle; normal
+    /// call paths hold the mutex for the clone only.
+    ///
+    /// Not a `RwLock`: there is no `&mut self` operation on `Engine`
+    /// (no equivalent of `redb::Database::compact`).
+    engine: Mutex<Option<Arc<::raft_engine::Engine>>>,
+    /// `true` once `close` has returned `Ok(())`. Checked via
+    /// `load(Acquire)` at the top of every public method so
+    /// concurrent in-flight operations see one consistent "closed"
+    /// cut.
+    closed: AtomicBool,
+    /// Data directory; captured at open time for error messages and
+    /// future diagnostics. Intentionally unused on the hot path.
+    #[allow(dead_code)]
+    data_dir: PathBuf,
+}
+
+impl RaftEngineLogStore {
+    /// Open (or create) a raft-engine log store under
+    /// `cfg.data_dir`. raft-engine itself creates missing
+    /// directories, so no pre-flight `create_dir_all` is required.
+    ///
+    /// # Errors
+    ///
+    /// Any engine-level error (I/O, corruption, invalid argument) is
+    /// translated through [`map_engine_error`].
+    pub fn open(cfg: RaftEngineConfig) -> Result<Self, BackendError> {
+        let data_dir = cfg.data_dir.clone();
+        let engine_cfg = cfg.into_engine_config();
+        let engine = ::raft_engine::Engine::open(engine_cfg).map_err(map_engine_error)?;
+        Ok(Self {
+            inner: Arc::new(Inner {
+                engine: Mutex::new(Some(Arc::new(engine))),
+                closed: AtomicBool::new(false),
+                data_dir,
+            }),
+        })
+    }
+
+    /// Idempotent close. Drops the engine handle, which causes
+    /// raft-engine to join its background threads. Subsequent calls
+    /// return `Ok(())` without side-effect.
+    ///
+    /// **Must be called before the last `RaftEngineLogStore` clone
+    /// is dropped** — see the close-always-before-drop invariant in
+    /// the module docstring.
+    ///
+    /// # Errors
+    ///
+    /// Currently never returns `Err`; reserved for a future
+    /// graceful-shutdown hook. Returning `Result` keeps the trait
+    /// door open if raft-engine ever exposes a fallible close.
+    pub fn close(&self) -> Result<(), BackendError> {
+        if self
+            .inner
+            .closed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            // Drop the last Arc<Engine> reference held inside the
+            // handle. If any other `clone()` is still live, this
+            // does NOT close the engine — but every method on this
+            // type checks `closed` first and short-circuits with
+            // `BackendError::Closed`, so no further operations will
+            // run against the engine from this type.
+            let mut guard = self.inner.engine.lock();
+            *guard = None;
+        }
+        Ok(())
+    }
+
+    /// Explicit purge of old log files beyond the configured
+    /// threshold. Surfaced on the public type because
+    /// [`RaftEngineConfig::purge_threshold`] would otherwise be an
+    /// orphaned knob — raft-engine does not purge automatically.
+    ///
+    /// Returns the set of Raft group ids that still hold references
+    /// into the oldest active file (empty in the single-group
+    /// Phase 1 layout under normal operation).
+    ///
+    /// # Errors
+    ///
+    /// Engine-level errors translate through [`map_engine_error`].
+    pub fn purge_expired_files(&self) -> Result<Vec<u64>, BackendError> {
+        let engine = self.engine_handle()?;
+        engine.purge_expired_files().map_err(map_engine_error)
+    }
+
+    /// Clone the `Arc<Engine>` or return [`BackendError::Closed`].
+    /// Factored because every method repeats the same check. The
+    /// mutex is held for the clone only.
+    fn engine_handle(&self) -> Result<Arc<::raft_engine::Engine>, BackendError> {
+        if self.inner.closed.load(Ordering::Acquire) {
+            return Err(BackendError::Closed);
+        }
+        self.inner
+            .engine
+            .lock()
+            .as_ref()
+            .cloned()
+            .ok_or(BackendError::Closed)
+    }
+
+    /// Validate and convert an append batch. Returns `Ok(None)` for
+    /// the empty-input fast path (no `spawn_blocking` needed); returns
+    /// `Ok(Some((engine, batch)))` ready for `engine.write` on any
+    /// non-empty input; returns `Err` for a closed store or a
+    /// consecutivity violation. Factored out of [`Self::append`] so
+    /// the synchronous validation path stays clippy-clean without
+    /// breaking the `async fn` return type.
+    #[allow(clippy::type_complexity)]
+    fn prepare_append(
+        &self,
+        entries: &[RaftEntry],
+    ) -> Result<Option<(Arc<::raft_engine::Engine>, ::raft_engine::LogBatch)>, BackendError> {
+        let engine = self.engine_handle()?;
+        let Some((first, rest)) = entries.split_first() else {
+            return Ok(None);
+        };
+
+        // Strict consecutivity: first.index == last_index + 1.
+        // Truncation lives in Phase 3 (see module docstring).
+        let expected = engine
+            .last_index(RAFT_GROUP_ID)
+            .unwrap_or(0)
+            .wrapping_add(1);
+        if first.index != expected {
+            return Err(BackendError::Other(format!(
+                "non-consecutive append: expected index {expected}, got {actual}",
+                actual = first.index,
+            )));
+        }
+
+        // Strict monotonic-by-one within the batch. raft-rs
+        // guarantees this upstream; the defensive check catches
+        // caller bugs with a readable message instead of letting
+        // raft-engine's panic-on-debug-assert fire.
+        let mut prev = first.index;
+        for entry in rest {
+            let next = prev.wrapping_add(1);
+            if entry.index != next {
+                return Err(BackendError::Other(format!(
+                    "non-consecutive entries in batch: {prev} -> {curr}",
+                    curr = entry.index,
+                )));
+            }
+            prev = entry.index;
+        }
+
+        let protos: Vec<::raft::eraftpb::Entry> = entries
+            .iter()
+            .cloned()
+            .map(convert::entry_to_proto)
+            .collect();
+
+        let mut batch = ::raft_engine::LogBatch::default();
+        batch
+            .add_entries::<EntryMessageExt>(RAFT_GROUP_ID, &protos)
+            .map_err(map_engine_error)?;
+
+        Ok(Some((engine, batch)))
+    }
+}
+
+impl RaftLogStore for RaftEngineLogStore {
+    fn append(
+        &self,
+        entries: &[RaftEntry],
+    ) -> impl Future<Output = Result<(), BackendError>> + Send {
+        // Sync prologue: validate, convert, build the batch. All the
+        // work that can fail on caller input happens here so the
+        // async block only deals with engine I/O.
+        let prepared = self.prepare_append(entries);
+        async move {
+            let Some((engine, mut batch)) = prepared? else {
+                return Ok(());
+            };
+            tokio::task::spawn_blocking(move || {
+                engine
+                    .write(&mut batch, /*sync=*/ true)
+                    .map(|_bytes| ())
+                    .map_err(map_engine_error)
+            })
+            .await
+            .map_err(|e| map_join_error(&e))?
+        }
+    }
+
+    fn entries(&self, low: u64, high: u64) -> Result<Vec<RaftEntry>, BackendError> {
+        let engine = self.engine_handle()?;
+        if low > high {
+            return Err(BackendError::InvalidRange("low > high"));
+        }
+        if low == high {
+            return Ok(Vec::new());
+        }
+        let first = engine.first_index(RAFT_GROUP_ID).unwrap_or(0);
+        let last = engine.last_index(RAFT_GROUP_ID).unwrap_or(0);
+        // `first_index` is `None` iff no entries exist; in that case
+        // `first == 0` and any non-empty range is out of bounds.
+        if first == 0 || low < first || high > last.wrapping_add(1) {
+            return Err(BackendError::InvalidRange(
+                "range outside [first_index, last_index+1]",
+            ));
+        }
+        // Capacity is advisory; clamp the u64 span to usize rather
+        // than propagate a try_from error for a Vec allocation.
+        let span = usize::try_from(high.saturating_sub(low)).unwrap_or(usize::MAX);
+        let mut out = Vec::with_capacity(span);
+        engine
+            .fetch_entries_to::<EntryMessageExt>(RAFT_GROUP_ID, low, high, None, &mut out)
+            .map_err(map_engine_error)?;
+        Ok(out.into_iter().map(convert::entry_from_proto).collect())
+    }
+
+    fn last_index(&self) -> Result<u64, BackendError> {
+        let engine = self.engine_handle()?;
+        Ok(engine.last_index(RAFT_GROUP_ID).unwrap_or(0))
+    }
+
+    fn first_index(&self) -> Result<u64, BackendError> {
+        let engine = self.engine_handle()?;
+        Ok(engine.first_index(RAFT_GROUP_ID).unwrap_or(0))
+    }
+
+    fn compact(&self, idx: u64) -> impl Future<Output = Result<(), BackendError>> + Send {
+        let engine = self.engine_handle();
+        async move {
+            let engine = engine?;
+            tokio::task::spawn_blocking(move || {
+                // `Engine::compact_to` is `sync=false`; hand-roll a
+                // batch so durability holds on return.
+                let mut batch = ::raft_engine::LogBatch::default();
+                batch.add_command(
+                    RAFT_GROUP_ID,
+                    ::raft_engine::Command::Compact { index: idx },
+                );
+                engine
+                    .write(&mut batch, /*sync=*/ true)
+                    .map(|_bytes| ())
+                    .map_err(map_engine_error)
+            })
+            .await
+            .map_err(|e| map_join_error(&e))?
+        }
+    }
+
+    fn install_snapshot(
+        &self,
+        snapshot: &RaftSnapshotMetadata,
+    ) -> impl Future<Output = Result<(), BackendError>> + Send {
+        let prologue = (|| -> Result<_, BackendError> {
+            let engine = self.engine_handle()?;
+            let proto = convert::snapshot_metadata_to_proto(snapshot)?;
+            let idx = snapshot.index;
+            Ok((engine, proto, idx))
+        })();
+
+        async move {
+            let (engine, proto, idx) = prologue?;
+            tokio::task::spawn_blocking(move || {
+                let mut batch = ::raft_engine::LogBatch::default();
+                batch
+                    .put_message(RAFT_GROUP_ID, SNAPSHOT_META_KEY.to_vec(), &proto)
+                    .map_err(map_engine_error)?;
+                batch.add_command(
+                    RAFT_GROUP_ID,
+                    ::raft_engine::Command::Compact { index: idx },
+                );
+                engine
+                    .write(&mut batch, /*sync=*/ true)
+                    .map(|_bytes| ())
+                    .map_err(map_engine_error)
+            })
+            .await
+            .map_err(|e| map_join_error(&e))?
+        }
+    }
+
+    fn save_hard_state(
+        &self,
+        hs: &HardState,
+    ) -> impl Future<Output = Result<(), BackendError>> + Send {
+        let engine = self.engine_handle();
+        let proto = convert::hard_state_to_proto(*hs);
+        async move {
+            let engine = engine?;
+            tokio::task::spawn_blocking(move || {
+                let mut batch = ::raft_engine::LogBatch::default();
+                batch
+                    .put_message(RAFT_GROUP_ID, HARD_STATE_KEY.to_vec(), &proto)
+                    .map_err(map_engine_error)?;
+                engine
+                    .write(&mut batch, /*sync=*/ true)
+                    .map(|_bytes| ())
+                    .map_err(map_engine_error)
+            })
+            .await
+            .map_err(|e| map_join_error(&e))?
+        }
+    }
+
+    fn hard_state(&self) -> Result<HardState, BackendError> {
+        let engine = self.engine_handle()?;
+        let proto: Option<::raft::eraftpb::HardState> = engine
+            .get_message(RAFT_GROUP_ID, HARD_STATE_KEY)
+            .map_err(map_engine_error)?;
+        Ok(proto
+            .map(|p| convert::hard_state_from_proto(&p))
+            .unwrap_or_default())
+    }
+}
+
+/// Translate a [`::raft_engine::Error`] into [`BackendError`]. The
+/// trait contract forbids leaking engine types (ADR 0002 §6 design
+/// point 1). Each arm preserves the upstream string so operators can
+/// correlate failures with raft-engine logs.
+fn map_engine_error(e: ::raft_engine::Error) -> BackendError {
+    match e {
+        ::raft_engine::Error::Io(err) => BackendError::Io(err),
+        ::raft_engine::Error::Corruption(s) => BackendError::Corruption(s),
+        ::raft_engine::Error::InvalidArgument(s) => {
+            BackendError::Other(format!("raft-engine invalid argument: {s}"))
+        }
+        ::raft_engine::Error::Codec(err) => {
+            BackendError::Corruption(format!("raft-engine codec: {err}"))
+        }
+        ::raft_engine::Error::Protobuf(err) => {
+            BackendError::Corruption(format!("raft-engine protobuf: {err}"))
+        }
+        ::raft_engine::Error::TryAgain(s) => {
+            BackendError::Other(format!("raft-engine try-again: {s}"))
+        }
+        ::raft_engine::Error::EntryCompacted => {
+            BackendError::InvalidRange("entry already compacted")
+        }
+        ::raft_engine::Error::EntryNotFound => BackendError::InvalidRange("entry not found"),
+        ::raft_engine::Error::Full => BackendError::Other("raft-engine: log batch full".to_owned()),
+        ::raft_engine::Error::Other(err) => BackendError::Other(format!("raft-engine: {err}")),
+    }
+}
+
+/// Map a `tokio::task::JoinError` onto [`BackendError`]. Matches the
+/// redb-side shape so operators see the same rendered prefix.
+fn map_join_error(e: &tokio::task::JoinError) -> BackendError {
+    BackendError::Other(format!("spawn_blocking join: {e}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::backend::RaftEntryType;
+    use bytes::Bytes;
+    use tempfile::TempDir;
+
+    fn open_fresh() -> (RaftEngineLogStore, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let cfg = RaftEngineConfig::new(dir.path().to_path_buf());
+        let store = RaftEngineLogStore::open(cfg).unwrap();
+        (store, dir)
+    }
+
+    #[test]
+    fn empty_store_indices_are_zero() {
+        let (store, _dir) = open_fresh();
+        assert_eq!(store.last_index().unwrap(), 0);
+        assert_eq!(store.first_index().unwrap(), 0);
+        assert_eq!(store.hard_state().unwrap(), HardState::default());
+        store.close().unwrap();
+    }
+
+    #[test]
+    fn map_engine_error_preserves_io_kind() {
+        let e = ::raft_engine::Error::Io(std::io::Error::other("disk boom"));
+        match map_engine_error(e) {
+            BackendError::Io(inner) => {
+                assert!(format!("{inner}").contains("disk boom"));
+            }
+            other => panic!("expected Io, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_engine_error_classifies_corruption() {
+        let e = ::raft_engine::Error::Corruption("crc mismatch".into());
+        match map_engine_error(e) {
+            BackendError::Corruption(s) => assert_eq!(s, "crc mismatch"),
+            other => panic!("expected Corruption, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_engine_error_classifies_entry_compacted_as_invalid_range() {
+        let e = ::raft_engine::Error::EntryCompacted;
+        match map_engine_error(e) {
+            BackendError::InvalidRange(_) => {}
+            other => panic!("expected InvalidRange, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn append_empty_is_noop() {
+        let (store, _dir) = open_fresh();
+        store.append(&[]).await.unwrap();
+        assert_eq!(store.last_index().unwrap(), 0);
+        store.close().unwrap();
+    }
+
+    #[tokio::test]
+    async fn append_rejects_non_consecutive() {
+        let (store, _dir) = open_fresh();
+        let bad = RaftEntry::new(
+            5,
+            1,
+            RaftEntryType::Normal,
+            Bytes::from_static(b"x"),
+            Bytes::new(),
+        );
+        let err = store.append(std::slice::from_ref(&bad)).await.unwrap_err();
+        match err {
+            BackendError::Other(msg) => {
+                assert!(msg.contains("expected index 1"), "got: {msg}");
+                assert!(msg.contains("got 5"), "got: {msg}");
+            }
+            other => panic!("expected Other, got {other:?}"),
+        }
+        store.close().unwrap();
+    }
+
+    #[tokio::test]
+    async fn closed_store_returns_closed_error() {
+        let (store, _dir) = open_fresh();
+        store.close().unwrap();
+        let err = store.last_index().unwrap_err();
+        assert!(matches!(err, BackendError::Closed), "got {err:?}");
+        // close is idempotent.
+        store.close().unwrap();
+    }
+}

--- a/crates/mango-storage/src/raft_engine/mod.rs
+++ b/crates/mango-storage/src/raft_engine/mod.rs
@@ -539,7 +539,13 @@ fn map_join_error(e: &tokio::task::JoinError) -> BackendError {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
+    // The async tests that exercise `append` use these; they are
+    // gated `#[cfg(not(madsim))]` below because `spawn_blocking` is
+    // not supported in the simulator. Mirror that gate on the imports
+    // so the madsim build doesn't emit `unused_imports`.
+    #[cfg(not(madsim))]
     use crate::backend::RaftEntryType;
+    #[cfg(not(madsim))]
     use bytes::Bytes;
     use tempfile::TempDir;
 
@@ -588,6 +594,13 @@ mod tests {
         }
     }
 
+    // The async tests below drive `append` / `save_hard_state`, which
+    // route through `tokio::task::spawn_blocking`. Under `--cfg
+    // madsim`, the simulator refuses to spawn OS threads; the full
+    // async surface is exercised by `tests/raft_engine_logstore.rs`
+    // (gated `#![cfg(not(madsim))]`) and the madsim-side smoke lives
+    // in `tests/raft_engine_madsim_smoke.rs`.
+    #[cfg(not(madsim))]
     #[tokio::test]
     async fn append_empty_is_noop() {
         let (store, _dir) = open_fresh();
@@ -596,6 +609,7 @@ mod tests {
         store.close().unwrap();
     }
 
+    #[cfg(not(madsim))]
     #[tokio::test]
     async fn append_rejects_non_consecutive() {
         let (store, _dir) = open_fresh();
@@ -617,6 +631,7 @@ mod tests {
         store.close().unwrap();
     }
 
+    #[cfg(not(madsim))]
     #[tokio::test]
     async fn closed_store_returns_closed_error() {
         let (store, _dir) = open_fresh();

--- a/crates/mango-storage/src/raft_engine/mod.rs
+++ b/crates/mango-storage/src/raft_engine/mod.rs
@@ -1,4 +1,4 @@
-//! `raft-engine`-backed [`RaftLogStore`](crate::RaftLogStore) impl.
+//! `raft-engine`-backed [`RaftLogStore`] impl.
 //!
 //! The public entry points are [`RaftEngineLogStore`] and the
 //! companion [`RaftEngineConfig`]. Supporting modules:
@@ -90,9 +90,8 @@ impl ::raft_engine::MessageExt for EntryMessageExt {
 /// cloneable (`Arc<Inner>` internally); every clone shares the same
 /// engine handle and `close` state.
 ///
-/// See the [module docstring](self) for the
-/// close-always-before-drop invariant and the Phase 3 truncation
-/// deferral.
+/// See the module docstring for the close-always-before-drop
+/// invariant and the Phase 3 truncation deferral.
 #[derive(Clone)]
 pub struct RaftEngineLogStore {
     inner: Arc<Inner>,
@@ -127,8 +126,8 @@ struct Inner {
     /// cut.
     closed: AtomicBool,
     /// Index of the most recently installed snapshot (0 when no
-    /// snapshot has been installed). Consulted by [`Self::first_index`]
-    /// and [`Self::last_index`] so the trait's
+    /// snapshot has been installed). Consulted by `first_index` and
+    /// `last_index` on [`RaftEngineLogStore`] so the trait's
     /// "`first_index() == snapshot.index + 1` after install" contract
     /// holds even when all log entries have been compacted out.
     ///
@@ -152,7 +151,8 @@ impl RaftEngineLogStore {
     /// # Errors
     ///
     /// Any engine-level error (I/O, corruption, invalid argument) is
-    /// translated through [`map_engine_error`].
+    /// translated through the internal `map_engine_error` helper
+    /// into [`BackendError`].
     pub fn open(cfg: RaftEngineConfig) -> Result<Self, BackendError> {
         let data_dir = cfg.data_dir.clone();
         let engine_cfg = cfg.into_engine_config();
@@ -220,7 +220,8 @@ impl RaftEngineLogStore {
     ///
     /// # Errors
     ///
-    /// Engine-level errors translate through [`map_engine_error`].
+    /// Engine-level errors translate through the internal
+    /// `map_engine_error` helper into [`BackendError`].
     pub fn purge_expired_files(&self) -> Result<Vec<u64>, BackendError> {
         let engine = self.engine_handle()?;
         engine.purge_expired_files().map_err(map_engine_error)

--- a/crates/mango-storage/tests/raft_engine_crash_recovery.rs
+++ b/crates/mango-storage/tests/raft_engine_crash_recovery.rs
@@ -1,0 +1,149 @@
+//! Crash-recovery test for [`mango_storage::RaftEngineLogStore`].
+//!
+//! This exercises the durability story the whole Raft-log surface
+//! depends on: a `sync=true` write must survive a SIGKILL of the
+//! writer process. A unit test can't cover this — the engine has to
+//! actually be running in a separate process that the OS tears down
+//! without a chance to run `Drop` or flush buffers.
+//!
+//! Pattern: the test binary re-executes itself with
+//! `--ignored --exact <worker-name> --nocapture`. The child opens a
+//! store under a path the parent passes via env var, writes 10
+//! entries + `hard_state` with `sync=true`, prints a marker to stdout,
+//! then sleeps forever. The parent reads the marker, sends SIGKILL,
+//! reopens the same path, and asserts the fsynced data survived.
+//!
+//! `#[cfg(unix)]` gates the whole file — SIGKILL semantics and
+//! `from_raw_fd` / signal numbers are Unix-only. On other platforms
+//! the file compiles to nothing.
+//!
+//! Under `--cfg madsim` this file is excluded — madsim does not
+//! emulate `fork` / `kill` semantics.
+
+#![cfg(all(unix, not(madsim)))]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::items_after_statements,
+    clippy::print_stdout
+)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+use mango_storage::{HardState, RaftEngineConfig, RaftEngineLogStore, RaftLogStore};
+
+const CHILD_DIR_ENV: &str = "MANGO_RAFT_CRASH_CHILD_DIR";
+const WRITES_DONE_MARKER: &str = "WRITES-DONE";
+
+/// Worker function that runs in the spawned child process. Writes
+/// data with `sync=true` then blocks forever so the parent can
+/// SIGKILL it mid-process (the Raft log state was already fsynced
+/// before the sleep).
+///
+/// Marked `#[ignore]` so `cargo test` won't run it directly; the
+/// parent test invokes it via `--ignored --exact`.
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "spawned by parent sigkill_after_append_preserves_fsynced_entries; do not run directly"]
+async fn crash_child_worker() {
+    let dir = std::env::var(CHILD_DIR_ENV).expect("child must receive target dir via env var");
+    let store = RaftEngineLogStore::open(RaftEngineConfig::new(dir.into())).expect("child open");
+
+    // 10 entries written with sync=true (the default for append in
+    // this impl — see `engine.write(&mut batch, /*sync=*/ true)`).
+    let batch: Vec<_> = (1_u64..=10)
+        .map(|i| {
+            mango_storage::RaftEntry::new(
+                i,
+                1,
+                mango_storage::RaftEntryType::Normal,
+                bytes::Bytes::copy_from_slice(&i.to_le_bytes()),
+                bytes::Bytes::new(),
+            )
+        })
+        .collect();
+    store.append(&batch).await.expect("child append");
+
+    // Hard state, also sync=true.
+    let hs = HardState::new(5, 7, 10);
+    store.save_hard_state(&hs).await.expect("child save_hs");
+
+    // Signal to the parent — MUST be printed AFTER all fsynced
+    // writes have returned. Flush explicitly so the line leaves the
+    // child's stdio buffer before we sleep.
+    println!("{WRITES_DONE_MARKER}");
+    std::io::stdout().flush().expect("flush");
+
+    // Park forever. The parent sends SIGKILL; `close()` is NEVER
+    // called here. That's the whole point of the test — we need the
+    // OS to tear down the engine without running `Drop`, simulating
+    // a real crash.
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+    }
+}
+
+/// Parent-side test: spawn the worker, wait for its "done" marker,
+/// SIGKILL it, then reopen the same directory and assert every
+/// `sync=true` write survived.
+#[test]
+fn sigkill_after_append_preserves_fsynced_entries() {
+    // tempfile::TempDir is fine here — the *parent* owns the
+    // directory; the child only writes into it, no lifetime issue.
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+
+    // Re-exec ourselves filtered to the worker test.
+    let exe = std::env::current_exe().expect("current_exe");
+    let mut child = Command::new(&exe)
+        .args(["--ignored", "--exact", "--nocapture", "crash_child_worker"])
+        .env(CHILD_DIR_ENV, tmp.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn child");
+
+    // Wait for the "writes done" marker on stdout.
+    let stdout = child.stdout.take().expect("child stdout");
+    let mut reader = BufReader::new(stdout);
+    let mut saw_marker = false;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).expect("read child stdout");
+        if n == 0 {
+            break; // EOF — child exited before printing marker.
+        }
+        if line.trim() == WRITES_DONE_MARKER {
+            saw_marker = true;
+            break;
+        }
+    }
+    assert!(saw_marker, "child did not print {WRITES_DONE_MARKER}");
+
+    // SIGKILL. `std::process::Child::kill` is documented to perform
+    // `kill(2)` with `SIGKILL` on Unix (stdlib docs). No cleanup, no
+    // `Drop`, no graceful close — which is the whole point of the
+    // test.
+    child.kill().expect("kill child");
+    let _ = child.wait().expect("wait child");
+
+    // Reopen the same path.
+    let store = RaftEngineLogStore::open(RaftEngineConfig::new(tmp.path().to_path_buf()))
+        .expect("parent reopen");
+
+    // sync=true on every write means no data loss. The engine may
+    // permit a trailing partial batch on `TolerateTailCorruption`
+    // recovery, but since our last fsynced write completed before
+    // the marker print, last_index MUST be at least 10.
+    assert!(
+        store.last_index().expect("last_index") >= 10,
+        "lost fsynced entries: last_index={}",
+        store.last_index().unwrap()
+    );
+    assert_eq!(store.hard_state().expect("hs"), HardState::new(5, 7, 10));
+
+    store.close().expect("parent close");
+}

--- a/crates/mango-storage/tests/raft_engine_logstore.rs
+++ b/crates/mango-storage/tests/raft_engine_logstore.rs
@@ -1,0 +1,329 @@
+//! Integration tests for [`mango_storage::RaftEngineLogStore`]
+//! (ROADMAP:818).
+//!
+//! Every test opens a real `raft-engine` under a `tempfile::TempDir`
+//! and exercises the [`mango_storage::RaftLogStore`] trait surface —
+//! the trait contract is what is verified, not the impl internals.
+//!
+//! All tests explicitly call `close()` before the handle drops per the
+//! close-always-before-drop invariant documented on
+//! [`mango_storage::RaftEngineLogStore`]; dropping without closing
+//! risks a background-thread join panic on the upstream `Drop` path.
+//!
+//! Under `--cfg madsim` this file is excluded — raft-engine runs real
+//! `fs2` file locks and real `fdatasync` which the simulator does not
+//! substitute. The madsim smoke lives in
+//! `raft_engine_madsim_smoke.rs`.
+
+#![cfg(not(madsim))]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_truncation
+)]
+
+use bytes::Bytes;
+use mango_storage::{
+    BackendError, HardState, RaftEngineConfig, RaftEngineLogStore, RaftEntry, RaftEntryType,
+    RaftLogStore, RaftSnapshotMetadata,
+};
+use tempfile::TempDir;
+
+fn open(dir: &TempDir) -> RaftEngineLogStore {
+    RaftEngineLogStore::open(RaftEngineConfig::new(dir.path().to_path_buf())).expect("open")
+}
+
+fn entry(index: u64, term: u64, data: &'static [u8]) -> RaftEntry {
+    RaftEntry::new(
+        index,
+        term,
+        RaftEntryType::Normal,
+        Bytes::from_static(data),
+        Bytes::new(),
+    )
+}
+
+fn make_batch(start: u64, count: u64, term: u64) -> Vec<RaftEntry> {
+    (0..count)
+        .map(|i| entry(start + i, term, b"payload"))
+        .collect()
+}
+
+// ---------- basic round-trip ----------------------------------------
+
+#[tokio::test]
+async fn open_append_read_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+
+    let batch = (1_u64..=5)
+        .map(|i| {
+            RaftEntry::new(
+                i,
+                1,
+                RaftEntryType::Normal,
+                Bytes::copy_from_slice(&i.to_le_bytes()),
+                Bytes::from_static(b"ctx"),
+            )
+        })
+        .collect::<Vec<_>>();
+    store.append(&batch).await.unwrap();
+
+    let back = store.entries(1, 6).unwrap();
+    assert_eq!(back.len(), 5);
+    for (i, e) in back.iter().enumerate() {
+        let expected_idx = u64::try_from(i).unwrap() + 1;
+        assert_eq!(e.index, expected_idx);
+        assert_eq!(e.term, 1);
+        assert_eq!(e.entry_type, RaftEntryType::Normal);
+        assert_eq!(e.data.as_ref(), &expected_idx.to_le_bytes());
+        assert_eq!(e.context.as_ref(), b"ctx");
+    }
+
+    assert_eq!(store.last_index().unwrap(), 5);
+    assert_eq!(store.first_index().unwrap(), 1);
+
+    store.close().unwrap();
+}
+
+#[test]
+fn empty_store_indices_are_zero() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    assert_eq!(store.last_index().unwrap(), 0);
+    assert_eq!(store.first_index().unwrap(), 0);
+    assert_eq!(store.hard_state().unwrap(), HardState::default());
+    store.close().unwrap();
+}
+
+// ---------- append validation ----------------------------------------
+
+#[tokio::test]
+async fn append_rejects_non_consecutive_first_entry() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    store.append(&[entry(1, 1, b"a")]).await.unwrap();
+    let bad = entry(3, 1, b"b");
+    let err = store.append(std::slice::from_ref(&bad)).await.unwrap_err();
+    match err {
+        BackendError::Other(msg) => {
+            assert!(msg.contains("expected index 2"), "got: {msg}");
+            assert!(msg.contains("got 3"), "got: {msg}");
+        }
+        other => panic!("expected Other, got {other:?}"),
+    }
+    store.close().unwrap();
+}
+
+#[tokio::test]
+async fn append_rejects_non_monotonic_within_batch() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    let bad = vec![entry(1, 1, b"a"), entry(3, 1, b"b")];
+    let err = store.append(&bad).await.unwrap_err();
+    assert!(matches!(err, BackendError::Other(_)), "got {err:?}");
+    store.close().unwrap();
+}
+
+#[tokio::test]
+async fn append_empty_is_noop() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    store.append(&[]).await.unwrap();
+    assert_eq!(store.last_index().unwrap(), 0);
+    store.close().unwrap();
+}
+
+// ---------- compact & snapshot --------------------------------------
+
+#[tokio::test]
+async fn compact_shifts_first_index_and_persists_across_reopen() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    store.append(&make_batch(1, 10, 1)).await.unwrap();
+    store.compact(5).await.unwrap();
+    assert_eq!(store.first_index().unwrap(), 5);
+    store.close().unwrap();
+
+    let store = open(&tmp);
+    assert_eq!(store.first_index().unwrap(), 5);
+    assert_eq!(store.last_index().unwrap(), 10);
+    store.close().unwrap();
+}
+
+#[tokio::test]
+async fn compact_beyond_last_is_noop_or_clamped() {
+    // raft-engine may either no-op or clamp when compacting past
+    // last_index. Both are acceptable — the trait contract is that no
+    // error surfaces and the store stays usable.
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    store.append(&make_batch(1, 5, 1)).await.unwrap();
+    store.compact(100).await.unwrap();
+    store.close().unwrap();
+}
+
+#[tokio::test]
+async fn install_snapshot_updates_first_index_and_persists() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    // Populate, then install a snapshot past all existing entries.
+    store.append(&make_batch(1, 50, 1)).await.unwrap();
+    let snap = RaftSnapshotMetadata::new(100, 3, Bytes::new());
+    store.install_snapshot(&snap).await.unwrap();
+
+    // Trait post-conditions: first_index == snap.index + 1,
+    // last_index >= snap.index.
+    assert_eq!(store.first_index().unwrap(), 101);
+    assert_eq!(store.last_index().unwrap(), 100);
+    store.close().unwrap();
+
+    // Reopen — the cursor is recovered from SNAPSHOT_META_KEY.
+    let store = open(&tmp);
+    assert_eq!(store.first_index().unwrap(), 101);
+    assert_eq!(store.last_index().unwrap(), 100);
+    // A fresh append MUST start at snap.index + 1.
+    store.append(&[entry(101, 3, b"post-snap")]).await.unwrap();
+    assert_eq!(store.last_index().unwrap(), 101);
+    store.close().unwrap();
+}
+
+// ---------- hard state ----------------------------------------------
+
+#[tokio::test]
+async fn save_and_read_hard_state_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    let hs = HardState::new(3, 7, 42);
+    store.save_hard_state(&hs).await.unwrap();
+    assert_eq!(store.hard_state().unwrap(), hs);
+    store.close().unwrap();
+}
+
+#[tokio::test]
+async fn hard_state_persists_across_reopen() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    let hs = HardState::new(5, 9, 100);
+    store.save_hard_state(&hs).await.unwrap();
+    store.close().unwrap();
+
+    let store = open(&tmp);
+    assert_eq!(store.hard_state().unwrap(), hs);
+    store.close().unwrap();
+}
+
+// ---------- lifecycle ------------------------------------------------
+
+#[tokio::test]
+async fn closed_store_returns_closed_error() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    store.close().unwrap();
+
+    assert!(matches!(store.last_index(), Err(BackendError::Closed)));
+    assert!(matches!(store.first_index(), Err(BackendError::Closed)));
+    assert!(matches!(store.entries(1, 2), Err(BackendError::Closed)));
+    assert!(matches!(store.hard_state(), Err(BackendError::Closed)));
+    assert!(matches!(
+        store.append(&[entry(1, 1, b"x")]).await,
+        Err(BackendError::Closed)
+    ));
+    assert!(matches!(store.compact(1).await, Err(BackendError::Closed)));
+    assert!(matches!(
+        store
+            .install_snapshot(&RaftSnapshotMetadata::new(1, 1, Bytes::new()))
+            .await,
+        Err(BackendError::Closed)
+    ));
+    assert!(matches!(
+        store.save_hard_state(&HardState::default()).await,
+        Err(BackendError::Closed)
+    ));
+
+    // close is idempotent.
+    store.close().unwrap();
+}
+
+#[tokio::test]
+async fn reopen_preserves_entries_and_hard_state() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    store.append(&make_batch(1, 7, 2)).await.unwrap();
+    let hs = HardState::new(2, 3, 7);
+    store.save_hard_state(&hs).await.unwrap();
+    store.close().unwrap();
+
+    let store = open(&tmp);
+    assert_eq!(store.first_index().unwrap(), 1);
+    assert_eq!(store.last_index().unwrap(), 7);
+    assert_eq!(store.hard_state().unwrap(), hs);
+    let back = store.entries(1, 8).unwrap();
+    assert_eq!(back.len(), 7);
+    for (i, e) in back.iter().enumerate() {
+        assert_eq!(e.index, u64::try_from(i).unwrap() + 1);
+        assert_eq!(e.term, 2);
+    }
+    store.close().unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_appenders_with_external_serialization() {
+    // Documents the contract: the RaftLogStore wrapper does NOT
+    // serialize concurrent appenders — the caller (raft-rs state
+    // machine) does. We serialize here by awaiting t1 before kicking
+    // off t2 and assert the combined log.
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    let s1 = store.clone();
+    let t1 = tokio::spawn(async move {
+        s1.append(&make_batch(1, 100, 1)).await.unwrap();
+    });
+    t1.await.unwrap();
+
+    let s2 = store.clone();
+    let t2 = tokio::spawn(async move {
+        s2.append(&make_batch(101, 100, 1)).await.unwrap();
+    });
+    t2.await.unwrap();
+
+    assert_eq!(store.last_index().unwrap(), 200);
+    assert_eq!(store.first_index().unwrap(), 1);
+    store.close().unwrap();
+}
+
+// ---------- range errors ---------------------------------------------
+
+#[tokio::test]
+async fn entries_rejects_inverted_range() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    store.append(&make_batch(1, 3, 1)).await.unwrap();
+    let err = store.entries(5, 2).unwrap_err();
+    assert!(matches!(err, BackendError::InvalidRange(_)), "got {err:?}");
+    store.close().unwrap();
+}
+
+#[tokio::test]
+async fn entries_rejects_out_of_bounds() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    store.append(&make_batch(1, 3, 1)).await.unwrap();
+    // last_index = 3, so (1, 5) is out of range.
+    let err = store.entries(1, 5).unwrap_err();
+    assert!(matches!(err, BackendError::InvalidRange(_)), "got {err:?}");
+    store.close().unwrap();
+}
+
+#[tokio::test]
+async fn entries_empty_range_is_ok() {
+    let tmp = TempDir::new().unwrap();
+    let store = open(&tmp);
+    store.append(&make_batch(1, 3, 1)).await.unwrap();
+    let out = store.entries(2, 2).unwrap();
+    assert!(out.is_empty());
+    store.close().unwrap();
+}

--- a/crates/mango-storage/tests/raft_engine_madsim_smoke.rs
+++ b/crates/mango-storage/tests/raft_engine_madsim_smoke.rs
@@ -1,0 +1,35 @@
+//! Sim-only compile-check for [`mango_storage::RaftEngineLogStore`],
+//! compiled (but NOT run) under `RUSTFLAGS="--cfg madsim"`.
+//!
+//! **This is a compile-check only, and deliberately has no
+//! `#[madsim::test]` — the sim cannot execute this crate.**
+//!
+//! Why: `raft_engine::Engine::open` spawns its own `std::thread`
+//! background purge/rewrite workers before returning. Under
+//! `--cfg madsim`, madsim's runtime intercepts `std::thread::spawn`
+//! and panics ("attempt to spawn a system thread in simulation") so
+//! the engine cannot be opened inside the simulator at all — never
+//! mind the further `tokio::task::spawn_blocking` hops our async
+//! methods rely on. The filesystem layer (`fs2::FileExt::lock_exclusive`,
+//! `fdatasync`) is also not substituted by madsim.
+//!
+//! What this file DOES buy us: the crate and its public surface
+//! monomorphize against madsim-tokio, catching any accidental
+//! breakage of the `#![cfg(not(madsim))]` gates or the tokio
+//! re-export path. The full async semantics live in
+//! `tests/raft_engine_logstore.rs` and
+//! `tests/raft_engine_crash_recovery.rs` under the default
+//! (non-madsim) build.
+
+#![cfg(madsim)]
+
+use mango_storage::{RaftEngineConfig, RaftEngineLogStore};
+
+/// Compile-only reference. Never called at runtime. The function
+/// signature forces monomorphization of [`RaftEngineLogStore::open`]
+/// against madsim-tokio so a future refactor that breaks the
+/// simulator build fails here.
+#[allow(dead_code)]
+fn _compile_check(cfg: RaftEngineConfig) -> Option<RaftEngineLogStore> {
+    RaftEngineLogStore::open(cfg).ok()
+}

--- a/deny.toml
+++ b/deny.toml
@@ -62,6 +62,7 @@ unsound = "all"
 ignore = [
     { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 formally unmaintained (the bincode team ceased development after a harassment incident; they consider 1.3.3 a complete version). Pulled in as a TRANSITIVE DEV-DEP of madsim 0.2.30 through mango-madsim-demo; not a runtime dep of any mango crate (sim scaffolding only). Blast radius: deterministic-simulator tests that serialize data the test itself controls — no untrusted input path. The advisory is informational (category `unmaintained`, no active CVE). Re-audit trigger: next madsim minor bump (0.3.x) — upstream may migrate to postcard/bitcode — or by 2026-10-23. See docs/madsim.md and .planning/0-5-3-madsim-dev-dep.plan.md." },
     { id = "RUSTSEC-2024-0437", reason = "protobuf 2.28.0 uncontrolled recursion (stack overflow on crafted input). Pulled TRANSITIVELY through raft-engine 0.4.2 → prometheus 0.13.4 (metrics, internal use only — not a network-facing deserializer). Patch is protobuf >= 3.7.2, but the dep is behind two upstream crates we do not control in this PR. Mitigations in the mango skeleton: (a) mango-storage ships no code that invokes protobuf parsing; (b) when mango-raft (Phase 1 impl PRs) starts calling raft-engine APIs that deserialize, those call sites will be under the `parser fuzz in the phase that introduces the parser` rule from ROADMAP's Reviewer's contract, with crafted-input fuzz corpora as the direct mitigation for this advisory class. Re-audit triggers (any): (1) raft-engine upstream bumps prometheus past the fixed protobuf version, (2) tikv/raft-engine#397 merges and we re-pin against a fresher master that may have bumped prometheus, (3) review-by 2026-10-23. See ADR 0002 §W5 and .planning/fork-raft-engine-lz4-verification.md." },
+    { id = "RUSTSEC-2025-0057", reason = "fxhash 0.2.1 formally unmaintained (repo stale, owner inactive; upstream recommends rustc-hash). Pulled TRANSITIVELY through raft v0.7.0 only (raft-rs's internal HashMap keying for ProgressTracker and similar bookkeeping — not a network-facing or untrusted-input surface). fxhash is a simple non-cryptographic hasher (≈100 LoC, no unsafe, no parser surface); there is no known CVE and no active vulnerability — the advisory is informational (category `unmaintained`). Mango never calls fxhash directly. Patch path requires upstream raft-rs migration to rustc-hash (tracked at tikv/raft-rs; they are gradually de-Prometheus-ing the 0.8 line). Re-audit triggers (any): (1) raft-rs 0.8+ release, (2) when we bump the workspace raft dep rev past the current SHA (53cf7a5b…), or (3) review-by 2026-10-23. See ROADMAP:818 and .planning/raft-engine-logstore.plan.md." },
 ]
 
 [bans]
@@ -83,6 +84,19 @@ skip = [
     { crate = "syn@1.0.109", reason = "raft-engine 0.4.2 transitive via older proc-macro crates (serde_repr, strum_macros 0.26, etc.); modern tree uses syn 2.x. Retires on raft-engine upstream refresh." },
     { crate = "thiserror@1.0.69", reason = "raft-engine 0.4.2 transitive via prometheus 0.13 holds thiserror 1.x; modern mango-storage uses thiserror 2.x directly. Retires on raft-engine upstream refresh (tikv/raft-engine#397 tree). Pinned at this specific version so a future transitive bump surfaces as a refreshable skip entry." },
     { crate = "thiserror-impl@1.0.69", reason = "Proc-macro half of thiserror 1.x; duplicated for the same raft-engine 0.4.2 transitive reason. Retires on raft-engine upstream refresh." },
+    # --- raft-rs 0.7.0 (SHA 53cf7a5b…) vs raft-engine 0.4.2 rand-ecosystem gap ---
+    # raft-rs master has migrated to rand 0.9.x while raft-engine 0.4.2's
+    # `fail` dep (fault-injection harness, dev/test-time) still pins rand 0.8.x,
+    # and madsim 0.2.30 also lands on rand 0.8.x. Both sides are transitive;
+    # neither is in mango's direct dep graph. No crypto/security surface —
+    # both versions are used for non-adversarial randomness (raft-rs's
+    # internal election-timer jitter, fail's random injection points,
+    # madsim's deterministic sim seeding). Retirement trigger: raft-engine
+    # upstream bump of `fail` past rand 0.9, or raft-rs backing off to 0.8
+    # (unlikely). Pinned to specific versions so a refresh surfaces the skip.
+    { crate = "rand@0.8.6", reason = "raft-engine 0.4.2 + madsim 0.2.30 transitive; modern raft-rs uses rand 0.9.x. Retires on raft-engine/madsim upstream bumps." },
+    { crate = "rand_chacha@0.3.1", reason = "rand 0.8.x transitive; dupe driver is the rand major-version gap above. Retires with rand@0.8.6." },
+    { crate = "rand_core@0.6.4", reason = "rand 0.8.x transitive; dupe driver is the rand major-version gap above. Retires with rand@0.8.6." },
 ]
 skip-tree = []
 wildcards = "deny"
@@ -113,4 +127,13 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # Retirement trigger: upstream tikv/raft-engine#397 merging — when that
 # lands, swap the workspace `raft-engine` dep to point at tikv/raft-engine
 # at the merged SHA and DROP this allow-git entry in the same PR.
-allow-git = ["https://github.com/humancto/raft-engine"]
+allow-git = [
+    "https://github.com/humancto/raft-engine",
+    # tikv/raft-rs is consumed SHA-pinned (see workspace Cargo.toml `raft`
+    # entry) because no released version exposes the 0.7 master surface
+    # we depend on. Retirement trigger: raft-rs 0.8+ release on crates.io —
+    # at that point, swap the workspace dep to a versioned registry entry
+    # and DROP this allow-git line. See ROADMAP:818 and
+    # .planning/raft-engine-logstore.plan.md for the SHA-pin rationale.
+    "https://github.com/tikv/raft-rs",
+]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -33,9 +33,17 @@ audit-as-crates-io = false
 criteria = "safe-to-deploy"
 notes = "first-party workspace crate; audit-as-crates-io=false so cargo-vet does not require third-party audits for mango's own code. safe-to-deploy is governed by in-tree review (CODEOWNERS + PR review)."
 
+[policy.raft]
+audit-as-crates-io = true
+notes = "tikv/raft-rs consumed SHA-pinned at master (see workspace Cargo.toml `raft` entry, ROADMAP:818). Used ONLY for the protobuf type surface (raft::eraftpb::{Entry, HardState, SnapshotMetadata}) at the RaftLogStore conversion boundary; the raft-rs state machine itself is NOT exercised from mango-storage (that lives in mango-raft at Phase 3). `audit-as-crates-io = true` asks cargo-vet to treat the git-pinned source as-if the crates.io tarball at matching package.version (0.7.0); the companion `[[exemptions.raft]]` entry carries the SHA-qualified version (`0.7.0@git:<SHA>`). Retirement trigger: raft-rs 0.8+ on crates.io — swap to a versioned registry entry and drop the SHA qualifier on the exemption line."
+
 [policy.raft-engine]
 audit-as-crates-io = true
 notes = """humancto/raft-engine fork of tikv/raft-engine (see ADR 0002 §W5, .planning/fork-raft-engine-lz4-verification.md). `audit-as-crates-io = true` governs how third-party audits are interpreted (git source audited as-if the crates.io tarball at matching package.version), NOT how exemption entries match. Exemptions for a git dep key on the full resolved source (`0.4.2@git:<SHA>`), so the companion `[[exemptions.raft-engine]]` entry carries the SHA-qualified version — see .planning/fork-raft-engine-lz4-verification.md §"Supply-chain audit posture" for the full rule and the retirement/rebase edits it implies. The fork's incremental delta over upstream (two commits feature-gating lz4-sys) is audited separately via rust-expert's two-round review of the fork and via upstream PR tikv/raft-engine#397."""
+
+[policy.raft-proto]
+audit-as-crates-io = true
+notes = "Sibling crate of tikv/raft-rs; contains the generated protobuf types (raft::eraftpb::*). Same SHA-pin and retirement rules as [policy.raft] above."
 
 [policy.xtask-vet-ttl]
 audit-as-crates-io = false
@@ -76,6 +84,11 @@ notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-m
 version = "1.5.0"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — raft-engine 0.4.2 transitive (build-dep), audit pending"
+
+[[exemptions.autotools]]
+version = "0.2.7"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive (build-dep of protobuf-src for codegen-time pure-C protoc vendoring; our protobuf-codec feature set for raft does NOT invoke protoc but autotools still enters the dep graph as a build-time tool). See ROADMAP:818 and .planning/raft-engine-logstore.plan.md."
 
 [[exemptions.bincode]]
 version = "1.3.3"
@@ -172,6 +185,11 @@ version = "1.2.1"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
+[[exemptions.erased-serde]]
+version = "0.3.31"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive via slog 2.x (slog-rs erases logger types through a `dyn` bound). dtolnay maintainership. See ROADMAP:818."
+
 [[exemptions.errno]]
 version = "0.3.14"
 criteria = "safe-to-deploy"
@@ -237,6 +255,11 @@ version = "0.3.32"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
 
+[[exemptions.fxhash]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive. fxhash is a ~100 LoC FxHash (Firefox's simple non-cryptographic hasher) with no unsafe and no parser surface — used by raft-rs for internal HashMap keying (ProgressTracker, etc.) on non-adversarial keys. Formally unmaintained (RUSTSEC-2025-0057 — see deny.toml advisories ignore for the parallel entry). Retirement trigger: raft-rs migration to rustc-hash. See ROADMAP:818 and .planning/raft-engine-logstore.plan.md."
+
 [[exemptions.generator]]
 version = "0.8.8"
 criteria = "safe-to-deploy"
@@ -251,6 +274,11 @@ notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-m
 version = "0.3.4"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — rust-random, audit pending"
+
+[[exemptions.getset]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive. getset is a small proc-macro crate that derives getter/setter accessors; no runtime surface. See ROADMAP:818."
 
 [[exemptions.hashbrown]]
 version = "0.14.5"
@@ -407,6 +435,16 @@ version = "0.2.37"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — dtolnay, audit pending"
 
+[[exemptions.proc-macro-error-attr2]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive via getset. proc-macro-error2 fork is the maintained successor to the unmaintained proc-macro-error 1.x (no longer depended on by raft-rs). Proc-macro-only; no runtime surface. See ROADMAP:818."
+
+[[exemptions.proc-macro-error2]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive via getset (companion of proc-macro-error-attr2). Proc-macro-only; no runtime surface. See ROADMAP:818."
+
 [[exemptions.proc-macro2]]
 version = "1.0.106"
 criteria = "safe-to-deploy"
@@ -447,6 +485,21 @@ version = "2.28.0"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — raft-engine 0.4.2 transitive (rust-protobuf 2.x via prometheus), audit pending"
 
+[[exemptions.protobuf-build]]
+version = "0.15.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive (build-dep only: drives protobuf-codegen at raft-proto build time). No runtime surface. See ROADMAP:818."
+
+[[exemptions.protobuf-codegen]]
+version = "2.28.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive (build-dep only: rust-protobuf 2.x codegen). Invoked at raft-proto build time; no runtime path. See ROADMAP:818."
+
+[[exemptions.protobuf-src]]
+version = "1.1.0+21.5"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive (build-dep only: vendors the upstream protoc binary for codegen). No runtime surface; pure build-time tooling. Version suffix `+21.5` tracks the vendored protoc release. See ROADMAP:818."
+
 [[exemptions.quote]]
 version = "1.0.45"
 criteria = "safe-to-deploy"
@@ -457,15 +510,40 @@ version = "5.3.0"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — getrandom transitive, r-efi maintainers, audit pending"
 
+[[exemptions.raft]]
+version = "0.7.0@git:53cf7a5b0bf08d278ad768a60b77e68fa10f93aa"
+criteria = "safe-to-deploy"
+notes = 'review-by: 2026-10-23 — tikv/raft-rs master SHA-pinned (see workspace Cargo.toml `raft` entry, ROADMAP:818). Consumed ONLY for the protobuf type surface (`raft::eraftpb::{Entry, HardState, SnapshotMetadata}`) at the `RaftLogStore` conversion boundary; raft-rs state machine not exercised from mango-storage. cargo-vet keys git-dep exemptions on `<version>@git:<SHA>`; the parallel `[policy.raft] audit-as-crates-io = true` controls how third-party audits match. Retirement trigger: raft-rs 0.8+ on crates.io — swap to a plain versioned exemption and drop the SHA qualifier. See .planning/raft-engine-logstore.plan.md §"Supply-chain audit posture".'
+
 [[exemptions.raft-engine]]
 version = "0.4.2@git:e1d738d9ad1c1fc4f5b21c8c73bf605b5696f535"
 criteria = "safe-to-deploy"
 notes = 'review-by: 2026-10-23 — Mango WAL backend via humancto/raft-engine fork. cargo-vet keys exemptions on the full resolved source (`0.4.2@git:<SHA>` for git deps), NOT on `package.version` alone, even with `[policy.raft-engine] audit-as-crates-io = true`. That means this exemption covers THIS SPECIFIC FORK SHA only: rebasing the fork requires a new exemption line at the new `0.4.2@git:<new-SHA>` form, and retiring to upstream crates.io 0.4.2 requires a new exemption at plain `version = "0.4.2"`. See ADR 0002 §W5 and .planning/fork-raft-engine-lz4-verification.md §"Supply-chain audit posture".'
 
+[[exemptions.raft-proto]]
+version = "0.7.0@git:53cf7a5b0bf08d278ad768a60b77e68fa10f93aa"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — Sibling crate of tikv/raft-rs; generated protobuf types for raft::eraftpb::*. Same SHA-pin and retirement rules as [[exemptions.raft]] above. See ROADMAP:818 and .planning/raft-engine-logstore.plan.md."
+
 [[exemptions.rand]]
 version = "0.8.6"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.rand]]
+version = "0.9.4"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive (non-adversarial randomness: election-timer jitter). rust-random maintainership. See ROADMAP:818."
+
+[[exemptions.rand_chacha]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive (rand 0.9.x PRNG backend). rust-random maintainership. See ROADMAP:818."
+
+[[exemptions.rand_core]]
+version = "0.9.5"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive (rand 0.9.x core trait). rust-random maintainership. See ROADMAP:818."
 
 [[exemptions.rand_xoshiro]]
 version = "0.6.0"
@@ -571,6 +649,11 @@ notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-m
 version = "0.4.12"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — madsim 0.2.30 transitive (dev-dep via mango-madsim-demo), audit pending"
+
+[[exemptions.slog]]
+version = "2.8.2"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-10-23 — raft-rs 0.7.0 transitive. slog is the structured-logger raft-rs emits internal events through; mango-storage does NOT attach a slog Drain (raft-rs accepts a no-op logger by default). No runtime surface in practice. See ROADMAP:818."
 
 [[exemptions.smartstring]]
 version = "1.0.1"


### PR DESCRIPTION
## Summary

Implements `RaftLogStore` against the git-pinned `humancto/raft-engine` fork per ROADMAP:818 and ADR 0002 §6/§W5. Closes the second half of the Phase 1 storage-engine work (the first half was ROADMAP:817 / redb Backend).

Key design decisions:

- **`RaftEngineLogStore` wraps `parking_lot::Mutex<Option<Arc<Engine>>>`** so `close()` is idempotent and explicit, avoiding the upstream `Engine::drop` path that unconditionally joins background purge/rewrite threads and panics on join failure.
- **Snapshot cursor cached as `AtomicU64`** (initialized from `SNAPSHOT_META_KEY` at open, updated monotonically via `compare_exchange` on `install_snapshot`). This makes `first_index()` / `last_index()` / `prepare_append` respect the post-snapshot contract even when the raft-engine log is empty (raft-engine returns `None` for `first_index(group)` once every entry has been compacted).
- **`install_snapshot` issues `Compact { index: snap.index + 1 }`** — raft-engine's `Compact` removes entries where `idx < N`, so `Compact { N }` would leave the entry AT `N` still present, which violates the trait-level contract of discarding "strictly before `snap.index + 1`".
- **All async operations route through `tokio::task::spawn_blocking`** because raft-engine's API is synchronous; write path is async, read path is sync per the trait shape.
- **Hard state and snapshot metadata persisted as raft-engine messages** under `b"hs"` / `b"snap_meta"` (raft-engine reserves the `INTERNAL_KEY_PREFIX = __`; user keys must not start with it).
- **`MessageExt` is impl'd locally** — raft-engine's own impl is `#[cfg(test)]`-only upstream.

## Test plan

- [x] `tests/raft_engine_logstore.rs` — 16 integration tests covering open/append/read roundtrip, empty-store indices, append validation (non-consecutive first, non-monotonic within batch, empty noop), `compact` + reopen persistence, `compact` beyond last (noop/clamp), `install_snapshot` + reopen (first_index == snap+1, last_index >= snap, fresh append starts at snap+1), hard-state roundtrip + reopen, closed-store error surface across every method, concurrent appenders with external serialization, range-error paths (inverted, out-of-bounds, empty-range OK).
- [x] `tests/raft_engine_crash_recovery.rs` — `#[cfg(all(unix, not(madsim)))]`; parent re-execs test binary to spawn child worker, child writes 10 entries + hard_state with `sync=true` and prints marker, parent reads marker then `child.kill()` (documented SIGKILL on Unix), reopens and asserts fsynced data survived.
- [x] `tests/raft_engine_madsim_smoke.rs` — `#[cfg(madsim)]` compile-check only. Header documents why no `#[madsim::test]`: `raft_engine::Engine::open` spawns `std::thread` background workers which madsim intercepts with a panic. The compile check still catches accidental breakage of the `#![cfg(not(madsim))]` gates and the tokio re-export path.
- [x] 3 inline async tests in `src/raft_engine/mod.rs` (`append_empty_is_noop`, `append_rejects_non_consecutive`, `closed_store_returns_closed_error`) gated `#[cfg(not(madsim))]`.
- [x] `cargo clippy -p mango-storage --all-targets -- -D warnings`: clean.
- [x] `cargo test -p mango-storage`: 84 passed, 1 ignored (the ignored one is `crash_child_worker`, spawned by its parent, not run directly).
- [x] `RUSTFLAGS=--cfg madsim cargo check -p mango-storage --all-targets`: 0 errors.

ROADMAP item at `ROADMAP.md:818`. Next unchecked items (differential vs bbolt, 7-day chaos) land in follow-up PRs.

Generated with Claude Code.
