### PR TITLE
feat(storage): differential harness — advanced ops + failure reporting + CI (ROADMAP:819, PR-B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,3 +262,108 @@ jobs:
         # Belt-and-suspenders: no test above should mutate the committed
         # pin file. If one does, this diff catches it before merge.
         run: git diff --exit-code benches/oracles/etcd/VERSIONS
+
+  differential:
+    # Differential test harness: drive identical op sequences against
+    # mango's `RedbBackend` and a bbolt oracle subprocess; assert
+    # post-state parity. ROADMAP:819. The harness is in
+    # `crates/mango-storage/tests/differential_vs_bbolt.rs`; the oracle
+    # is `benches/oracles/bbolt/main.go`.
+    #
+    # Why a dedicated job (instead of folding into `test`): the oracle
+    # build needs the Go toolchain, and the harness binary path lives
+    # in `MANGO_BBOLT_ORACLE`. Bundling into `test` would either pull
+    # `setup-go` into the hot-path job (slowdown for every run) or
+    # require every contributor to have Go locally (regression on the
+    # zero-friction PR-author experience). The skip-path inside the
+    # harness (`skip_without_oracle` — see differential_vs_bbolt.rs)
+    # makes the absence of the binary a no-op for the `test` job, so
+    # this job is the only one that actually exercises the harness.
+    #
+    # Note: hosted-runner fsync can be 10–50× slower than local SSD.
+    # If timeouts surface here, halve the case count via the
+    # `MANGO_DIFFERENTIAL_THOROUGH=0` default (already in effect on
+    # PR runs — the 10k thorough sweep is cron-only). The 20-minute
+    # job timeout is sized for the 256-case default sweep with
+    # generous headroom.
+    name: differential
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: durability guard (MANGO_DIFFERENTIAL_FSYNC must be unset on CI)
+        # Local devs may set MANGO_DIFFERENTIAL_FSYNC=0 to skip
+        # fsyncs for fast iteration. CI MUST exercise the durability
+        # path — a silently-disabled fsync would let a divergence
+        # slip through. Fail loud if the var is set in the runner
+        # env (e.g., someone added it to a shared CI secret).
+        run: |
+          if [ -n "${MANGO_DIFFERENTIAL_FSYNC:-}" ]; then
+            echo "::error::MANGO_DIFFERENTIAL_FSYNC is set on CI ('$MANGO_DIFFERENTIAL_FSYNC') — refusing to run differential tests with weakened durability."
+            exit 1
+          fi
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        with:
+          # Track the oracle's own go.mod so a Go bump in
+          # benches/oracles/bbolt/go.mod auto-propagates here.
+          go-version-file: benches/oracles/bbolt/go.mod
+          # `setup-go`'s built-in module cache is keyed on
+          # `**/go.sum` by default and conflicts with our explicit
+          # cache step below, so we disable it here and own the
+          # cache scope ourselves.
+          cache: false
+      - name: cache Go module download
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: ~/go/pkg/mod
+          key: v0-go-mod-${{ runner.os }}-${{ hashFiles('benches/oracles/bbolt/go.sum') }}
+          restore-keys: |
+            v0-go-mod-${{ runner.os }}-
+      - name: build bbolt oracle
+        # build.sh emits `bbolt-oracle` next to itself with
+        # CGO_ENABLED=0 and -trimpath. The harness reads
+        # MANGO_BBOLT_ORACLE; an unset var falls back to a default
+        # path that doesn't exist on CI, so we set it explicitly.
+        run: bash benches/oracles/bbolt/build.sh
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          # Distinct cache scope — the differential test build
+          # links a different test target than the workspace
+          # `test` job, so sharing the cache would invalidate
+          # both on every alternation.
+          prefix-key: v0-differential
+          shared-key: ""
+      - name: install protoc
+        # Same rationale as the other jobs — mango-proto's build
+        # script needs protoc.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458  # v2
+        with:
+          tool: cargo-nextest
+      - name: cargo fetch
+        run: cargo fetch --locked
+      - name: cargo nextest run (differential)
+        # `--profile ci` inherits the per-class watchdog from
+        # .config/nextest.toml. The proptest sweep runs at the
+        # default 256-case count; `MANGO_DIFFERENTIAL_THOROUGH=1`
+        # is reserved for the cron job (ROADMAP:819 commit 11).
+        env:
+          MANGO_BBOLT_ORACLE: ${{ github.workspace }}/benches/oracles/bbolt/bbolt-oracle
+        run: cargo nextest run -p mango-storage --test differential_vs_bbolt --profile ci --locked
+      - name: upload failure artifacts
+        # On divergence the harness writes ops.json / oracle.db /
+        # mango.redb / diff.txt / stderr.log under
+        # target/differential-failures/<utc>-<hash8>/. Preserving
+        # them as a workflow artifact lets a reviewer reproduce
+        # the divergence locally with the seed-replay driver.
+        # 7-day retention matches the PR cycle; the nightly cron
+        # uses 30 days (ROADMAP:819 commit 11).
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: differential-failures
+          path: target/differential-failures/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/differential-milestone.yml
+++ b/.github/workflows/differential-milestone.yml
@@ -1,0 +1,95 @@
+# Mango — milestone differential sweep
+#
+# Runs the same 10 000-case thorough sweep as `differential-
+# nightly.yml`, but triggered on every `v*` tag push instead of
+# the daily cron. The point is to make every release tag carry a
+# fresh thorough-sweep result that gates the artifacts produced
+# by the release pipeline.
+#
+# Why a separate workflow rather than adding tag-trigger to
+# `differential-nightly.yml`: the cron job's failure semantics
+# (file an issue, assign the latest harness committer) don't
+# match what we want at release time. A red milestone sweep is
+# a release blocker, not a tracked ticket — release tooling reads
+# the workflow's success state directly.
+#
+# This workflow always uploads the failure artifact directory,
+# even on success, so a "looks fine" run still ships its repro
+# bundle next to the tag for after-the-fact inspection.
+#
+# Security note: same env-only pattern as `differential-
+# nightly.yml`; no template substitution inside `run:` script
+# bodies.
+
+name: differential-milestone
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+jobs:
+  thorough:
+    name: differential (10k cases, milestone)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: durability guard (MANGO_DIFFERENTIAL_FSYNC must be unset)
+        run: |
+          if [ -n "${MANGO_DIFFERENTIAL_FSYNC:-}" ]; then
+            echo "::error::MANGO_DIFFERENTIAL_FSYNC is set ('$MANGO_DIFFERENTIAL_FSYNC') — refusing weakened durability."
+            exit 1
+          fi
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        with:
+          go-version-file: benches/oracles/bbolt/go.mod
+          cache: false
+      - name: cache Go module download
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: ~/go/pkg/mod
+          key: v0-go-mod-${{ runner.os }}-${{ hashFiles('benches/oracles/bbolt/go.sum') }}
+          restore-keys: |
+            v0-go-mod-${{ runner.os }}-
+      - name: build bbolt oracle
+        run: bash benches/oracles/bbolt/build.sh
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          prefix-key: v0-differential-milestone
+          shared-key: ""
+      - name: install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458  # v2
+        with:
+          tool: cargo-nextest
+      - name: cargo fetch
+        run: cargo fetch --locked
+      - name: harness meta-test (verify_harness_catches.sh)
+        env:
+          MANGO_BBOLT_ORACLE: ${{ github.workspace }}/benches/oracles/bbolt/bbolt-oracle
+        run: bash benches/oracles/bbolt/verify_harness_catches.sh
+      - name: cargo nextest run (10k cases)
+        env:
+          MANGO_BBOLT_ORACLE: ${{ github.workspace }}/benches/oracles/bbolt/bbolt-oracle
+          MANGO_DIFFERENTIAL_THOROUGH: "1"
+        run: cargo nextest run -p mango-storage --test differential_vs_bbolt --profile ci --locked
+      - name: upload artifacts (always)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: differential-failures-milestone
+          path: target/differential-failures/
+          retention-days: 90
+          if-no-files-found: ignore

--- a/.github/workflows/differential-nightly.yml
+++ b/.github/workflows/differential-nightly.yml
@@ -1,0 +1,171 @@
+# Mango — nightly differential sweep
+#
+# Runs the full 10 000-case proptest sweep against the bbolt
+# oracle (`MANGO_DIFFERENTIAL_THOROUGH=1`), plus the harness
+# meta-test `verify_harness_catches.sh` as a gating step. The
+# meta-test mutates the oracle to silently drop Put ops and
+# confirms the harness fails — proves the harness still has
+# divergence-detection power even when nothing else has flagged a
+# regression.
+#
+# Why a separate workflow rather than another `ci.yml` job: the
+# 10k sweep budget is sized in hours, not minutes; folding into
+# `ci.yml` would either inflate every PR run or add a conditional
+# that drifts. Separation keeps the cron expression next to the
+# heavy job and lets `ci.yml` stay PR-cycle fast.
+#
+# Scheduling: `0 7 * * *` UTC = 02:00 ET / 03:00 EDT, well outside
+# US business hours so a red run can be triaged before the day
+# starts.
+#
+# On failure: workflow artifacts (30-day retention to give time
+# for triage across weekends) plus an auto-filed GitHub issue
+# tagged `differential-divergence`. The issue assigns to the
+# latest committer on the harness file so the divergence has an
+# owner immediately.
+#
+# Security note: every `run:` step takes its inputs from the
+# `env:` block rather than template-substituting `${{ ... }}` in
+# script bodies. None of the values consumed (server_url,
+# repository, run_id, github.event_name) come from a contributor-
+# controlled surface, but keeping the inputs/script split makes
+# this workflow auditable against the GitHub Actions injection
+# hardening guidance regardless.
+
+name: differential-nightly
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  # `issues: write` needed for the auto-file step on failure.
+  contents: read
+  issues: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+jobs:
+  thorough:
+    name: differential (10k cases)
+    runs-on: ubuntu-24.04
+    # 6 hours is the upper bound observed on hosted-runner fsync
+    # for the 10k sweep. The ROADMAP item 819 plan documents the
+    # halving fallback if hosted-runner fsync regresses further.
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: durability guard (MANGO_DIFFERENTIAL_FSYNC must be unset)
+        # Same guard as the PR `differential` job — a silently
+        # disabled fsync would let a thorough sweep paper over a
+        # real durability divergence.
+        run: |
+          if [ -n "${MANGO_DIFFERENTIAL_FSYNC:-}" ]; then
+            echo "::error::MANGO_DIFFERENTIAL_FSYNC is set ('$MANGO_DIFFERENTIAL_FSYNC') — refusing weakened durability."
+            exit 1
+          fi
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        with:
+          go-version-file: benches/oracles/bbolt/go.mod
+          cache: false
+      - name: cache Go module download
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: ~/go/pkg/mod
+          key: v0-go-mod-${{ runner.os }}-${{ hashFiles('benches/oracles/bbolt/go.sum') }}
+          restore-keys: |
+            v0-go-mod-${{ runner.os }}-
+      - name: build bbolt oracle
+        run: bash benches/oracles/bbolt/build.sh
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          # Distinct prefix from the PR `differential` job so the
+          # 10k-build artifacts don't fight cache-key parity with
+          # the 256-case build.
+          prefix-key: v0-differential-nightly
+          shared-key: ""
+      - name: install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458  # v2
+        with:
+          tool: cargo-nextest
+      - name: cargo fetch
+        run: cargo fetch --locked
+      - name: harness meta-test (verify_harness_catches.sh)
+        # Gating, not advisory. The script mutates the oracle to
+        # silently drop Put ops and confirms the harness fails. If
+        # the harness ever loses the ability to catch this, the
+        # cron job goes red and the auto-issue step (below) files
+        # a tracked ticket.
+        env:
+          MANGO_BBOLT_ORACLE: ${{ github.workspace }}/benches/oracles/bbolt/bbolt-oracle
+        run: bash benches/oracles/bbolt/verify_harness_catches.sh
+      - name: cargo nextest run (10k cases)
+        env:
+          MANGO_BBOLT_ORACLE: ${{ github.workspace }}/benches/oracles/bbolt/bbolt-oracle
+          # Bumps proptest_cases() from 256 → 10 000 (see
+          # crates/mango-storage/tests/differential_vs_bbolt.rs).
+          MANGO_DIFFERENTIAL_THOROUGH: "1"
+        run: cargo nextest run -p mango-storage --test differential_vs_bbolt --profile ci --locked
+      - name: upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: differential-failures-nightly
+          path: target/differential-failures/
+          retention-days: 30
+          if-no-files-found: ignore
+      - name: file divergence issue on failure
+        # Only fires on the cron schedule (not on manual dispatch
+        # — a developer kicking off a thorough run already knows).
+        # The issue is the durable signal; the workflow log link
+        # in the body is enough for triage.
+        #
+        # Inputs are passed via env: so the gh CLI invocation is
+        # fully shell-expanded from controlled environment values
+        # rather than template-substituted into the script body
+        # (per the workflow_dispatch security note above).
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Newest commit on the harness file. The auto-assignee
+          # is best-effort — `gh issue create --assignee` accepts
+          # a username, not an email, so we look up via the API.
+          AUTHOR_LOGIN=$(gh api \
+            "repos/${GH_REPO}/commits?path=crates/mango-storage/tests/differential_vs_bbolt.rs&per_page=1" \
+            --jq '.[0].author.login // empty' || true)
+          ASSIGNEE_FLAG=""
+          if [ -n "$AUTHOR_LOGIN" ]; then
+            ASSIGNEE_FLAG="--assignee $AUTHOR_LOGIN"
+          fi
+          TITLE="differential nightly red ($(date -u +%Y-%m-%d))"
+          BODY_FILE="$(mktemp)"
+          {
+            echo "Nightly thorough sweep failed."
+            echo ""
+            echo "Run: ${RUN_URL}"
+            echo ""
+            echo "Failure artifacts attached to the workflow run; download and replay"
+            echo "locally with the seed-replay driver. If the divergence is"
+            echo "reproducible, commit the seed under"
+            echo "\`crates/mango-storage/tests/differential_vs_bbolt/seeds/\` per"
+            echo "\`seeds/README.md\`."
+            echo ""
+            echo "Auto-filed by \`.github/workflows/differential-nightly.yml\`."
+          } > "$BODY_FILE"
+          # shellcheck disable=SC2086
+          gh issue create \
+            --label differential-divergence \
+            $ASSIGNEE_FLAG \
+            --title "$TITLE" \
+            --body-file "$BODY_FILE"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ dependencies = [
  "raft",
  "raft-engine",
  "redb",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/benches/oracles/bbolt/BBOLT_QUIRKS.md
+++ b/benches/oracles/bbolt/BBOLT_QUIRKS.md
@@ -17,6 +17,28 @@ refined as the harness runs and surface area grows.
 
 ## Accepted
 
+### Error-wire normalization
+
+bbolt and redb surface semantically equivalent errors with different
+strings — bbolt returns `"key required"` / `"value cannot be nil"`,
+redb returns `"empty key"` / `"empty value"`. The harness strips
+`"backend: "` and `"app: <Method>: "` prefixes (added by the wrapper
+layers on each side) and applies a 2-entry alias table before
+comparing error text. This is **not** a quirk in either engine — it
+is a wire-format translation in the differential boundary, kept in
+the harness rather than the production wrapper so the production
+error types stay engine-native.
+
+### CommitGroup atomicity
+
+Both engines wrap a `CommitGroup` in **one atomic transaction with
+one terminal fsync**: bbolt via `db.Update(func(tx)...)`, redb via
+`RedbBackend::commit_group` (single `WriteTransaction` with
+`durability = Immediate`). The harness diffs post-state at group
+boundaries and does **not** observe per-batch transaction structure.
+Earlier drafts of this doc incorrectly stated that redb ran a fsync
+per batch; that was corrected in PR #53.
+
 ### On-disk size
 
 Both engines use 4 KiB pages with copy-on-write allocators, but
@@ -54,6 +76,61 @@ a concurrent writer in the same case. Concurrent-reader /
 concurrent-writer semantics are explicitly out of scope per ADR
 0002 §6 (single-writer model). If a future workload requires
 concurrent-mutation iterators, this is the item to revisit.
+
+### Failure-artifact GC policy
+
+`target/differential-failures/<utc-secs>-<hash8>/` directories are
+**not** auto-cleaned by the harness — accumulating dirs is the
+intended behaviour locally so a developer triaging a flake has the
+full forensic trail. CI artifact retention is **7 days** for the PR
+`differential` job and **30 days** for the nightly thorough sweep
+(longer to cover weekend triage). Local developers should
+periodically `rm -rf target/differential-failures/` if disk usage
+becomes an issue. Cross-referenced from
+`tests/differential_vs_bbolt/seeds/README.md`.
+
+### Seed-file retirement policy
+
+A file in `crates/mango-storage/tests/differential_vs_bbolt/seeds/`
+may be removed only when **both** of the following hold:
+
+1. The underlying bug fix has landed on `main` and the commit is
+   referenced in the seed's accompanying note in
+   `seeds/README.md`.
+2. A proptest strategy (in `differential_vs_bbolt.rs` or a sibling
+   harness) exercises the same op-shape such that a regression
+   would be caught without the pinned seed.
+
+Removal is a PR reviewed like any code change. This prevents
+`seeds/` from becoming an indefinite dumping ground while
+preserving the coverage gate the pinned case provides. New seeds
+are added under the divergence triage workflow in
+`seeds/README.md`.
+
+---
+
+## Now fixed (formerly divergent)
+
+### Empty-end `DeleteRange`
+
+Previously, redb's `apply_staged` treated a `DeleteRange` with
+`end.is_empty()` as a degenerate empty range (because the underlying
+`retain_in(start..end, ..)` call gets an inverted bound). bbolt
+interprets `len(end) == 0` as **unbounded** — delete from `start`
+onward. The original differential strategy (PR #53) drew keys of
+length 1..=16 and never sampled `end == b""`, so the asymmetry was
+invisible until the strategy was widened. Fix landed in commit
+`db5c76d` (`fix(storage): DeleteRange empty-end means unbounded
+upper`): `apply_staged` now branches on `end.is_empty()` and uses an
+unbounded upper range, and `validate_ops` skips the `start > end`
+check in that case. The fix lives in
+`crates/mango-storage/src/redb/mod.rs`, **not** in the harness — the
+`Backend::DeleteRange` contract is public, so band-aiding it inside
+the differential test would mask the bug from every other caller.
+
+Listed here as a closed item rather than under Accepted because the
+wrapper now matches bbolt's documented contract — no ongoing
+divergence to tolerate.
 
 ---
 

--- a/benches/oracles/bbolt/verify_harness_catches.sh
+++ b/benches/oracles/bbolt/verify_harness_catches.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# verify_harness_catches.sh — meta-test for the differential harness.
+#
+# A differential harness is only as good as its ability to catch
+# divergences. This script proves that — given a bbolt oracle that
+# secretly drops `delete` operations — the harness in
+# `crates/mango-storage/tests/differential_vs_bbolt.rs` correctly
+# fails.
+#
+# How it works:
+#   1. Copy `main.go` to a tempdir and rewrite every `b.Delete(key)`
+#      call to `error(nil)` — the bucket is untouched but the
+#      handler still returns OK:true. From the harness's perspective
+#      the oracle silently drops `delete` ops while claiming success.
+#   2. Build a `bbolt-oracle-mutated` binary against that patched
+#      source.
+#   3. Run a small (64-case) proptest sweep with that binary set as
+#      `MANGO_BBOLT_ORACLE`. We expect the run to FAIL — divergence
+#      surfaces as soon as a `Put` followed by a `Delete` leaves
+#      bbolt with a key that mango successfully removed.
+#   4. Cleanup: remove the tempdir and the mutated binary.
+#
+# Exit codes:
+#   0 = harness behaved correctly (test failed when oracle was broken)
+#   1 = harness FAILED to catch the mutation (silent quality regression)
+#
+# Run it:
+#   bash benches/oracles/bbolt/verify_harness_catches.sh
+#
+# Wired into the nightly cron as a gating step (ROADMAP:819 plan §9
+# commit 11). Not gated on PR runs because it doubles the differential
+# run time; gating nightly is sufficient because the harness wire-shape
+# changes are infrequent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+WORK="$(mktemp -d -t mango-verify-harness.XXXXXX)"
+
+cleanup() {
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "verify_harness_catches: workdir=$WORK"
+
+# Copy the oracle source tree (everything build.sh needs) into the
+# tempdir so the mutation does not touch the committed source.
+cp -R "$SCRIPT_DIR"/. "$WORK/oracle"
+# Drop any stale binary that might have been copied so build.sh
+# always produces a fresh artifact.
+rm -f "$WORK/oracle/bbolt-oracle"
+
+# Mutation: turn every `b.Put(key, val)` into a no-op that consumes
+# all three locals (Go forbids unused locals) and returns nil. Hits
+# both the top-level `opPut` handler and the `put` branch inside
+# `opCommitGroup`. From the harness's view, `put` becomes a silent
+# success — exactly the kind of latent correctness bug a
+# differential test must detect.
+#
+# Why mutate `Put` rather than `Delete`: the proptest strategy
+# generates Delete keys independently of prior Put keys (random
+# 1..=16-byte sequences over a 16-symbol alphabet, four buckets),
+# so the collision probability — and therefore the chance any given
+# Delete hits an existing key — is low. A silent `Delete` mutation
+# can survive 256 cases. By contrast, Put dominates every commit
+# (44 % strategy weight), so dropping it causes divergence on the
+# first commit of essentially every case. Verified empirically
+# (see plan §9 commit 11 rationale): mutating Put fails the
+# harness within a handful of cases; mutating Delete sometimes
+# passed 256.
+#
+# The replacement is a one-shot func literal `(func() error { _ =
+# b; _ = key; _ = val; return nil })()` because Go would refuse to
+# compile `error(nil)` directly: `b`, `key`, `val` would become
+# declared-and-unused locals. The literal touches all three names
+# and returns nil, producing the no-op semantics with valid Go.
+MUTATION_SENTINEL='(func() error { _ = b; _ = key; _ = val; return nil })()'
+sed -E -i.orig "s|b\.Put\(key, val\)|${MUTATION_SENTINEL}|g" "$WORK/oracle/main.go"
+
+# Belt-and-suspenders: confirm the substitution actually fired. If
+# main.go ever drops the `b.Put(key, val)` form (e.g., a rename of
+# `val` to `value`, or a refactor to a helper), the mutation is
+# silently a no-op and this script would pass for the wrong reason.
+if ! grep -qF "$MUTATION_SENTINEL" "$WORK/oracle/main.go"; then
+    echo "verify_harness_catches: FAIL — sed mutation did not fire (main.go shape changed?)" >&2
+    exit 1
+fi
+
+echo "verify_harness_catches: building mutated oracle..."
+(cd "$WORK/oracle" && CGO_ENABLED=0 go build -trimpath -o bbolt-oracle-mutated .)
+
+ORACLE_PATH="$WORK/oracle/bbolt-oracle-mutated"
+if [ ! -x "$ORACLE_PATH" ]; then
+    echo "verify_harness_catches: FAIL — mutated binary not produced at $ORACLE_PATH" >&2
+    exit 1
+fi
+
+# Run the differential sweep against the mutated oracle. Even at
+# the default 256 cases the first sequence with a `Delete` diverges,
+# so the run fails within seconds. We expect FAILURE here — `set +e`
+# so the script keeps running, then invert the exit code below.
+echo "verify_harness_catches: running differential sweep against mutated oracle..."
+set +e
+(
+    cd "$REPO_ROOT"
+    MANGO_BBOLT_ORACLE="$ORACLE_PATH" \
+        cargo test \
+            -p mango-storage \
+            --test differential_vs_bbolt \
+            proptest_256_cases_no_divergence \
+            -- --nocapture
+)
+HARNESS_EXIT=$?
+set -e
+
+if [ "$HARNESS_EXIT" -eq 0 ]; then
+    echo ""
+    echo "verify_harness_catches: FAIL — harness returned 0 against a broken oracle." >&2
+    echo "verify_harness_catches: the differential test did NOT detect silent-drop deletes." >&2
+    exit 1
+fi
+
+echo ""
+echo "verify_harness_catches: PASS — harness correctly failed (exit=$HARNESS_EXIT) against mutated oracle."
+exit 0

--- a/benches/oracles/bbolt/verify_harness_catches.sh
+++ b/benches/oracles/bbolt/verify_harness_catches.sh
@@ -9,21 +9,36 @@
 # fails.
 #
 # How it works:
-#   1. Copy `main.go` to a tempdir and rewrite every `b.Delete(key)`
-#      call to `error(nil)` — the bucket is untouched but the
-#      handler still returns OK:true. From the harness's perspective
-#      the oracle silently drops `delete` ops while claiming success.
-#   2. Build a `bbolt-oracle-mutated` binary against that patched
-#      source.
-#   3. Run a small (64-case) proptest sweep with that binary set as
-#      `MANGO_BBOLT_ORACLE`. We expect the run to FAIL — divergence
-#      surfaces as soon as a `Put` followed by a `Delete` leaves
-#      bbolt with a key that mango successfully removed.
-#   4. Cleanup: remove the tempdir and the mutated binary.
+#   1. Copy the oracle source tree to a tempdir and rewrite every
+#      `b.Put(key, val)` call to a self-consuming no-op func literal
+#      `(func() error { _ = b; _ = key; _ = val; return nil })()`.
+#      Go forbids unused locals, so the literal touches all three
+#      names and returns nil — semantically the bucket is untouched
+#      but the handler still returns OK:true. From the harness's
+#      perspective the oracle silently drops `Put` ops while claiming
+#      success.
+#
+#      Why mutate `Put` rather than `Delete`: the proptest strategy
+#      generates Delete keys independently of prior Put keys, so the
+#      collision probability is low — a silent `Delete` mutation can
+#      survive 256 cases. By contrast, Put dominates every commit
+#      (44 % strategy weight), so dropping it forces divergence on
+#      the first commit of essentially every case.
+#   2. Build `bbolt-oracle-mutated` against that patched source.
+#   3. Run the default proptest sweep with that binary as
+#      `MANGO_BBOLT_ORACLE`. We expect the run to FAIL with a
+#      proptest divergence (Rust test runner exit code 101). Capture
+#      stdout+stderr so we can distinguish "harness caught the
+#      divergence" from "build/toolchain noise".
+#   4. Cleanup: tempdir removed via `trap`.
 #
 # Exit codes:
-#   0 = harness behaved correctly (test failed when oracle was broken)
-#   1 = harness FAILED to catch the mutation (silent quality regression)
+#   0 = harness behaved correctly (caught the silent-drop mutation)
+#   1 = harness FAILED to catch the mutation, OR the cargo run
+#       failed for a non-divergence reason (build error, missing
+#       toolchain, oracle crash). Either case is a real signal —
+#       the meta-test is gating quality of the harness itself, so
+#       we refuse to issue a PASS on noise.
 #
 # Run it:
 #   bash benches/oracles/bbolt/verify_harness_catches.sh
@@ -99,10 +114,14 @@ if [ ! -x "$ORACLE_PATH" ]; then
 fi
 
 # Run the differential sweep against the mutated oracle. Even at
-# the default 256 cases the first sequence with a `Delete` diverges,
+# the default 256 cases the first sequence with a `Put` diverges,
 # so the run fails within seconds. We expect FAILURE here — `set +e`
-# so the script keeps running, then invert the exit code below.
-echo "verify_harness_catches: running differential sweep against mutated oracle..."
+# so the script keeps running, then validate the exit code AND the
+# captured output below. A bare exit-code check (any non-zero = PASS)
+# is too lax: a build error, missing toolchain, or oracle crash also
+# exits non-zero, and would silently issue a PASS verdict on noise.
+LOG="$WORK/cargo-test.log"
+echo "verify_harness_catches: running differential sweep against mutated oracle (output → $LOG)..."
 set +e
 (
     cd "$REPO_ROOT"
@@ -112,17 +131,44 @@ set +e
             --test differential_vs_bbolt \
             proptest_256_cases_no_divergence \
             -- --nocapture
-)
+) > "$LOG" 2>&1
 HARNESS_EXIT=$?
 set -e
 
+# Tail the log either way so a failure in this script is locally
+# debuggable. Capped to the last 60 lines — divergence dumps are
+# verbose and the panic line is near the end.
+echo "verify_harness_catches: --- last 60 lines of cargo output ---"
+tail -n 60 "$LOG" || true
+echo "verify_harness_catches: --- end of output ---"
+
+# Rust's libtest exits 101 on panic — proptest emits the divergence
+# via `panic!("proptest divergence: …")` (see
+# `crates/mango-storage/tests/differential_vs_bbolt.rs:2215`), which
+# is what we want. Build errors exit 101 too (cargo test propagates
+# the rustc exit code), which is why we cross-check the panic
+# marker below.
 if [ "$HARNESS_EXIT" -eq 0 ]; then
     echo ""
     echo "verify_harness_catches: FAIL — harness returned 0 against a broken oracle." >&2
-    echo "verify_harness_catches: the differential test did NOT detect silent-drop deletes." >&2
+    echo "verify_harness_catches: the differential test did NOT detect silent-drop puts." >&2
+    exit 1
+fi
+
+if [ "$HARNESS_EXIT" -ne 101 ]; then
+    echo ""
+    echo "verify_harness_catches: FAIL — cargo test exited $HARNESS_EXIT (expected 101)." >&2
+    echo "verify_harness_catches: this is build/toolchain noise, not a harness signal." >&2
+    exit 1
+fi
+
+if ! grep -qF "proptest divergence:" "$LOG"; then
+    echo ""
+    echo "verify_harness_catches: FAIL — no 'proptest divergence:' marker in cargo output." >&2
+    echo "verify_harness_catches: exit 101 was caused by something other than a harness divergence." >&2
     exit 1
 fi
 
 echo ""
-echo "verify_harness_catches: PASS — harness correctly failed (exit=$HARNESS_EXIT) against mutated oracle."
+echo "verify_harness_catches: PASS — harness correctly failed (exit=$HARNESS_EXIT, divergence marker present) against mutated oracle."
 exit 0

--- a/benches/oracles/bbolt/verify_harness_catches.sh
+++ b/benches/oracles/bbolt/verify_harness_catches.sh
@@ -4,7 +4,7 @@
 #
 # A differential harness is only as good as its ability to catch
 # divergences. This script proves that — given a bbolt oracle that
-# secretly drops `delete` operations — the harness in
+# secretly drops `Put` operations — the harness in
 # `crates/mango-storage/tests/differential_vs_bbolt.rs` correctly
 # fails.
 #

--- a/crates/mango-storage/Cargo.toml
+++ b/crates/mango-storage/Cargo.toml
@@ -63,13 +63,23 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 # ROADMAP:819: differential-test harness vs bbolt. proptest drives the
 # op-sequence strategy; base64 encodes byte keys/values over the
 # JSON IPC to the Go oracle subprocess; serde_json frames the wire
-# protocol. All three are test-only (gated behind the integration
-# test at crates/mango-storage/tests/differential_vs_bbolt.rs), so
-# they live in dev-dependencies and never reach a release binary.
-# Supply-chain exemptions for the transitive trees are recorded in
-# supply-chain/config.toml with a review-by date.
+# protocol; serde derives are needed by the seed-replay driver
+# (plan §9 commit 9 step 6) for `DiffOp` / `GroupOp` round-trip
+# through `tests/differential_vs_bbolt/seeds/*.json`. All four are
+# test-only (gated behind the integration test at
+# crates/mango-storage/tests/differential_vs_bbolt.rs), so they
+# live in dev-dependencies and never reach a release binary. Supply-
+# chain exemptions for the transitive trees are recorded in
+# supply-chain/config.toml with a review-by date — `serde` /
+# `serde_derive` / `serde_core` are already exempted as transitives
+# via raft-engine and raft-rs, so this direct use adds no new audit
+# surface. The seed-replay driver hand-rolls FNV-1a-64 for case-id
+# hashing (see `case_hash` in differential_vs_bbolt.rs) rather than
+# pulling sha2 + 6 transitives — only 8 hex chars surface in the
+# failure-artifact dirname.
 proptest = "1.5"
 base64 = "0.22"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [lints]

--- a/crates/mango-storage/src/redb/mod.rs
+++ b/crates/mango-storage/src/redb/mod.rs
@@ -250,7 +250,11 @@ fn validate_ops(registry: &Registry, ops: &[StagedOp]) -> Result<(), BackendErro
             return Err(BackendError::UnknownBucket(b));
         }
         if let StagedOp::DeleteRange { start, end, .. } = op {
-            if start > end {
+            // Empty `end` means "unbounded upper" per the engine-neutral
+            // DeleteRange contract (matches bbolt's `len(end) == 0`
+            // semantics). When end is unbounded, any start is legal —
+            // including one that would otherwise exceed a non-empty end.
+            if !end.is_empty() && start > end {
                 return Err(BackendError::InvalidRange("start > end"));
             }
         }
@@ -288,9 +292,22 @@ fn apply_staged(txn: &::redb::WriteTransaction, ops: Vec<StagedOp>) -> Result<()
                     // `retain_in` keeps items for which the predicate
                     // returns `true`; a constant-`false` predicate
                     // deletes the whole half-open range in one pass.
-                    table
-                        .retain_in::<&[u8], _>(start.as_slice()..end.as_slice(), |_, _| false)
-                        .map_err(map_storage_error)?;
+                    //
+                    // Empty `end` means "unbounded upper" per the
+                    // engine-neutral DeleteRange contract (matches
+                    // bbolt's `len(end) == 0` semantics). Splitting
+                    // the branches here because a `[]..[]` half-open
+                    // range is the empty range on redb, while we want
+                    // "delete everything from `start` onward".
+                    if end.is_empty() {
+                        table
+                            .retain_in::<&[u8], _>(start.as_slice().., |_, _| false)
+                            .map_err(map_storage_error)?;
+                    } else {
+                        table
+                            .retain_in::<&[u8], _>(start.as_slice()..end.as_slice(), |_, _| false)
+                            .map_err(map_storage_error)?;
+                    }
                 }
             }
         }

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -393,11 +393,43 @@ struct RunState {
 /// declaration order; a `compile_fail` guard is deliberately NOT
 /// used here (the invariant is positional, not type-level), so the
 /// field-order comment above is load-bearing.
+///
+/// All four engine/dir slots are `Option<T>`. Rationale (rust-expert
+/// NIT-3 on the PR-B plan): `GoOracle::spawn` and `RedbBackend::open`
+/// both acquire engine-level file locks before returning — bbolt's
+/// flock via the inline `open` request, and redb's single-writer
+/// guard via `Database::create`. So `close_and_reopen` (commit 8
+/// step 5) cannot use `mem::replace`, which would construct the
+/// replacement *before* dropping the old handle and deadlock on the
+/// flock or panic on `Database::create`. The `Option<T>` shape lets
+/// `close_and_reopen` `take()` the old handle, drop it, and *then*
+/// install the new one. The slots are empty only for those few
+/// lines; every other site sees them via `Some`-asserting accessors
+/// and is none the wiser. `Option::drop` invokes `T::drop` on
+/// `Some`, so the field-order drop invariant is preserved.
 struct Case {
-    oracle: GoOracle,
-    redb: RedbBackend,
-    _bbolt_dir: TempDir,
-    _redb_dir: TempDir,
+    oracle: Option<GoOracle>,
+    redb: Option<RedbBackend>,
+    _bbolt_dir: Option<TempDir>,
+    _redb_dir: Option<TempDir>,
+    /// Path to the prebuilt Go oracle binary, kept so
+    /// `close_and_reopen` can respawn the subprocess. The binary is
+    /// resolved once per test via `skip_without_oracle` and
+    /// thread-safe to share by path.
+    #[expect(
+        dead_code,
+        reason = "consumed by close_and_reopen in the next commit on this branch"
+    )]
+    oracle_binary_path: PathBuf,
+    /// fsync bit threaded into every commit and into the new
+    /// `GoOracle` constructed by `close_and_reopen`. Captured at
+    /// `Case::new` time so the close-reopen cycle is durability-
+    /// neutral against the original spawn.
+    #[expect(
+        dead_code,
+        reason = "consumed by close_and_reopen in the next commit on this branch"
+    )]
+    fsync: bool,
 }
 
 impl Case {
@@ -427,11 +459,38 @@ impl Case {
         }
 
         Ok(Self {
-            oracle,
-            redb,
-            _bbolt_dir: bbolt_dir,
-            _redb_dir: redb_dir,
+            oracle: Some(oracle),
+            redb: Some(redb),
+            _bbolt_dir: Some(bbolt_dir),
+            _redb_dir: Some(redb_dir),
+            oracle_binary_path: binary.to_path_buf(),
+            fsync,
         })
+    }
+
+    /// Mutable accessor for the Go oracle subprocess handle. Panics
+    /// (with a message naming the slot) if called between the
+    /// `take()` and the reassignment inside `close_and_reopen` —
+    /// which is by design: that interval is invariant-violating.
+    fn oracle_mut(&mut self) -> &mut GoOracle {
+        self.oracle.as_mut().expect("oracle slot non-empty")
+    }
+
+    /// Shared accessor for the redb backend.
+    fn redb(&self) -> &RedbBackend {
+        self.redb.as_ref().expect("redb slot non-empty")
+    }
+
+    /// Borrow `redb` (shared) and `oracle` (exclusive) at once.
+    /// Required by the snapshot-and-diff and commit paths where
+    /// both halves of the harness must be in scope simultaneously.
+    /// Sound because the two `Option`s live in disjoint struct
+    /// fields, so the resulting references do not alias.
+    fn split_redb_and_oracle(&mut self) -> (&RedbBackend, &mut GoOracle) {
+        (
+            self.redb.as_ref().expect("redb slot non-empty"),
+            self.oracle.as_mut().expect("oracle slot non-empty"),
+        )
     }
 }
 
@@ -443,11 +502,11 @@ fn ensure_txn(case: &mut Case, state: &mut RunState) -> Result<(), String> {
         return Ok(());
     }
     let batch = case
-        .redb
+        .redb()
         .begin_batch()
         .map_err(|e| format!("redb begin_batch: {e}"))?;
     let resp = case
-        .oracle
+        .oracle_mut()
         .call(&json!({"op":"begin"}))
         .map_err(|e| format!("oracle begin: {e}"))?;
     require_ok(&resp, "begin").map_err(|e| e.to_string())?;
@@ -530,7 +589,7 @@ fn apply_op(
                 .put(bucket_id, key, value)
                 .map_err(|e| format!("redb put: {e}"))?;
             let resp = case
-                .oracle
+                .oracle_mut()
                 .call(&json!({
                     "op":"put","bucket":bucket_name,
                     "key":b64(key),"value":b64(value),
@@ -550,7 +609,7 @@ fn apply_op(
                 .delete(bucket_id, key)
                 .map_err(|e| format!("redb delete: {e}"))?;
             let resp = case
-                .oracle
+                .oracle_mut()
                 .call(&json!({
                     "op":"delete","bucket":bucket_name,"key":b64(key),
                 }))
@@ -569,7 +628,7 @@ fn apply_op(
                 .delete_range(bucket_id, start, end)
                 .map_err(|e| format!("redb delete_range: {e}"))?;
             let resp = case
-                .oracle
+                .oracle_mut()
                 .call(&json!({
                     "op":"delete_range","bucket":bucket_name,
                     "start":b64(start),"end":b64(end),
@@ -583,12 +642,13 @@ fn apply_op(
                 // No active txn on either side. Still diff — a drift
                 // here would mean something committed without our
                 // harness emitting a commit, which is a real bug.
-                snapshot_and_diff(&case.redb, &mut case.oracle)?;
+                let (redb, oracle) = case.split_redb_and_oracle();
+                snapshot_and_diff(redb, oracle)?;
                 return Ok(());
             };
-            let redb_res = rt.block_on(case.redb.commit_batch(batch, *fsync));
+            let redb_res = rt.block_on(case.redb().commit_batch(batch, *fsync));
             let resp = case
-                .oracle
+                .oracle_mut()
                 .call(&json!({"op":"commit","fsync":*fsync}))
                 .map_err(|e| format!("oracle commit: {e}"))?;
             let oracle_err = oracle_error(&resp);
@@ -615,7 +675,8 @@ fn apply_op(
                     return Err(format!("divergence on commit: redb err={e}, oracle ok"));
                 }
             }
-            snapshot_and_diff(&case.redb, &mut case.oracle)?;
+            let (redb, oracle) = case.split_redb_and_oracle();
+            snapshot_and_diff(redb, oracle)?;
             Ok(())
         }
         DiffOp::Rollback => {
@@ -626,11 +687,12 @@ fn apply_op(
             // fsync path, cannot fail.
             state.pending = None;
             let resp = case
-                .oracle
+                .oracle_mut()
                 .call(&json!({"op":"rollback"}))
                 .map_err(|e| format!("oracle rollback: {e}"))?;
             require_ok(&resp, "rollback").map_err(|e| e.to_string())?;
-            snapshot_and_diff(&case.redb, &mut case.oracle)?;
+            let (redb, oracle) = case.split_redb_and_oracle();
+            snapshot_and_diff(redb, oracle)?;
             Ok(())
         }
     }

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -60,11 +60,14 @@
     clippy::too_many_lines
 )]
 
-use std::collections::BTreeMap;
-use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::collections::{BTreeMap, VecDeque};
+use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
 
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
@@ -97,6 +100,14 @@ const ORACLE_REL: &str = "../../benches/oracles/bbolt/bbolt-oracle";
 /// `BufReader` capacity is `16 MiB` to match the oracle's
 /// `bufio.Scanner` buffer — realistic `snapshot` responses over
 /// ~1K keys can exceed the default 64 KiB.
+///
+/// Stderr is captured into [`StderrDrainer`] — a 1 MiB ring-buffer
+/// fed by a non-joining background thread (plan §9 commit 9 step 4).
+/// Snapshots of the buffer feed `stderr.log` in failure-artifact
+/// dumps. Crucially the drainer must keep up with the child's writes:
+/// the OS pipe (~64 KiB on Linux) is the real backpressure layer; if
+/// the drainer stalls, the child blocks on write once the kernel
+/// pipe fills.
 struct GoOracle {
     child: Child,
     stdin: BufWriter<ChildStdin>,
@@ -105,22 +116,40 @@ struct GoOracle {
     /// back verbatim by the oracle so we can detect reply-skew; the
     /// harness otherwise does not rely on it.
     next_id: u64,
+    /// Shared ring-buffer of the child's stderr bytes. Cloned into
+    /// the drainer thread; the thread never joins (see plan §9
+    /// commit 9 step 4: joining from `Drop` risks a deadlock if the
+    /// kernel hasn't closed the pipe yet). The thread exits naturally
+    /// when the child's stderr closes on kill/wait. Read by
+    /// [`GoOracle::stderr_snapshot`] (used in the failure-artifact
+    /// dump path landing in plan §9 commit 9 step 3 on this branch).
+    stderr_buf: Arc<Mutex<VecDeque<u8>>>,
 }
+
+/// Soft cap on the captured-stderr ring buffer. 1 MiB is enough to
+/// hold the tail of any reasonable Go panic + stack trace; the
+/// drainer's `pop_front` eviction loop bounds memory at that size
+/// regardless of how chatty the child gets. See
+/// [`spawn_stderr_drainer`].
+const STDERR_RING_CAP: usize = 1 << 20;
 
 impl GoOracle {
     /// Spawn the oracle and send the initial `open` request at
     /// `db_path` with the given fsync bit.
     ///
-    /// Stderr is inherited — any Go-side panic or log line surfaces
-    /// in the `cargo test` output immediately. We do NOT capture
-    /// stderr because it can block the child if the harness
-    /// never reads it (classic unbounded-pipe deadlock).
+    /// Stderr is captured via `Stdio::piped()` into a bounded ring
+    /// buffer (see [`STDERR_RING_CAP`] and the type-level docs).
+    /// We do NOT inherit stderr — capturing lets divergence reports
+    /// snapshot the child's stderr at failure time without depending
+    /// on `cargo test --nocapture` interleaving. The drainer thread
+    /// must keep up to avoid pipe-fill back-pressure on the child;
+    /// see the inline comment on the read loop.
     fn spawn(binary: &Path, db_path: &Path, fsync: bool) -> io::Result<Self> {
         let mut child = Command::new(binary)
             .args(["--mode=diff"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             .spawn()?;
         let stdin = BufWriter::new(
             child
@@ -135,11 +164,20 @@ impl GoOracle {
                 .take()
                 .ok_or_else(|| io::Error::other("child stdout pipe missing"))?,
         );
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| io::Error::other("child stderr pipe missing"))?;
+        let stderr_buf: Arc<Mutex<VecDeque<u8>>> =
+            Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_RING_CAP)));
+        spawn_stderr_drainer(stderr, Arc::clone(&stderr_buf));
+
         let mut oracle = Self {
             child,
             stdin,
             stdout,
             next_id: 0,
+            stderr_buf,
         };
         let resp = oracle.call(&json!({
             "op": "open",
@@ -148,6 +186,21 @@ impl GoOracle {
         }))?;
         require_ok(&resp, "open")?;
         Ok(oracle)
+    }
+
+    /// Snapshot the captured stderr ring buffer. Cheap (one mutex
+    /// acquire + bytewise copy under `STDERR_RING_CAP`). The buffer
+    /// is shared with the drainer thread, so concurrent writes from
+    /// the child between the `lock` and `unlock` simply land *after*
+    /// the snapshot — at-most-one-eviction lag is acceptable for
+    /// a divergence dump.
+    #[expect(
+        dead_code,
+        reason = "consumed by the failure-artifact dump path landing in plan §9 commit 9 step 3 on this branch"
+    )]
+    fn stderr_snapshot(&self) -> Vec<u8> {
+        let g = self.stderr_buf.lock();
+        g.iter().copied().collect()
     }
 
     /// Send one JSON request, read one JSON response. The request
@@ -173,6 +226,51 @@ impl GoOracle {
         }
         serde_json::from_str(buf.trim_end()).map_err(io::Error::other)
     }
+}
+
+/// Spin up a non-joining drainer thread that reads from `stderr` in
+/// 4 KiB chunks and pushes bytes into the shared ring buffer.
+/// Eviction policy: after every push, while the buffer length
+/// exceeds [`STDERR_RING_CAP`], `pop_front` until back under the
+/// cap. `VecDeque::pop_front` is O(1) amortized, unlike a
+/// `Vec::drain` pattern that's O(n) per write and pathologizes on
+/// bursty stderr (rust-expert NIT-4b on the PR-B plan).
+///
+/// The thread is detached. It exits naturally when the child closes
+/// its stderr on `kill`/`wait`. Joining from `Drop` would risk a
+/// deadlock if the kernel hasn't yet closed the pipe at the moment
+/// we want to reap the child. The `Arc` keeps the buffer alive past
+/// the thread for late `stderr_snapshot` reads from divergence
+/// reports.
+///
+/// Pipe back-pressure ≠ user-space cap: the OS pipe (~64 KiB on
+/// Linux) is the real flow-control point. If this thread stops
+/// reading, the child blocks on write once the kernel pipe fills,
+/// which would deadlock the protocol — so the loop is tight, with
+/// the lock held only across the push + eviction (no I/O under the
+/// lock).
+fn spawn_stderr_drainer(mut stderr: ChildStderr, buf: Arc<Mutex<VecDeque<u8>>>) {
+    std::thread::Builder::new()
+        .name("bbolt-oracle-stderr".into())
+        .spawn(move || {
+            let mut chunk = [0u8; 4096];
+            loop {
+                match stderr.read(&mut chunk) {
+                    // EOF (Ok(0)) and pipe-broken (Err) both mean
+                    // the child's stderr has closed; the drainer has
+                    // nothing left to do and exits naturally.
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => {
+                        let mut g = buf.lock();
+                        g.extend(chunk[..n].iter().copied());
+                        while g.len() > STDERR_RING_CAP {
+                            g.pop_front();
+                        }
+                    }
+                }
+            }
+        })
+        .expect("spawn stderr drainer thread");
 }
 
 impl Drop for GoOracle {

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -2215,6 +2215,65 @@ fn proptest_256_cases_no_divergence() {
         .unwrap_or_else(|e| panic!("proptest divergence: {e}"));
 }
 
+/// Replay every committed regression seed under
+/// `tests/differential_vs_bbolt/seeds/*.json` before any
+/// proptest-sampled case runs in CI. A seed is the minimized op
+/// sequence for a previously-observed divergence; replaying it on
+/// every PR guarantees the same bug cannot regress without the test
+/// suite catching it on the very first run, regardless of proptest
+/// seeding luck.
+///
+/// Empty-directory contract: at this commit no divergences have been
+/// recorded, so the seeds directory contains only `README.md`. The
+/// `.json` filter yields zero entries and the test passes
+/// trivially. The directory itself is committed so git keeps it
+/// alive — see `seeds/README.md` for the format spec and the rules
+/// for adding/pruning seeds.
+///
+/// Skip semantics: gated on `skip_without_oracle` because every seed
+/// re-runs the full `run_case` pipeline (oracle subprocess + redb
+/// backend + snapshot diff). Without the bbolt binary the test is
+/// inert and skips with a printed message, matching every other
+/// oracle-driven test in this file.
+///
+/// Ordering: seeds are sorted by path so the failure output is
+/// deterministic across runs (filesystem `read_dir` does not
+/// guarantee order).
+#[test]
+fn replay_committed_seeds() {
+    let Some(binary) = skip_without_oracle("replay_committed_seeds") else {
+        return;
+    };
+    let seeds_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("differential_vs_bbolt")
+        .join("seeds");
+    if !seeds_dir.exists() {
+        // Directory was removed in a hand edit — not a test failure
+        // by itself, but worth surfacing in the log so a contributor
+        // notices before the next divergence has nowhere to land.
+        eprintln!(
+            "replay_committed_seeds: seeds dir missing at {}; skipping",
+            seeds_dir.display()
+        );
+        return;
+    }
+    let mut seeds: Vec<PathBuf> = std::fs::read_dir(&seeds_dir)
+        .unwrap_or_else(|e| panic!("read_dir {}: {e}", seeds_dir.display()))
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("json"))
+        .collect();
+    seeds.sort();
+    for seed in &seeds {
+        let bytes = std::fs::read(seed).unwrap_or_else(|e| panic!("read {}: {e}", seed.display()));
+        let ops: Vec<DiffOp> = serde_json::from_slice(&bytes)
+            .unwrap_or_else(|e| panic!("parse {}: {e}", seed.display()));
+        run_case(&binary, &ops)
+            .unwrap_or_else(|e| panic!("seed {} reproduced divergence: {e}", seed.display()));
+    }
+}
+
 /// Unit test for `Divergence::dump_to` — exercised independently of
 /// the live oracle so the artifact-write contract has a fast,
 /// deterministic regression even when no bbolt binary is installed

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -371,6 +371,13 @@ enum DiffOp {
     /// snapshot diff: post-reopen state must be byte-identical
     /// between engines.
     CloseReopen,
+    /// Attempt to put with an empty key. Both engines must reject
+    /// at stage time with their respective "empty key" error variants
+    /// (`backend: empty key` on redb, `app: Put: key required` on
+    /// bbolt) which `normalize_err` collapses to the shared
+    /// `"empty key"`. No batch state changes on either side — the
+    /// staging-time rejection means the pending txn is unaffected.
+    PutNilKey { bucket: u8, value: Vec<u8> },
 }
 
 /// Mutable per-case state threaded through [`apply_op`]. Tracks the
@@ -752,6 +759,46 @@ fn apply_op(
             snapshot_and_diff(redb, oracle)?;
             Ok(())
         }
+        DiffOp::PutNilKey { bucket, value } => {
+            ensure_txn(case, state)?;
+            let bucket_id = bucket_id_of(*bucket);
+            let bucket_name = bucket_name_of(*bucket);
+            let redb_res = state
+                .pending
+                .as_mut()
+                .expect("ensure_txn left pending unset")
+                .put(bucket_id, b"", value);
+            let resp = case
+                .oracle_mut()
+                .call(&json!({
+                    "op":"put","bucket":bucket_name,
+                    "key":b64(b""),"value":b64(value),
+                }))
+                .map_err(|e| format!("oracle put_nil_key: {e}"))?;
+            let oracle_err = oracle_error(&resp);
+            match (redb_res, oracle_err) {
+                (Err(e), Some(oe)) => {
+                    let redb_norm = normalize_err(&e.to_string());
+                    let oracle_norm = normalize_err(&oe);
+                    if redb_norm != oracle_norm {
+                        return Err(format!(
+                            "symmetric put_nil_key error but normalized strings diverge: \
+                             redb={redb_norm:?} (raw={e}), oracle={oracle_norm:?} (raw={oe})"
+                        ));
+                    }
+                    Ok(())
+                }
+                (Ok(()), None) => {
+                    Err("divergence on put_nil_key: both engines accepted an empty key".to_owned())
+                }
+                (Ok(()), Some(oe)) => Err(format!(
+                    "divergence on put_nil_key: redb accepted, oracle rejected ({oe})"
+                )),
+                (Err(e), None) => Err(format!(
+                    "divergence on put_nil_key: redb rejected ({e}), oracle accepted"
+                )),
+            }
+        }
         DiffOp::CloseReopen => {
             // Discard the pending batch on the Rust side — close
             // throws away any uncommitted state on the oracle child
@@ -963,26 +1010,34 @@ fn close_reopen_strat() -> Just<DiffOp> {
     Just(DiffOp::CloseReopen)
 }
 
+/// Generates a `PutNilKey` op — empty key, non-empty value, random
+/// bucket. Pinned to value-`1..=16` (the same key alphabet) so the
+/// rejection path is the only error axis under test.
+fn put_nil_key_strat() -> impl Strategy<Value = DiffOp> {
+    (bucket_idx(), value_bytes()).prop_map(|(bucket, value)| DiffOp::PutNilKey { bucket, value })
+}
+
 /// Per-op strategy. Weights derived from plan §3 by zeroing the op
-/// classes that don't yet exist (`CommitGroup`, `Defragment`,
-/// error-triggering) and renormalizing.
+/// classes that don't yet exist (`CommitGroup`, `Defragment`) and
+/// renormalizing.
 ///
-/// Put 49 / Delete 19 / `DeleteRange` 5 / Commit 20 / Rollback 5 /
-/// `CloseReopen` 2 = total 100. `CloseReopen` weight is small on
-/// purpose: each fires drops both engine handles and respawns a Go
-/// subprocess (~50 ms), so heavy oversampling would dominate runtime
-/// without proportional bug-finding power. Two percent over a
-/// length-1..=40 sequence yields ~0.8 close-reopen events per case
-/// on average — enough to exercise the path frequently across the
-/// 256-case sweep without blowing past the 60 s budget.
+/// Put 47 / Delete 19 / `DeleteRange` 5 / Commit 20 / Rollback 5 /
+/// `CloseReopen` 2 / `PutNilKey` 2 = total 100. `CloseReopen` weight
+/// is small on purpose (~50 ms per fire on subprocess respawn);
+/// `PutNilKey` is small because every fire is a guaranteed
+/// rejection-path test — diminishing returns past one or two per
+/// case. Two percent over a length-1..=40 sequence yields ~0.8
+/// fires per case on average — enough to exercise both error and
+/// durability axes frequently without blowing past the 60 s budget.
 fn op_strat() -> impl Strategy<Value = DiffOp> {
     prop_oneof![
-        49 => put_strat(),
+        47 => put_strat(),
         19 => delete_strat(),
         5  => delete_range_strat(),
         20 => commit_strat(),
         5  => rollback_strat(),
         2  => close_reopen_strat(),
+        2  => put_nil_key_strat(),
     ]
 }
 

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -627,6 +627,18 @@ struct Case {
     /// `Case::new` time so the close-reopen cycle is durability-
     /// neutral against the original spawn.
     fsync: bool,
+    /// Set to `true` from `run_case` immediately before returning a
+    /// divergence error. Read by `Drop` to short-circuit the
+    /// `TempDir` cleanup via `into_path()`, leaving the raw on-disk
+    /// state behind as a belt-and-suspenders fallback to the
+    /// `target/differential-failures/` artifact dump (plan §9 commit
+    /// 9 step 1). `Cell` instead of plain `bool` because mark-failed
+    /// fires from contexts that hold only `&Case` (the divergence
+    /// branch in `run_case` borrows `case` mutably for the dump
+    /// path; flipping `failed` after that borrow ends would still
+    /// require interior mutability if any caller ever flipped it
+    /// while another `&Case` was live).
+    failed: std::cell::Cell<bool>,
 }
 
 impl Case {
@@ -662,7 +674,18 @@ impl Case {
             redb_dir: Some(redb_dir),
             oracle_binary_path: binary.to_path_buf(),
             fsync,
+            failed: std::cell::Cell::new(false),
         })
+    }
+
+    /// Mark this case as failed so `Drop` preserves the raw tempdirs
+    /// via `TempDir::into_path()` instead of cleaning them up. Idem-
+    /// potent — calling twice is a no-op. Set from `run_case` before
+    /// returning a divergence error (and from any future test path
+    /// that wants the raw on-disk state preserved alongside the
+    /// `target/differential-failures/` dump).
+    fn mark_failed(&self) {
+        self.failed.set(true);
     }
 
     /// Mutable accessor for the Go oracle subprocess handle. Panics
@@ -765,6 +788,59 @@ impl Case {
         self.oracle = Some(oracle);
         self.redb = Some(redb);
         Ok(())
+    }
+}
+
+/// Panic-preserving / failure-preserving cleanup (plan §9 commit 9
+/// step 1).
+///
+/// On `failed.get() == true` we leak both `TempDir`s via
+/// `TempDir::keep()` so the raw on-disk state remains available for
+/// the developer alongside the `target/differential-failures/` dump.
+/// `keep()` (was `into_path()`, deprecated in tempfile 3.27) is the
+/// documented idiom — it consumes the handle and skips the cleanup
+/// destructor, leaving the directory behind without leaking anything
+/// else (`mem::forget` would leak the whole `Case`, including the
+/// live `RedbBackend` that still holds redb's single-writer file
+/// lock).
+///
+/// We must drop `oracle` and `redb` first inside this body — they
+/// own file locks (bbolt's flock and redb's single-writer guard)
+/// against the directories. Releasing those handles before the
+/// `into_path()` calls means a developer poking at the artifacts
+/// later does not race a still-live process. `oracle.take()` runs
+/// the `GoOracle::drop` impl which kills the child (releasing the
+/// flock); `redb.take()` runs `RedbBackend::drop` which closes the
+/// redb database (releasing the writer guard).
+///
+/// Drop order matters even on the success path: the field-decl
+/// order is `oracle, redb, bbolt_dir, redb_dir`, and Rust drops
+/// fields in declaration order. So even with no manual Drop, the
+/// implicit order is correct. The explicit `take()`s here just
+/// hoist that ordering ahead of the `failed`-flag branch so the
+/// `into_path()` happens *after* lock release on the failed path.
+impl Drop for Case {
+    fn drop(&mut self) {
+        // Release engine locks first, regardless of pass/fail.
+        drop(self.oracle.take());
+        drop(self.redb.take());
+
+        if self.failed.get() {
+            // Leak both tempdirs onto the user's disk. `keep`
+            // returns the path; we discard it because `run_case`
+            // already surfaced the canonical artifact dir under
+            // `target/differential-failures/`. The leaked tempdir
+            // is a fallback for the rare case where `dump_to`
+            // missed a file.
+            if let Some(d) = self.bbolt_dir.take() {
+                let _ = d.keep();
+            }
+            if let Some(d) = self.redb_dir.take() {
+                let _ = d.keep();
+            }
+        }
+        // On the success path the remaining `Some(TempDir)`s drop
+        // normally after this body returns and clean themselves up.
     }
 }
 
@@ -1557,6 +1633,11 @@ fn run_case(binary: &Path, ops: &[DiffOp]) -> Result<(), String> {
                 let bbolt_path = case.bbolt_db_path();
                 let redb_path = case.redb_dir_path();
                 let stderr = case.oracle_mut().stderr_snapshot();
+                // Mark failed BEFORE the dump so a panic mid-`dump_to`
+                // (disk full, permission denied) still preserves the
+                // raw tempdirs as a fallback. `Drop` reads this flag
+                // when `Case` goes out of scope at function return.
+                case.mark_failed();
                 let dump =
                     divergence.dump_to(&failure_artifacts_root(), &bbolt_path, &redb_path, &stderr);
                 let suffix = match dump {
@@ -2258,4 +2339,73 @@ fn divergence_dump_to_writes_all_artifacts() {
     // bbolt copy preserves source bytes.
     let bbolt_copy = std::fs::read(dir.join("oracle.db")).unwrap();
     assert_eq!(bbolt_copy, b"BBOLT_FAKE_DB");
+}
+
+/// Pin the `Case` failed-flag → `Drop` → `keep()` chain (plan §9
+/// commit 9 step 1). On `mark_failed()`, both tempdirs must survive
+/// the `Case` going out of scope so the developer has the raw
+/// on-disk state as a fallback to the `target/differential-failures/`
+/// dump. Cleans up the leaked dirs at the end so the test does not
+/// accumulate disk garbage on every run.
+#[test]
+fn case_drop_preserves_tempdirs_when_failed() {
+    let Some(binary) = skip_without_oracle("case_drop_preserves_tempdirs_when_failed") else {
+        return;
+    };
+    let case = Case::new(&binary, false).expect("Case::new");
+    // Capture paths *before* drop — `bbolt_db_path` joins
+    // "oracle.db" onto the bbolt tempdir, so its parent is what we
+    // want to check for survival.
+    let bbolt_dir = case
+        .bbolt_db_path()
+        .parent()
+        .expect("bbolt path has parent")
+        .to_path_buf();
+    let redb_dir = case.redb_dir_path();
+    case.mark_failed();
+    drop(case);
+    assert!(
+        bbolt_dir.exists(),
+        "bbolt_dir cleaned up despite failed=true: {}",
+        bbolt_dir.display()
+    );
+    assert!(
+        redb_dir.exists(),
+        "redb_dir cleaned up despite failed=true: {}",
+        redb_dir.display()
+    );
+    // Manual cleanup of leaked dirs — the test asserts the leak
+    // happened, then removes the evidence so CI does not accumulate
+    // gigabytes over time.
+    let _ = std::fs::remove_dir_all(&bbolt_dir);
+    let _ = std::fs::remove_dir_all(&redb_dir);
+}
+
+/// Counterpart to the failed-preservation test: on the success
+/// path the tempdirs MUST be cleaned up. Catches a regression where
+/// someone flips the polarity of the `failed` flag or accidentally
+/// calls `keep()` unconditionally.
+#[test]
+fn case_drop_cleans_tempdirs_on_success() {
+    let Some(binary) = skip_without_oracle("case_drop_cleans_tempdirs_on_success") else {
+        return;
+    };
+    let case = Case::new(&binary, false).expect("Case::new");
+    let bbolt_dir = case
+        .bbolt_db_path()
+        .parent()
+        .expect("bbolt path has parent")
+        .to_path_buf();
+    let redb_dir = case.redb_dir_path();
+    drop(case);
+    assert!(
+        !bbolt_dir.exists(),
+        "bbolt_dir leaked despite success: {}",
+        bbolt_dir.display()
+    );
+    assert!(
+        !redb_dir.exists(),
+        "redb_dir leaked despite success: {}",
+        redb_dir.display()
+    );
 }

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -74,6 +74,7 @@ use mango_storage::{
 };
 use proptest::prelude::*;
 use proptest::test_runner::{Config as ProptestConfig, TestCaseError, TestRunner};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tempfile::TempDir;
 
@@ -295,6 +296,27 @@ fn b64(bytes: &[u8]) -> String {
     BASE64.encode(bytes)
 }
 
+/// Serde adapter for serializing `Vec<u8>` fields as base64 strings
+/// instead of `serde_json`'s default JSON-array-of-bytes shape. Used
+/// by `#[serde(with = "base64_helper")]` on the byte-vector fields of
+/// [`DiffOp`] and [`GroupOp`] so seed files in
+/// `tests/differential_vs_bbolt/seeds/*.json` stay grep-friendly and
+/// ~4× smaller than the default encoding (plan §9 commit 9 step 6).
+mod base64_helper {
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::Engine as _;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn serialize<S: Serializer>(bytes: &[u8], ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&BASE64.encode(bytes))
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Vec<u8>, D::Error> {
+        let s = String::deserialize(de)?;
+        BASE64.decode(s).map_err(serde::de::Error::custom)
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Differential harness — plan §9 commit 7.
 // -----------------------------------------------------------------------------
@@ -335,23 +357,34 @@ fn bucket_name_of(idx: u8) -> &'static str {
 ///
 /// `#[derive(Debug, Clone)]` — cheap to clone for proptest
 /// shrinking; the harness does not hold ops across threads, so
-/// `Send`-ness is not required.
-#[derive(Debug, Clone)]
+/// `Send`-ness is not required. `Serialize` / `Deserialize` round-trip
+/// to/from `tests/differential_vs_bbolt/seeds/*.json` via the seed-
+/// replay driver (plan §9 commit 9 step 6); byte-vector fields are
+/// adapted through `base64_helper` so seed files stay grep-friendly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 enum DiffOp {
     /// Insert-or-overwrite a non-empty (key, value) in `bucket`.
     Put {
         bucket: u8,
+        #[serde(with = "base64_helper")]
         key: Vec<u8>,
+        #[serde(with = "base64_helper")]
         value: Vec<u8>,
     },
     /// Delete a single key. No-op on both engines when absent.
-    Delete { bucket: u8, key: Vec<u8> },
+    Delete {
+        bucket: u8,
+        #[serde(with = "base64_helper")]
+        key: Vec<u8>,
+    },
     /// Delete every key in `[start, end)`. Strategies generate
     /// `start <= end` — the `start > end` axis is an error-triggering
     /// op and lands in commit 8.
     DeleteRange {
         bucket: u8,
+        #[serde(with = "base64_helper")]
         start: Vec<u8>,
+        #[serde(with = "base64_helper")]
         end: Vec<u8>,
     },
     /// Commit the pending batch. If no writes have been staged since
@@ -378,7 +411,11 @@ enum DiffOp {
     /// bbolt) which `normalize_err` collapses to the shared
     /// `"empty key"`. No batch state changes on either side — the
     /// staging-time rejection means the pending txn is unaffected.
-    PutNilKey { bucket: u8, value: Vec<u8> },
+    PutNilKey {
+        bucket: u8,
+        #[serde(with = "base64_helper")]
+        value: Vec<u8>,
+    },
     /// Defragment / compact both engines. redb runs its in-place
     /// compaction; bbolt opens a fresh DB, copies via `bolt.Compact`,
     /// and atomic-renames over the original. Both reject if a txn is
@@ -412,21 +449,27 @@ enum DiffOp {
 /// `benches/oracles/bbolt/main.go::groupOp`). Reads are intentionally
 /// excluded — a read inside a write group would need its own txn
 /// (forbidden by the single-writer invariant) and is never emitted
-/// by the harness.
-#[derive(Debug, Clone)]
+/// by the harness. Serde derives match [`DiffOp`] for the seed-
+/// replay driver; byte fields use `base64_helper` for compactness.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 enum GroupOp {
     Put {
         bucket: u8,
+        #[serde(with = "base64_helper")]
         key: Vec<u8>,
+        #[serde(with = "base64_helper")]
         value: Vec<u8>,
     },
     Delete {
         bucket: u8,
+        #[serde(with = "base64_helper")]
         key: Vec<u8>,
     },
     DeleteRange {
         bucket: u8,
+        #[serde(with = "base64_helper")]
         start: Vec<u8>,
+        #[serde(with = "base64_helper")]
         end: Vec<u8>,
     },
 }
@@ -1312,6 +1355,74 @@ fn proptest_cases() -> u32 {
     match std::env::var("MANGO_DIFFERENTIAL_THOROUGH").as_deref() {
         Ok("1") => 10_000,
         _ => 256,
+    }
+}
+
+/// Round-trip every [`DiffOp`] variant through `serde_json` and back.
+/// Locks in the seed-file wire format (plan §9 commit 9 step 6) — a
+/// future structural change to `DiffOp` that breaks deserialization
+/// of older seed files would silently turn `replay_committed_seeds`
+/// into a no-op; this test fails loud first.
+///
+/// Bytes are explicitly chosen to exercise the base64 path: NUL,
+/// newline, and high-bit bytes that JSON would otherwise mangle in
+/// the default `Vec<u8>` encoding.
+#[test]
+fn diff_op_serde_round_trip_every_variant() {
+    let cases: Vec<DiffOp> = vec![
+        DiffOp::Put {
+            bucket: 0,
+            key: b"\x00\nk".to_vec(),
+            value: b"\xffv".to_vec(),
+        },
+        DiffOp::Delete {
+            bucket: 1,
+            key: b"k".to_vec(),
+        },
+        DiffOp::DeleteRange {
+            bucket: 2,
+            start: Vec::new(),
+            end: vec![0xff],
+        },
+        DiffOp::Commit { fsync: true },
+        DiffOp::Rollback,
+        DiffOp::CloseReopen,
+        DiffOp::PutNilKey {
+            bucket: 0,
+            value: b"v".to_vec(),
+        },
+        DiffOp::Defragment,
+        DiffOp::CommitGroup {
+            batches: vec![
+                vec![
+                    GroupOp::Put {
+                        bucket: 0,
+                        key: b"g".to_vec(),
+                        value: b"v".to_vec(),
+                    },
+                    GroupOp::Delete {
+                        bucket: 1,
+                        key: b"d".to_vec(),
+                    },
+                ],
+                vec![GroupOp::DeleteRange {
+                    bucket: 2,
+                    start: b"a".to_vec(),
+                    end: Vec::new(),
+                }],
+            ],
+            fsync: false,
+        },
+    ];
+    for op in &cases {
+        let s = serde_json::to_string(op).expect("serialize");
+        let back: DiffOp = serde_json::from_str(&s).expect("deserialize");
+        // Re-serialize and compare strings: structural equality without
+        // adding a `PartialEq` derive on `DiffOp` (which would require
+        // the same on `GroupOp` and start a chain of implementation
+        // burdens for a test-only convenience).
+        let s2 = serde_json::to_string(&back).expect("re-serialize");
+        assert_eq!(s, s2, "round-trip diverged for {op:?}");
     }
 }
 

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -327,9 +327,10 @@ fn bucket_name_of(idx: u8) -> &'static str {
     BUCKET_NAMES[idx as usize]
 }
 
-/// An op in the differential language. Subset per plan §9 commit 7:
-/// `CommitGroup` / `Defragment` / `CloseReopen` / error-triggering
-/// ops land in commit 8.
+/// An op in the differential language. Commit 7 shipped Put / Delete /
+/// `DeleteRange` / Commit / Rollback. Commit 8 adds `CloseReopen`
+/// (process-restart durability axis); `CommitGroup` / `Defragment` /
+/// error-triggering ops land in subsequent commits.
 ///
 /// `#[derive(Debug, Clone)]` — cheap to clone for proptest
 /// shrinking; the harness does not hold ops across threads, so
@@ -362,6 +363,14 @@ enum DiffOp {
     /// an active txn is a no-op. Like `Commit`, followed by a
     /// snapshot diff for drift-detection.
     Rollback,
+    /// Drop both engine handles and reopen against the same on-disk
+    /// state. Tests durability across a "process restart". Any pending
+    /// batch is discarded on the Rust side (no fsync, no commit) and
+    /// the oracle's pending txn is dropped by closing its child
+    /// process — symmetrical and lossy by design. Followed by a
+    /// snapshot diff: post-reopen state must be byte-identical
+    /// between engines.
+    CloseReopen,
 }
 
 /// Mutable per-case state threaded through [`apply_op`]. Tracks the
@@ -384,8 +393,8 @@ struct RunState {
 ///
 /// 1. `oracle` — close the pipe, reap the Go child.
 /// 2. `redb` — close the redb Database handle.
-/// 3. `_bbolt_dir` — remove the bbolt db file.
-/// 4. `_redb_dir` — remove the redb db file.
+/// 3. `bbolt_dir` — remove the bbolt db file.
+/// 4. `redb_dir` — remove the redb db file.
 ///
 /// If the `TempDir`s dropped before the engines, `db.Close()` on the
 /// Go side would run on a deleted directory → EIO on fsync → panic
@@ -410,25 +419,17 @@ struct RunState {
 struct Case {
     oracle: Option<GoOracle>,
     redb: Option<RedbBackend>,
-    _bbolt_dir: Option<TempDir>,
-    _redb_dir: Option<TempDir>,
+    bbolt_dir: Option<TempDir>,
+    redb_dir: Option<TempDir>,
     /// Path to the prebuilt Go oracle binary, kept so
     /// `close_and_reopen` can respawn the subprocess. The binary is
     /// resolved once per test via `skip_without_oracle` and
     /// thread-safe to share by path.
-    #[expect(
-        dead_code,
-        reason = "consumed by close_and_reopen in the next commit on this branch"
-    )]
     oracle_binary_path: PathBuf,
     /// fsync bit threaded into every commit and into the new
     /// `GoOracle` constructed by `close_and_reopen`. Captured at
     /// `Case::new` time so the close-reopen cycle is durability-
     /// neutral against the original spawn.
-    #[expect(
-        dead_code,
-        reason = "consumed by close_and_reopen in the next commit on this branch"
-    )]
     fsync: bool,
 }
 
@@ -461,8 +462,8 @@ impl Case {
         Ok(Self {
             oracle: Some(oracle),
             redb: Some(redb),
-            _bbolt_dir: Some(bbolt_dir),
-            _redb_dir: Some(redb_dir),
+            bbolt_dir: Some(bbolt_dir),
+            redb_dir: Some(redb_dir),
             oracle_binary_path: binary.to_path_buf(),
             fsync,
         })
@@ -491,6 +492,62 @@ impl Case {
             self.redb.as_ref().expect("redb slot non-empty"),
             self.oracle.as_mut().expect("oracle slot non-empty"),
         )
+    }
+
+    /// Drop both engine handles, then respawn against the same on-disk
+    /// state. Tests that durable writes survive a "process restart"
+    /// (plan §3 axis B6 / §9 commit 8 step 5).
+    ///
+    /// Drop-then-reopen sequencing is load-bearing: `GoOracle::spawn`
+    /// acquires bbolt's flock and `RedbBackend::open` calls
+    /// `Database::create` (single-writer guard); both fail or hang if
+    /// the previous owner is still alive. `Option::take()` drops the
+    /// old handle *before* constructing the new one, eliminating the
+    /// overlap that `mem::replace` would create.
+    ///
+    /// The `TempDir`s in `bbolt_dir` / `redb_dir` are intentionally
+    /// not touched — the on-disk files must persist across the cycle
+    /// for the durability assertion to mean anything. Buckets are
+    /// re-registered on both sides because bbolt's `CreateBucket` and
+    /// redb's `register_bucket` are idempotent ("already registered"
+    /// is a no-op success), so this is cheap and keeps the post-reopen
+    /// state byte-identical to a fresh `Case::new`.
+    fn close_and_reopen(&mut self) -> Result<(), String> {
+        // Drop oracle first, then redb — same order as struct-field
+        // drop order, so no flock/lock-overlap is possible.
+        drop(self.oracle.take());
+        drop(self.redb.take());
+
+        let bbolt_dir = self
+            .bbolt_dir
+            .as_ref()
+            .expect("bbolt_dir slot non-empty")
+            .path();
+        let redb_dir = self
+            .redb_dir
+            .as_ref()
+            .expect("redb_dir slot non-empty")
+            .path();
+        let db_path = bbolt_dir.join("oracle.db");
+
+        let mut oracle = GoOracle::spawn(&self.oracle_binary_path, &db_path, self.fsync)
+            .map_err(|e| format!("oracle respawn: {e}"))?;
+        let redb = RedbBackend::open(BackendConfig::new(redb_dir.to_path_buf(), false))
+            .map_err(|e| format!("redb reopen: {e}"))?;
+
+        for (idx, name) in BUCKET_NAMES.iter().enumerate() {
+            let id = BucketId::new((idx + 1) as u16);
+            let resp = oracle
+                .call(&json!({"op":"bucket","name":name}))
+                .map_err(|e| format!("oracle bucket {name} (reopen): {e}"))?;
+            require_ok(&resp, &format!("bucket {name} (reopen)")).map_err(|e| e.to_string())?;
+            redb.register_bucket(name, id)
+                .map_err(|e| format!("redb register_bucket {name} (reopen): {e}"))?;
+        }
+
+        self.oracle = Some(oracle);
+        self.redb = Some(redb);
+        Ok(())
     }
 }
 
@@ -695,6 +752,18 @@ fn apply_op(
             snapshot_and_diff(redb, oracle)?;
             Ok(())
         }
+        DiffOp::CloseReopen => {
+            // Discard the pending batch on the Rust side — close
+            // throws away any uncommitted state on the oracle child
+            // (its in-memory bbolt txn dies with the process), so
+            // mirroring on the Rust side keeps the two state machines
+            // in lockstep. No fsync path, cannot fail.
+            state.pending = None;
+            case.close_and_reopen()?;
+            let (redb, oracle) = case.split_redb_and_oracle();
+            snapshot_and_diff(redb, oracle)?;
+            Ok(())
+        }
     }
 }
 
@@ -890,20 +959,30 @@ fn rollback_strat() -> Just<DiffOp> {
     Just(DiffOp::Rollback)
 }
 
-/// Per-op strategy. Weights derived from plan §3 by zeroing the
-/// op classes that don't exist in commit 7 (`CommitGroup`,
-/// `CloseReopen`, `Defragment`, error-triggering) and renormalizing.
+fn close_reopen_strat() -> Just<DiffOp> {
+    Just(DiffOp::CloseReopen)
+}
+
+/// Per-op strategy. Weights derived from plan §3 by zeroing the op
+/// classes that don't yet exist (`CommitGroup`, `Defragment`,
+/// error-triggering) and renormalizing.
 ///
-/// Put 50 / Delete 20 / `DeleteRange` 5 / Commit 20 / Rollback 5 =
-/// total 100. Put-heavy to build up state; Commit at 20 % keeps
-/// the snapshot-diff cadence frequent.
+/// Put 49 / Delete 19 / `DeleteRange` 5 / Commit 20 / Rollback 5 /
+/// `CloseReopen` 2 = total 100. `CloseReopen` weight is small on
+/// purpose: each fires drops both engine handles and respawns a Go
+/// subprocess (~50 ms), so heavy oversampling would dominate runtime
+/// without proportional bug-finding power. Two percent over a
+/// length-1..=40 sequence yields ~0.8 close-reopen events per case
+/// on average — enough to exercise the path frequently across the
+/// 256-case sweep without blowing past the 60 s budget.
 fn op_strat() -> impl Strategy<Value = DiffOp> {
     prop_oneof![
-        50 => put_strat(),
-        20 => delete_strat(),
+        49 => put_strat(),
+        19 => delete_strat(),
         5  => delete_range_strat(),
         20 => commit_strat(),
         5  => rollback_strat(),
+        2  => close_reopen_strat(),
     ]
 }
 

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -61,6 +61,7 @@
 )]
 
 use std::collections::{BTreeMap, VecDeque};
+use std::fmt::Write as _;
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
@@ -194,10 +195,6 @@ impl GoOracle {
     /// the child between the `lock` and `unlock` simply land *after*
     /// the snapshot — at-most-one-eviction lag is acceptable for
     /// a divergence dump.
-    #[expect(
-        dead_code,
-        reason = "consumed by the failure-artifact dump path landing in plan §9 commit 9 step 3 on this branch"
-    )]
     fn stderr_snapshot(&self) -> Vec<u8> {
         let g = self.stderr_buf.lock();
         g.iter().copied().collect()
@@ -693,6 +690,27 @@ impl Case {
         )
     }
 
+    /// Path to bbolt's on-disk database file. Stable across
+    /// `close_and_reopen` because the `bbolt_dir` `TempDir` is
+    /// preserved across the cycle.
+    fn bbolt_db_path(&self) -> PathBuf {
+        self.bbolt_dir
+            .as_ref()
+            .expect("bbolt_dir slot non-empty")
+            .path()
+            .join("oracle.db")
+    }
+
+    /// Path to redb's tempdir. Caller copies every flat file beneath
+    /// it on the failure-artifact path.
+    fn redb_dir_path(&self) -> PathBuf {
+        self.redb_dir
+            .as_ref()
+            .expect("redb_dir slot non-empty")
+            .path()
+            .to_path_buf()
+    }
+
     /// Drop both engine handles, then respawn against the same on-disk
     /// state. Tests that durable writes survive a "process restart"
     /// (plan §3 axis B6 / §9 commit 8 step 5).
@@ -832,7 +850,7 @@ fn apply_op(
     case: &mut Case,
     state: &mut RunState,
     op: &DiffOp,
-) -> Result<(), String> {
+) -> Result<(), OpError> {
     match op {
         DiffOp::Put { bucket, key, value } => {
             ensure_txn(case, state)?;
@@ -918,17 +936,21 @@ fn apply_op(
                     let redb_norm = normalize_err(&e.to_string());
                     let oracle_norm = normalize_err(&oe);
                     if redb_norm != oracle_norm {
-                        return Err(format!(
+                        return Err(OpError::Other(format!(
                             "symmetric commit error but normalized strings diverge: \
                              redb={redb_norm:?} (raw={e}), oracle={oracle_norm:?} (raw={oe})"
-                        ));
+                        )));
                     }
                 }
                 (Ok(_), Some(oe)) => {
-                    return Err(format!("divergence on commit: redb ok, oracle err={oe}"));
+                    return Err(OpError::Other(format!(
+                        "divergence on commit: redb ok, oracle err={oe}"
+                    )));
                 }
                 (Err(e), None) => {
-                    return Err(format!("divergence on commit: redb err={e}, oracle ok"));
+                    return Err(OpError::Other(format!(
+                        "divergence on commit: redb err={e}, oracle ok"
+                    )));
                 }
             }
             let (redb, oracle) = case.split_redb_and_oracle();
@@ -973,22 +995,22 @@ fn apply_op(
                     let redb_norm = normalize_err(&e.to_string());
                     let oracle_norm = normalize_err(&oe);
                     if redb_norm != oracle_norm {
-                        return Err(format!(
+                        return Err(OpError::Other(format!(
                             "symmetric put_nil_key error but normalized strings diverge: \
                              redb={redb_norm:?} (raw={e}), oracle={oracle_norm:?} (raw={oe})"
-                        ));
+                        )));
                     }
                     Ok(())
                 }
-                (Ok(()), None) => {
-                    Err("divergence on put_nil_key: both engines accepted an empty key".to_owned())
-                }
-                (Ok(()), Some(oe)) => Err(format!(
+                (Ok(()), None) => Err(OpError::Other(
+                    "divergence on put_nil_key: both engines accepted an empty key".to_owned(),
+                )),
+                (Ok(()), Some(oe)) => Err(OpError::Other(format!(
                     "divergence on put_nil_key: redb accepted, oracle rejected ({oe})"
-                )),
-                (Err(e), None) => Err(format!(
+                ))),
+                (Err(e), None) => Err(OpError::Other(format!(
                     "divergence on put_nil_key: redb rejected ({e}), oracle accepted"
-                )),
+                ))),
             }
         }
         DiffOp::CloseReopen => {
@@ -1103,21 +1125,21 @@ fn apply_op(
                     let redb_norm = normalize_err(&e.to_string());
                     let oracle_norm = normalize_err(&oe);
                     if redb_norm != oracle_norm {
-                        return Err(format!(
+                        return Err(OpError::Other(format!(
                             "symmetric commit_group error but normalized strings diverge: \
                              redb={redb_norm:?} (raw={e}), oracle={oracle_norm:?} (raw={oe})"
-                        ));
+                        )));
                     }
                 }
                 (Ok(()), Some(oe)) => {
-                    return Err(format!(
+                    return Err(OpError::Other(format!(
                         "divergence on commit_group: redb ok, oracle err={oe}"
-                    ));
+                    )));
                 }
                 (Err(e), None) => {
-                    return Err(format!(
+                    return Err(OpError::Other(format!(
                         "divergence on commit_group: redb err={e}, oracle ok"
-                    ));
+                    )));
                 }
             }
             let (redb, oracle) = case.split_redb_and_oracle();
@@ -1151,17 +1173,21 @@ fn apply_op(
                     let redb_norm = normalize_err(&e.to_string());
                     let oracle_norm = normalize_err(&oe);
                     if redb_norm != oracle_norm {
-                        return Err(format!(
+                        return Err(OpError::Other(format!(
                             "symmetric defrag error but normalized strings diverge: \
                              redb={redb_norm:?} (raw={e}), oracle={oracle_norm:?} (raw={oe})"
-                        ));
+                        )));
                     }
                 }
                 (Ok(()), Some(oe)) => {
-                    return Err(format!("divergence on defrag: redb ok, oracle err={oe}"));
+                    return Err(OpError::Other(format!(
+                        "divergence on defrag: redb ok, oracle err={oe}"
+                    )));
                 }
                 (Err(e), None) => {
-                    return Err(format!("divergence on defrag: redb err={e}, oracle ok"));
+                    return Err(OpError::Other(format!(
+                        "divergence on defrag: redb err={e}, oracle ok"
+                    )));
                 }
             }
             let (redb, oracle) = case.split_redb_and_oracle();
@@ -1182,6 +1208,223 @@ const RANGE_END_SENTINEL: &[u8] = &[0xff; 17];
 /// materialized via iteration over each registered bucket. Used by
 /// [`snapshot_and_diff`] to compare byte-identically.
 type StateMap = BTreeMap<(String, Vec<u8>), Vec<u8>>;
+
+// ============================================================================
+// Failure-artifact reporting (plan §9 commit 9 step 2)
+// ----------------------------------------------------------------------------
+// On any post-commit-boundary divergence we preserve a self-contained
+// repro under `target/differential-failures/<utc>-<hash8>/` so the
+// next investigator can re-run the exact case against the exact
+// engine state without re-deriving anything from CI logs.
+// ============================================================================
+
+/// One row of disagreement between bbolt's snapshot and redb's
+/// snapshot at a commit boundary. `bbolt_val == None` means "key
+/// absent from bbolt"; same for `redb_val`. Rendered into `diff.txt`
+/// human-readable form; not serde-serialized (the wire artifact is
+/// `ops.json`, not the diff).
+#[derive(Debug, Clone)]
+struct DiffEntry {
+    bucket: String,
+    key: Vec<u8>,
+    bbolt_val: Option<Vec<u8>>,
+    redb_val: Option<Vec<u8>>,
+}
+
+/// Error variant for `apply_op`. Splitting `Divergence` from
+/// `Other` lets `run_case` route the two paths differently:
+/// `Divergence` triggers an artifact dump and a divergence-shaped
+/// error message; `Other` is a harness or oracle fault and passes
+/// through as a plain string. Without this split we'd have to
+/// reverse-engineer the kind from a stringified message at the
+/// `run_case` boundary.
+#[derive(Debug)]
+enum OpError {
+    /// Snapshot diff disagreed at a commit boundary. Carries the
+    /// per-key entries so the caller can dump them.
+    Divergence(Vec<DiffEntry>),
+    /// Anything else: oracle subprocess error, redb engine error,
+    /// JSON build error, normalization mismatch on a symmetric
+    /// failure path. Already a human-readable string by the time
+    /// the inner `?` operator wraps it.
+    Other(String),
+}
+
+impl From<String> for OpError {
+    fn from(s: String) -> Self {
+        Self::Other(s)
+    }
+}
+
+impl std::fmt::Display for OpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Divergence(entries) => {
+                write!(f, "snapshot divergence ({} differing keys)", entries.len())
+            }
+            Self::Other(s) => f.write_str(s),
+        }
+    }
+}
+
+/// A complete failure case: the op sequence that produced the
+/// divergence, the per-key diff at the moment of detection, and a
+/// stable hash of the ops for the artifact dirname. Constructed by
+/// `run_case` on the divergence path; written to disk via `dump_to`.
+struct Divergence {
+    /// FNV-1a-64 hash of the ops sequence in JSON form. Surfaces in
+    /// the dump dirname (first 8 hex chars) so the same op-sequence
+    /// always lands in the same dirname slot, making CI artifact
+    /// upload deterministic across re-runs of the same seed.
+    case_hash: u64,
+    /// The full op sequence run before divergence. Round-trippable
+    /// via the serde derives added in commit 9a.
+    ops: Vec<DiffOp>,
+    /// Per-key disagreements at the commit boundary where divergence
+    /// was first detected. Ordered by `(bucket, key)` ascending.
+    diff: Vec<DiffEntry>,
+}
+
+impl Divergence {
+    /// Hash the JSON-serialized ops with FNV-1a-64. We hand-roll FNV
+    /// rather than pull `sha2` (and its 6 transitives needing supply-
+    /// chain exemptions) because `case_hash` is a developer-facing
+    /// identifier — only 8 hex chars surface in the dirname — not a
+    /// security primitive. See `Cargo.toml` dev-deps comment for the
+    /// deviation rationale.
+    fn new(ops: &[DiffOp], diff: Vec<DiffEntry>) -> Self {
+        let json = serde_json::to_vec(ops).unwrap_or_default();
+        Self {
+            case_hash: fnv1a_64(&json),
+            ops: ops.to_vec(),
+            diff,
+        }
+    }
+
+    /// Write all artifacts under `<root>/<utc-secs>-<hash8>/`:
+    ///
+    /// * `ops.json`   — pretty-printed `Vec<DiffOp>` for replay
+    /// * `oracle.db`  — copy of bbolt's on-disk file
+    /// * `mango.redb` — copy of redb's data file (whichever file in
+    ///   the redb tempdir matches; redb writes a single file)
+    /// * `diff.txt`   — human-readable per-key diff
+    /// * `stderr.log` — bbolt oracle's stderr ring-buffer snapshot
+    ///
+    /// Returns the dirname on success. Errors are surfaced as
+    /// `io::Error` so a partial dump still propagates a useful
+    /// message; we deliberately do NOT swallow them — a silent
+    /// dump-failure on a real divergence would defeat the whole
+    /// point.
+    fn dump_to(
+        &self,
+        root: &Path,
+        bbolt_db: &Path,
+        redb_dir: &Path,
+        stderr: &[u8],
+    ) -> io::Result<PathBuf> {
+        let utc_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let hash8 = format!("{:016x}", self.case_hash);
+        let dirname = format!("{utc_secs}-{}", &hash8[..8]);
+        let dir = root.join(dirname);
+        std::fs::create_dir_all(&dir)?;
+
+        // ops.json — round-trippable via serde derives.
+        let ops_json = serde_json::to_vec_pretty(&self.ops).map_err(io::Error::other)?;
+        std::fs::write(dir.join("ops.json"), ops_json)?;
+
+        // oracle.db — copy by path. bbolt's file lock is released by
+        // the time we get here only if the oracle child is dead;
+        // since `Case` is still alive at dump time, the child still
+        // holds the flock. `fs::copy` on Linux/macOS does not require
+        // exclusive access (just read access on the source), so the
+        // copy succeeds despite the live flock.
+        if bbolt_db.exists() {
+            std::fs::copy(bbolt_db, dir.join("oracle.db"))?;
+        }
+
+        // redb writes a single file inside the dir; copy every flat
+        // file in it (no recursion — the tempdir is flat by
+        // construction in `Case::new`).
+        if redb_dir.exists() {
+            for entry in std::fs::read_dir(redb_dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                if path.is_file() {
+                    let name = entry.file_name();
+                    std::fs::copy(&path, dir.join(name))?;
+                }
+            }
+        }
+
+        // diff.txt — first 100 entries human-readable, base64 for
+        // bytes. 100 is enough to spot a pattern but bounds the
+        // artifact size on pathological multi-MB diffs. `writeln!`
+        // into the String avoids the temporary alloc that
+        // `push_str(&format!(...))` would create per row (clippy
+        // `format_push_string`); the trait import lives at file top.
+        let mut diff_text = String::new();
+        writeln!(
+            &mut diff_text,
+            "DIVERGENCE: {} differing keys (showing up to 100)\n",
+            self.diff.len()
+        )
+        .map_err(io::Error::other)?;
+        for entry in self.diff.iter().take(100) {
+            let key_b64 = BASE64.encode(&entry.key);
+            let bbolt = entry
+                .bbolt_val
+                .as_ref()
+                .map_or_else(|| "<absent>".to_owned(), |v| BASE64.encode(v));
+            let redb = entry
+                .redb_val
+                .as_ref()
+                .map_or_else(|| "<absent>".to_owned(), |v| BASE64.encode(v));
+            writeln!(
+                &mut diff_text,
+                "{}/{key_b64}\n  bbolt: {bbolt}\n  redb:  {redb}",
+                entry.bucket
+            )
+            .map_err(io::Error::other)?;
+        }
+        std::fs::write(dir.join("diff.txt"), diff_text)?;
+
+        // stderr.log — drained ring-buffer snapshot. May be empty if
+        // bbolt was quiet; written unconditionally so the artifact
+        // set is shape-stable.
+        std::fs::write(dir.join("stderr.log"), stderr)?;
+
+        Ok(dir)
+    }
+}
+
+/// FNV-1a-64. Hand-rolled per the supply-chain decision: 8 hex chars
+/// of a developer-facing dirname does not warrant 7 supply-chain
+/// exemptions. Constants are the standardized 64-bit FNV offset
+/// basis (`0xcbf2_9ce4_8422_2325`) and prime (`0x0000_0100_0000_01b3`).
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// Resolve the `target/differential-failures/` root. Honors
+/// `CARGO_TARGET_TMPDIR`'s parent (workspace target dir) so the
+/// path tracks `CARGO_TARGET_DIR` overrides automatically — nextest,
+/// custom out-of-tree builds, and CI runners that relocate target/
+/// all just work without env-var plumbing.
+fn failure_artifacts_root() -> PathBuf {
+    let tmpdir = PathBuf::from(env!("CARGO_TARGET_TMPDIR"));
+    tmpdir
+        .parent()
+        .map_or_else(|| tmpdir.clone(), Path::to_path_buf)
+        .join("differential-failures")
+}
 
 fn full_snapshot_redb(redb: &RedbBackend) -> Result<StateMap, String> {
     let snap = redb.snapshot().map_err(|e| format!("redb snapshot: {e}"))?;
@@ -1242,51 +1485,53 @@ fn full_snapshot_oracle(oracle: &mut GoOracle) -> Result<StateMap, String> {
 }
 
 /// Snapshot both engines at the same logical cut and assert
-/// byte-identical state. Commit 9 layers on artifact preservation
-/// (`target/differential-failures/<case>/{ops,bbolt,redb,diff}`);
-/// for now a plain `Err` with the minimal diff is sufficient — the
-/// proptest runner surfaces the message and the test fails loud.
-fn snapshot_and_diff(redb: &RedbBackend, oracle: &mut GoOracle) -> Result<(), String> {
-    let r = full_snapshot_redb(redb)?;
-    let o = full_snapshot_oracle(oracle)?;
+/// byte-identical state.
+///
+/// Returns `Ok(())` on equality. On disagreement returns
+/// `Err(OpError::Divergence(...))` carrying the per-key diff so
+/// [`run_case`] can dump artifacts before stringifying. Engine /
+/// oracle communication errors (snapshot fetch failures) surface as
+/// `Err(OpError::Other(...))` — those are harness faults, not data
+/// divergences, and must NOT trigger an artifact dump.
+fn snapshot_and_diff(redb: &RedbBackend, oracle: &mut GoOracle) -> Result<(), OpError> {
+    let r = full_snapshot_redb(redb).map_err(OpError::Other)?;
+    let o = full_snapshot_oracle(oracle).map_err(OpError::Other)?;
     if r == o {
         return Ok(());
     }
-    let mut lines = Vec::new();
-    lines.push(format!(
-        "DIVERGENCE: redb has {} entries, oracle has {}",
-        r.len(),
-        o.len()
-    ));
-    // Collect first 20 differing keys for minimal readable output.
-    let mut shown = 0usize;
+    let mut entries = Vec::new();
     let mut keys: std::collections::BTreeSet<&(String, Vec<u8>)> =
         std::collections::BTreeSet::new();
     keys.extend(r.keys());
     keys.extend(o.keys());
     for key in keys {
-        if shown >= 20 {
-            lines.push("...(truncated)".into());
-            break;
-        }
         let rv = r.get(key);
         let ov = o.get(key);
         if rv == ov {
             continue;
         }
-        shown += 1;
-        lines.push(format!(
-            "{}/{:?}: redb={:?}, oracle={:?}",
-            key.0, key.1, rv, ov
-        ));
+        entries.push(DiffEntry {
+            bucket: key.0.clone(),
+            key: key.1.clone(),
+            bbolt_val: ov.cloned(),
+            redb_val: rv.cloned(),
+        });
     }
-    Err(lines.join("\n"))
+    Err(OpError::Divergence(entries))
 }
 
 /// Run a sequence of [`DiffOp`]s against both engines. Returns
 /// `Ok(())` iff every post-commit snapshot diff agreed. Errors
 /// carry a human-readable message; the proptest runner promotes
 /// them into `TestCaseError::fail`.
+///
+/// On `OpError::Divergence` we dump a self-contained repro to
+/// `target/differential-failures/<utc>-<hash8>/` (see
+/// [`Divergence::dump_to`]). The dump path is included in the
+/// returned error message so CI logs and local proptest output
+/// surface it directly. Dump failures are folded into the message
+/// rather than masking the underlying divergence — a missing dump
+/// must never cause the test to "pass" silently.
 fn run_case(binary: &Path, ops: &[DiffOp]) -> Result<(), String> {
     // Default true; override with MANGO_DIFFERENTIAL_FSYNC=0 for
     // local macOS iteration (plan §7).
@@ -1304,7 +1549,26 @@ fn run_case(binary: &Path, ops: &[DiffOp]) -> Result<(), String> {
     let mut state = RunState::default();
 
     for (idx, op) in ops.iter().enumerate() {
-        apply_op(&rt, &mut case, &mut state, op).map_err(|e| format!("op[{idx}] {op:?}: {e}"))?;
+        match apply_op(&rt, &mut case, &mut state, op) {
+            Ok(()) => {}
+            Err(OpError::Other(s)) => return Err(format!("op[{idx}] {op:?}: {s}")),
+            Err(OpError::Divergence(diff)) => {
+                let divergence = Divergence::new(ops, diff);
+                let bbolt_path = case.bbolt_db_path();
+                let redb_path = case.redb_dir_path();
+                let stderr = case.oracle_mut().stderr_snapshot();
+                let dump =
+                    divergence.dump_to(&failure_artifacts_root(), &bbolt_path, &redb_path, &stderr);
+                let suffix = match dump {
+                    Ok(p) => format!(" (artifacts: {})", p.display()),
+                    Err(e) => format!(" (artifact dump failed: {e})"),
+                };
+                return Err(format!(
+                    "op[{idx}] {op:?}: snapshot divergence ({} differing keys){suffix}",
+                    divergence.diff.len()
+                ));
+            }
+        }
     }
     Ok(())
 }
@@ -1868,4 +2132,130 @@ fn proptest_256_cases_no_divergence() {
             Ok(())
         })
         .unwrap_or_else(|e| panic!("proptest divergence: {e}"));
+}
+
+/// Unit test for `Divergence::dump_to` — exercised independently of
+/// the live oracle so the artifact-write contract has a fast,
+/// deterministic regression even when no bbolt binary is installed
+/// (CI without the Go toolchain, contributor laptops, Miri runs).
+///
+/// Verifies:
+/// 1. The dirname format is `<utc-secs>-<hash8>` (8 hex chars).
+/// 2. All five artifacts (`ops.json`, `oracle.db`, `mango.redb`,
+///    `diff.txt`, `stderr.log`) are present.
+/// 3. `ops.json` round-trips back to the original `Vec<DiffOp>` via
+///    serde — pinning the wire shape that the seed-replay driver
+///    relies on.
+/// 4. `diff.txt` is human-readable and references the divergence
+///    bucket name verbatim.
+/// 5. `stderr.log` contains the bytes we passed in.
+/// 6. FNV-1a-64 of an empty op list is the algorithm's known
+///    initial-state value (`0xcbf2_9ce4_8422_2325`), so a future
+///    constant-tweak can't silently land.
+#[test]
+fn divergence_dump_to_writes_all_artifacts() {
+    // Constants are the standard FNV-1a-64 offset basis. If this
+    // assert ever fails, someone changed the algorithm.
+    assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+
+    let root = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let bbolt_db = src.path().join("oracle.db");
+    let redb_dir = src.path().join("redb");
+    std::fs::create_dir(&redb_dir).unwrap();
+
+    // Synthetic source files so dump_to has something to copy.
+    std::fs::write(&bbolt_db, b"BBOLT_FAKE_DB").unwrap();
+    std::fs::write(redb_dir.join("data.redb"), b"REDB_FAKE_DATA").unwrap();
+
+    let ops = vec![
+        DiffOp::Put {
+            bucket: 0,
+            key: b"k".to_vec(),
+            value: b"v".to_vec(),
+        },
+        DiffOp::Commit { fsync: false },
+    ];
+    let diff = vec![DiffEntry {
+        bucket: "alpha".to_owned(),
+        key: b"k".to_vec(),
+        bbolt_val: Some(b"v_bbolt".to_vec()),
+        redb_val: None,
+    }];
+    let divergence = Divergence::new(&ops, diff);
+
+    let dir = divergence
+        .dump_to(root.path(), &bbolt_db, &redb_dir, b"BBOLT_STDERR_BYTES")
+        .expect("dump_to succeeds");
+
+    // Dirname shape: `<digits>-<8 hex>` ⇒ split on '-' from the right.
+    let name = dir.file_name().unwrap().to_str().unwrap();
+    let (secs, hash) = name.rsplit_once('-').expect("dirname has dash");
+    assert!(
+        secs.chars().all(|c| c.is_ascii_digit()),
+        "secs prefix not all digits: {secs}"
+    );
+    assert_eq!(hash.len(), 8, "hash suffix wrong width: {hash}");
+    assert!(
+        hash.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash suffix not hex: {hash}"
+    );
+
+    // All five artifacts present.
+    for name in [
+        "ops.json",
+        "oracle.db",
+        "data.redb",
+        "diff.txt",
+        "stderr.log",
+    ] {
+        assert!(
+            dir.join(name).exists(),
+            "artifact {name} missing under {}",
+            dir.display()
+        );
+    }
+
+    // ops.json round-trips back to the original sequence.
+    let ops_bytes = std::fs::read(dir.join("ops.json")).unwrap();
+    let ops_back: Vec<DiffOp> = serde_json::from_slice(&ops_bytes).unwrap();
+    assert_eq!(ops_back.len(), ops.len());
+    match (&ops_back[0], &ops[0]) {
+        (
+            DiffOp::Put {
+                bucket: ba,
+                key: ka,
+                value: va,
+            },
+            DiffOp::Put {
+                bucket: bb,
+                key: kb,
+                value: vb,
+            },
+        ) => {
+            assert_eq!(ba, bb);
+            assert_eq!(ka, kb);
+            assert_eq!(va, vb);
+        }
+        other => panic!("ops[0] round-trip mismatch: {other:?}"),
+    }
+
+    // diff.txt mentions the divergence bucket verbatim.
+    let diff_text = std::fs::read_to_string(dir.join("diff.txt")).unwrap();
+    assert!(
+        diff_text.contains("alpha/"),
+        "diff.txt missing bucket marker: {diff_text}"
+    );
+    assert!(
+        diff_text.contains("DIVERGENCE: 1 differing keys"),
+        "diff.txt missing summary: {diff_text}"
+    );
+
+    // stderr.log preserves the bytes we passed in.
+    let stderr = std::fs::read(dir.join("stderr.log")).unwrap();
+    assert_eq!(stderr, b"BBOLT_STDERR_BYTES");
+
+    // bbolt copy preserves source bytes.
+    let bbolt_copy = std::fs::read(dir.join("oracle.db")).unwrap();
+    assert_eq!(bbolt_copy, b"BBOLT_FAKE_DB");
 }

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -1543,6 +1543,83 @@ fn smoke_10_ops_no_divergence() {
     run_case(&binary, &ops).expect("smoke 10 ops diverged");
 }
 
+/// Deterministic regression test for every advanced op variant
+/// (`CommitGroup`, `CloseReopen`, `Defragment`, `PutNilKey`).
+/// Independent of proptest — guarantees these paths are exercised
+/// every test run even if a proptest config change zeros their
+/// weights. Each op is followed by enough state-mutating context
+/// to make a divergence observable (writes before/after, a final
+/// commit + snapshot diff).
+#[test]
+fn smoke_advanced_ops_no_divergence() {
+    let Some(binary) = skip_without_oracle("smoke_advanced_ops_no_divergence") else {
+        return;
+    };
+    let ops = vec![
+        // Seed: two committed keys so Defragment/CloseReopen have
+        // real state to preserve.
+        DiffOp::Put {
+            bucket: 0,
+            key: b"k1".to_vec(),
+            value: b"v1".to_vec(),
+        },
+        DiffOp::Put {
+            bucket: 1,
+            key: b"k2".to_vec(),
+            value: b"v2".to_vec(),
+        },
+        DiffOp::Commit { fsync: false },
+        // PutNilKey: both engines must reject with normalized
+        // "empty key". A successful put on either side is divergence.
+        DiffOp::PutNilKey {
+            bucket: 0,
+            value: b"v".to_vec(),
+        },
+        DiffOp::Commit { fsync: false },
+        // CommitGroup with a non-empty multi-batch group.
+        DiffOp::CommitGroup {
+            batches: vec![
+                vec![
+                    GroupOp::Put {
+                        bucket: 0,
+                        key: b"g1".to_vec(),
+                        value: b"a".to_vec(),
+                    },
+                    GroupOp::Delete {
+                        bucket: 0,
+                        key: b"k1".to_vec(),
+                    },
+                ],
+                vec![GroupOp::Put {
+                    bucket: 2,
+                    key: b"g2".to_vec(),
+                    value: b"b".to_vec(),
+                }],
+            ],
+            fsync: false,
+        },
+        // CommitGroup edge case: empty outer Vec is a legal no-op.
+        DiffOp::CommitGroup {
+            batches: vec![],
+            fsync: false,
+        },
+        // Defragment: post-state must remain byte-identical.
+        DiffOp::Defragment,
+        // CloseReopen: durability across a "process restart". The
+        // committed state from above must survive intact.
+        DiffOp::CloseReopen,
+        // Final write + commit so the snapshot-diff has a fresh
+        // mutation to compare across the full op sequence.
+        DiffOp::Put {
+            bucket: 1,
+            key: b"k3".to_vec(),
+            value: b"v3".to_vec(),
+        },
+        DiffOp::Commit { fsync: false },
+    ];
+    run_case(&binary, &ops).expect("smoke advanced ops diverged");
+}
+
 /// Proptest-driven 256-case (default) / 10k-case (thorough) sweep.
 ///
 /// Every generated sequence ends in `Commit`, so the terminal op

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -69,7 +69,8 @@ use std::time::{Duration, Instant};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
 use mango_storage::{
-    Backend, BackendConfig, BucketId, ReadSnapshot, RedbBackend, RedbBatch, WriteBatch,
+    Backend, BackendConfig, BackendError, BucketId, ReadSnapshot, RedbBackend, RedbBatch,
+    WriteBatch,
 };
 use proptest::prelude::*;
 use proptest::test_runner::{Config as ProptestConfig, TestCaseError, TestRunner};
@@ -386,6 +387,48 @@ enum DiffOp {
     /// Followed by a snapshot diff: post-defrag state must remain
     /// byte-identical between engines.
     Defragment,
+    /// Commit multiple batches atomically as a single group. Mirrors
+    /// `Backend::commit_group` on the Rust side and the oracle's
+    /// `commit_group` (whose `req.Batches` is `[][]groupOp`). All
+    /// inner mutations succeed-or-fail as one — bbolt's Update
+    /// closure rolls back on any error, redb's `commit_group` commits
+    /// all staged batches in a single write txn. Pre-condition:
+    /// no active txn (both engines reject otherwise), so the harness
+    /// rolls back any pending batch first.
+    CommitGroup {
+        /// Outer Vec is batches; inner is the ops in that batch.
+        /// Empty inner Vecs and an empty outer Vec are intentionally
+        /// generated to exercise the no-op edge cases on both engines.
+        batches: Vec<Vec<GroupOp>>,
+        /// Threaded through to bbolt's `db.NoSync` flip and
+        /// redb's commit-time fsync. Macroaligned with `Commit`
+        /// to keep the durability axis consistent.
+        fsync: bool,
+    },
+}
+
+/// One mutation inside a [`DiffOp::CommitGroup`] batch. Mirrors the
+/// Go oracle's `groupOp` struct field-for-field (see
+/// `benches/oracles/bbolt/main.go::groupOp`). Reads are intentionally
+/// excluded — a read inside a write group would need its own txn
+/// (forbidden by the single-writer invariant) and is never emitted
+/// by the harness.
+#[derive(Debug, Clone)]
+enum GroupOp {
+    Put {
+        bucket: u8,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    },
+    Delete {
+        bucket: u8,
+        key: Vec<u8>,
+    },
+    DeleteRange {
+        bucket: u8,
+        start: Vec<u8>,
+        end: Vec<u8>,
+    },
 }
 
 /// Mutable per-case state threaded through [`apply_op`]. Tracks the
@@ -819,6 +862,127 @@ fn apply_op(
             snapshot_and_diff(redb, oracle)?;
             Ok(())
         }
+        DiffOp::CommitGroup { batches, fsync } => {
+            // commit_group requires no active txn on both engines.
+            // Roll back the pending batch symmetrically before the
+            // call so the operation under test is the multi-batch
+            // commit, not a txn-active error path.
+            if state.pending.take().is_some() {
+                let resp = case
+                    .oracle_mut()
+                    .call(&json!({"op":"rollback"}))
+                    .map_err(|e| format!("oracle pre-commit_group rollback: {e}"))?;
+                require_ok(&resp, "pre-commit_group rollback").map_err(|e| e.to_string())?;
+            }
+
+            // Build the JSON wire shape for the oracle's
+            // `[][]groupOp` field. Done before any redb staging so
+            // a JSON build error doesn't leave us with an
+            // open-ended state on either side.
+            let json_batches: Vec<Vec<Value>> = batches
+                .iter()
+                .map(|inner| {
+                    inner
+                        .iter()
+                        .map(|op| match op {
+                            GroupOp::Put { bucket, key, value } => json!({
+                                "op":"put",
+                                "bucket": bucket_name_of(*bucket),
+                                "key": b64(key),
+                                "value": b64(value),
+                            }),
+                            GroupOp::Delete { bucket, key } => json!({
+                                "op":"delete",
+                                "bucket": bucket_name_of(*bucket),
+                                "key": b64(key),
+                            }),
+                            GroupOp::DeleteRange { bucket, start, end } => json!({
+                                "op":"delete_range",
+                                "bucket": bucket_name_of(*bucket),
+                                "start": b64(start),
+                                "end": b64(end),
+                            }),
+                        })
+                        .collect()
+                })
+                .collect();
+
+            // Stage each batch on redb. We collect into a Vec rather
+            // than a streaming iterator because Backend::commit_group
+            // takes ownership.
+            let mut redb_batches = Vec::with_capacity(batches.len());
+            let mut staging_err: Option<BackendError> = None;
+            'staging: for inner in batches {
+                let mut b = match case.redb().begin_batch() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        staging_err = Some(e);
+                        break 'staging;
+                    }
+                };
+                for op in inner {
+                    let bucket_id = match op {
+                        GroupOp::Put { bucket, .. }
+                        | GroupOp::Delete { bucket, .. }
+                        | GroupOp::DeleteRange { bucket, .. } => bucket_id_of(*bucket),
+                    };
+                    let res = match op {
+                        GroupOp::Put { key, value, .. } => b.put(bucket_id, key, value),
+                        GroupOp::Delete { key, .. } => b.delete(bucket_id, key),
+                        GroupOp::DeleteRange { start, end, .. } => {
+                            b.delete_range(bucket_id, start, end)
+                        }
+                    };
+                    if let Err(e) = res {
+                        staging_err = Some(e);
+                        break 'staging;
+                    }
+                }
+                redb_batches.push(b);
+            }
+
+            let redb_res = if let Some(e) = staging_err {
+                Err(e)
+            } else {
+                rt.block_on(case.redb().commit_group(redb_batches))
+                    .map(|_| ())
+            };
+            let resp = case
+                .oracle_mut()
+                .call(&json!({
+                    "op":"commit_group",
+                    "fsync": *fsync,
+                    "batches": json_batches,
+                }))
+                .map_err(|e| format!("oracle commit_group: {e}"))?;
+            let oracle_err = oracle_error(&resp);
+            match (redb_res, oracle_err) {
+                (Ok(()), None) => {}
+                (Err(e), Some(oe)) => {
+                    let redb_norm = normalize_err(&e.to_string());
+                    let oracle_norm = normalize_err(&oe);
+                    if redb_norm != oracle_norm {
+                        return Err(format!(
+                            "symmetric commit_group error but normalized strings diverge: \
+                             redb={redb_norm:?} (raw={e}), oracle={oracle_norm:?} (raw={oe})"
+                        ));
+                    }
+                }
+                (Ok(()), Some(oe)) => {
+                    return Err(format!(
+                        "divergence on commit_group: redb ok, oracle err={oe}"
+                    ));
+                }
+                (Err(e), None) => {
+                    return Err(format!(
+                        "divergence on commit_group: redb err={e}, oracle ok"
+                    ));
+                }
+            }
+            let (redb, oracle) = case.split_redb_and_oracle();
+            snapshot_and_diff(redb, oracle)?;
+            Ok(())
+        }
         DiffOp::Defragment => {
             // Both engines reject defrag/compact under an active txn.
             // Roll the pending batch back symmetrically before the
@@ -1073,21 +1237,53 @@ fn defragment_strat() -> Just<DiffOp> {
     Just(DiffOp::Defragment)
 }
 
-/// Per-op strategy. Weights derived from plan §3 by zeroing the op
-/// classes that don't yet exist (`CommitGroup`) and renormalizing.
+/// One inner op inside a [`DiffOp::CommitGroup`] batch. Reuses the
+/// same key/value/bucket alphabets as the top-level Put/Delete/
+/// `DeleteRange` strategies, so the multi-batch path exercises the
+/// same byte distributions as the single-batch path.
+fn group_op_strat() -> impl Strategy<Value = GroupOp> {
+    prop_oneof![
+        70 => (bucket_idx(), key_bytes(), value_bytes())
+            .prop_map(|(bucket, key, value)| GroupOp::Put { bucket, key, value }),
+        20 => (bucket_idx(), key_bytes())
+            .prop_map(|(bucket, key)| GroupOp::Delete { bucket, key }),
+        10 => (bucket_idx(), key_bytes(), key_bytes())
+            .prop_map(|(bucket, a, b)| {
+                let (start, end) = if a <= b { (a, b) } else { (b, a) };
+                GroupOp::DeleteRange { bucket, start, end }
+            }),
+    ]
+}
+
+/// Generates a `CommitGroup` op. Outer Vec length `0..=3` covers
+/// the empty-group edge case and small groupings; inner Vec length
+/// `0..=4` covers the empty-batch case (a legal no-op on both
+/// engines per the bbolt source) and small batches. Per-case op
+/// budget capped well below redb/bbolt's group-size limits to keep
+/// runtime predictable.
+fn commit_group_strat() -> impl Strategy<Value = DiffOp> {
+    (
+        proptest::collection::vec(proptest::collection::vec(group_op_strat(), 0..=4), 0..=3),
+        any::<bool>(),
+    )
+        .prop_map(|(batches, fsync)| DiffOp::CommitGroup { batches, fsync })
+}
+
+/// Per-op strategy. All advanced ops (`CommitGroup`, `Defragment`,
+/// `CloseReopen`, `PutNilKey`) now wired in.
 ///
-/// Put 46 / Delete 19 / `DeleteRange` 5 / Commit 20 / Rollback 5 /
-/// `CloseReopen` 2 / `PutNilKey` 2 / `Defragment` 1 = total 100.
-/// `Defragment` is the most expensive op (bbolt copies the entire
-/// file, then atomic-renames; redb runs in-place compaction holding
-/// the write lock) so it's pinned to 1 % — ~0.4 fires per case on
-/// average across length-1..=40 sequences. The 256-case sweep
-/// therefore exercises ≈100 defrag cycles, enough to detect a
-/// post-defrag divergence reliably without blowing past the 60 s
-/// budget.
+/// Put 44 / Delete 19 / `DeleteRange` 5 / Commit 20 / Rollback 5 /
+/// `CloseReopen` 2 / `PutNilKey` 2 / `Defragment` 1 / `CommitGroup`
+/// 2 = total 100. `CommitGroup` weight kept small (2 %) because each
+/// fire stages multiple inner ops at once — its bug-finding power
+/// per *fire* is high but per *inner op* is comparable to the single-
+/// batch `Commit` path. Two percent over a length-1..=40 sequence
+/// yields ~0.8 fires per case on average — enough to exercise the
+/// multi-batch atomicity path frequently across the 256-case sweep
+/// without dominating runtime.
 fn op_strat() -> impl Strategy<Value = DiffOp> {
     prop_oneof![
-        46 => put_strat(),
+        44 => put_strat(),
         19 => delete_strat(),
         5  => delete_range_strat(),
         20 => commit_strat(),
@@ -1095,6 +1291,7 @@ fn op_strat() -> impl Strategy<Value = DiffOp> {
         2  => close_reopen_strat(),
         2  => put_nil_key_strat(),
         1  => defragment_strat(),
+        2  => commit_group_strat(),
     ]
 }
 

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -2248,16 +2248,26 @@ fn replay_committed_seeds() {
         .join("tests")
         .join("differential_vs_bbolt")
         .join("seeds");
-    if !seeds_dir.exists() {
-        // Directory was removed in a hand edit — not a test failure
-        // by itself, but worth surfacing in the log so a contributor
-        // notices before the next divergence has nowhere to land.
-        eprintln!(
-            "replay_committed_seeds: seeds dir missing at {}; skipping",
-            seeds_dir.display()
-        );
-        return;
-    }
+    // The seeds directory is committed (with `seeds/README.md` as
+    // an anchor file). A missing directory is not "no seeds yet" —
+    // it is a structural integrity failure: a contributor's edit or
+    // a bad rebase has removed the regression-gate file. Hard-fail
+    // so the regression gate cannot silently disappear, per the
+    // seed-file retirement policy in BBOLT_QUIRKS.md.
+    assert!(
+        seeds_dir.is_dir(),
+        "seeds dir missing or not a directory at {}; refusing to silently pass — \
+         the directory is committed and must always exist (see seeds/README.md and \
+         benches/oracles/bbolt/BBOLT_QUIRKS.md § 'Seed-file retirement policy')",
+        seeds_dir.display()
+    );
+    let readme = seeds_dir.join("README.md");
+    assert!(
+        readme.is_file(),
+        "{} missing — the README is the structural anchor that keeps the directory \
+         alive in git and documents the seed lifecycle",
+        readme.display()
+    );
     let mut seeds: Vec<PathBuf> = std::fs::read_dir(&seeds_dir)
         .unwrap_or_else(|e| panic!("read_dir {}: {e}", seeds_dir.display()))
         .filter_map(Result::ok)

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -467,6 +467,42 @@ fn oracle_error(resp: &Value) -> Option<String> {
         .map(std::borrow::ToOwned::to_owned)
 }
 
+/// Normalize an error string to its engine-neutral core by stripping
+/// known wire-level wrappers. Go's oracle wraps errors as
+/// `"app: <Method>: <inner>"`, and redb's [`BackendError`] `Display`
+/// adds `"backend: "`. Structural prefix stripping — not method-name
+/// matching — keeps the helper decoupled from the oracle's exact
+/// labels.
+///
+/// If `"app: "` is present without the inner `": "` separator (a
+/// drift in `main.go` that lacks a method label), the helper still
+/// strips `"app: "` so a future wire-format change can't silently
+/// mask a divergence.
+fn normalize_err(raw: &str) -> String {
+    // Strip redb's BackendError Display prefix.
+    let s = raw.strip_prefix("backend: ").unwrap_or(raw);
+    // Strip the Go oracle's wire wrapper.
+    if let Some(rest) = s.strip_prefix("app: ") {
+        if let Some((_method, inner)) = rest.split_once(": ") {
+            return map_alias(inner);
+        }
+        return map_alias(rest);
+    }
+    map_alias(s)
+}
+
+/// Map bbolt's error vocabulary into redb's where they differ on wire
+/// but mean the same thing. Keep this table tiny and obvious — every
+/// entry is a deliberate "these two strings are the same error class"
+/// decision, not a regex or heuristic.
+fn map_alias(s: &str) -> String {
+    match s {
+        "key required" => "empty key".to_owned(),
+        "value cannot be nil" => "empty value".to_owned(),
+        other => other.to_owned(),
+    }
+}
+
 /// Apply one [`DiffOp`] in lockstep to both engines. Post-commit
 /// and post-rollback we run [`snapshot_and_diff`] to detect drift.
 ///
@@ -559,12 +595,18 @@ fn apply_op(
             match (redb_res, oracle_err) {
                 (Ok(_), None) => {}
                 (Err(e), Some(oe)) => {
-                    // Symmetric error — both engines rejected.
-                    // Expected on commit 7 only if a harness bug let
-                    // through a staging-time invariant violation.
-                    return Err(format!(
-                        "symmetric commit error (not expected in commit-7 scope): redb={e}, oracle={oe}"
-                    ));
+                    // Symmetric error — both engines rejected. The
+                    // plan §5 hard contract requires the normalized
+                    // errors to match: identical error class on wire,
+                    // modulo engine-specific wrappers.
+                    let redb_norm = normalize_err(&e.to_string());
+                    let oracle_norm = normalize_err(&oe);
+                    if redb_norm != oracle_norm {
+                        return Err(format!(
+                            "symmetric commit error but normalized strings diverge: \
+                             redb={redb_norm:?} (raw={e}), oracle={oracle_norm:?} (raw={oe})"
+                        ));
+                    }
                 }
                 (Ok(_), Some(oe)) => {
                     return Err(format!("divergence on commit: redb ok, oracle err={oe}"));
@@ -825,6 +867,35 @@ fn proptest_cases() -> u32 {
 
 /// The 10-op protocol round-trip smoke test (plan §9 commit 6).
 ///
+/// Pin the normalizer's behavior across the wire-wrapper permutations
+/// the harness actually observes. If `main.go` ever drifts — renaming
+/// a method label, changing the alias strings, or omitting the
+/// inner `": "` separator — this test is the canary.
+#[test]
+fn normalize_err_unit() {
+    // 1. Redb BackendError Display prefix stripped, pass-through after.
+    assert_eq!(normalize_err("backend: empty key"), "empty key");
+    // 2. Go oracle wrapper + alias: "Put: key required" → "empty key".
+    assert_eq!(normalize_err("app: Put: key required"), "empty key");
+    // 3. Same alias through Delete path.
+    assert_eq!(normalize_err("app: Delete: key required"), "empty key");
+    // 4. Empty-value alias through commit_group path.
+    assert_eq!(
+        normalize_err("app: commit_group: value cannot be nil"),
+        "empty value"
+    );
+    // 5. Redb prefix + non-aliased inner — pass through.
+    assert_eq!(
+        normalize_err("backend: UnknownBucket(BucketId { raw: 7 })"),
+        "UnknownBucket(BucketId { raw: 7 })"
+    );
+    // 6. Malformed Go wrapper without the inner ": " separator still
+    //    strips "app: " (defensive fallthrough per rust-expert NIT-5).
+    assert_eq!(normalize_err("app: kaboom"), "kaboom");
+    // 7. Pass-through for a string with no recognized prefix.
+    assert_eq!(normalize_err("some other thing"), "some other thing");
+}
+
 /// Exercises every basic op the harness will emit once proptest is
 /// wired, without yet involving `RedbBackend`. A green run here
 /// proves: (a) the subprocess spawn works, (b) JSON framing is

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -378,6 +378,14 @@ enum DiffOp {
     /// `"empty key"`. No batch state changes on either side — the
     /// staging-time rejection means the pending txn is unaffected.
     PutNilKey { bucket: u8, value: Vec<u8> },
+    /// Defragment / compact both engines. redb runs its in-place
+    /// compaction; bbolt opens a fresh DB, copies via `bolt.Compact`,
+    /// and atomic-renames over the original. Both reject if a txn is
+    /// active — the harness rolls back the pending batch first to
+    /// avoid that error path (it would mask real divergences).
+    /// Followed by a snapshot diff: post-defrag state must remain
+    /// byte-identical between engines.
+    Defragment,
 }
 
 /// Mutable per-case state threaded through [`apply_op`]. Tracks the
@@ -811,6 +819,50 @@ fn apply_op(
             snapshot_and_diff(redb, oracle)?;
             Ok(())
         }
+        DiffOp::Defragment => {
+            // Both engines reject defrag/compact under an active txn.
+            // Roll the pending batch back symmetrically before the
+            // call so the operation under test is the actual
+            // defragmentation, not the txn-active error path. Drop
+            // the redb staged ops (no fsync, infallible) and tell
+            // the oracle to rollback (no-op on the oracle if its
+            // child has no active txn).
+            if state.pending.take().is_some() {
+                let resp = case
+                    .oracle_mut()
+                    .call(&json!({"op":"rollback"}))
+                    .map_err(|e| format!("oracle pre-defrag rollback: {e}"))?;
+                require_ok(&resp, "pre-defrag rollback").map_err(|e| e.to_string())?;
+            }
+            let redb_res = rt.block_on(case.redb().defragment());
+            let resp = case
+                .oracle_mut()
+                .call(&json!({"op":"compact"}))
+                .map_err(|e| format!("oracle compact: {e}"))?;
+            let oracle_err = oracle_error(&resp);
+            match (redb_res, oracle_err) {
+                (Ok(()), None) => {}
+                (Err(e), Some(oe)) => {
+                    let redb_norm = normalize_err(&e.to_string());
+                    let oracle_norm = normalize_err(&oe);
+                    if redb_norm != oracle_norm {
+                        return Err(format!(
+                            "symmetric defrag error but normalized strings diverge: \
+                             redb={redb_norm:?} (raw={e}), oracle={oracle_norm:?} (raw={oe})"
+                        ));
+                    }
+                }
+                (Ok(()), Some(oe)) => {
+                    return Err(format!("divergence on defrag: redb ok, oracle err={oe}"));
+                }
+                (Err(e), None) => {
+                    return Err(format!("divergence on defrag: redb err={e}, oracle ok"));
+                }
+            }
+            let (redb, oracle) = case.split_redb_and_oracle();
+            snapshot_and_diff(redb, oracle)?;
+            Ok(())
+        }
     }
 }
 
@@ -1017,27 +1069,32 @@ fn put_nil_key_strat() -> impl Strategy<Value = DiffOp> {
     (bucket_idx(), value_bytes()).prop_map(|(bucket, value)| DiffOp::PutNilKey { bucket, value })
 }
 
+fn defragment_strat() -> Just<DiffOp> {
+    Just(DiffOp::Defragment)
+}
+
 /// Per-op strategy. Weights derived from plan §3 by zeroing the op
-/// classes that don't yet exist (`CommitGroup`, `Defragment`) and
-/// renormalizing.
+/// classes that don't yet exist (`CommitGroup`) and renormalizing.
 ///
-/// Put 47 / Delete 19 / `DeleteRange` 5 / Commit 20 / Rollback 5 /
-/// `CloseReopen` 2 / `PutNilKey` 2 = total 100. `CloseReopen` weight
-/// is small on purpose (~50 ms per fire on subprocess respawn);
-/// `PutNilKey` is small because every fire is a guaranteed
-/// rejection-path test — diminishing returns past one or two per
-/// case. Two percent over a length-1..=40 sequence yields ~0.8
-/// fires per case on average — enough to exercise both error and
-/// durability axes frequently without blowing past the 60 s budget.
+/// Put 46 / Delete 19 / `DeleteRange` 5 / Commit 20 / Rollback 5 /
+/// `CloseReopen` 2 / `PutNilKey` 2 / `Defragment` 1 = total 100.
+/// `Defragment` is the most expensive op (bbolt copies the entire
+/// file, then atomic-renames; redb runs in-place compaction holding
+/// the write lock) so it's pinned to 1 % — ~0.4 fires per case on
+/// average across length-1..=40 sequences. The 256-case sweep
+/// therefore exercises ≈100 defrag cycles, enough to detect a
+/// post-defrag divergence reliably without blowing past the 60 s
+/// budget.
 fn op_strat() -> impl Strategy<Value = DiffOp> {
     prop_oneof![
-        47 => put_strat(),
+        46 => put_strat(),
         19 => delete_strat(),
         5  => delete_range_strat(),
         20 => commit_strat(),
         5  => rollback_strat(),
         2  => close_reopen_strat(),
         2  => put_nil_key_strat(),
+        1  => defragment_strat(),
     ]
 }
 

--- a/crates/mango-storage/tests/redb_backend.rs
+++ b/crates/mango-storage/tests/redb_backend.rs
@@ -242,6 +242,74 @@ async fn delete_range_removes_half_open_interval() {
 }
 
 #[tokio::test]
+async fn delete_range_with_empty_end_deletes_to_max() {
+    // `end = []` means "unbounded upper" per the engine-neutral
+    // DeleteRange contract (mirrors bbolt's `len(end) == 0`
+    // semantics). Regression test for the wrapper fix: prior to this
+    // commit, `retain_in(b"b"..b"", _)` was the empty range on redb
+    // and deleted nothing, while bbolt deleted b..∞. That silent
+    // divergence surfaces the moment the differential harness's
+    // proptest strategy draws `end == b""`.
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    for k in [b"a", b"b", b"c", b"d", b"e"] {
+        put(&b, KV, k, b"v").await;
+    }
+
+    let mut batch = b.begin_batch().unwrap();
+    batch.delete_range(KV, b"b", b"").unwrap();
+    let _ = b.commit_batch(batch, true).await.unwrap();
+
+    assert_eq!(get(&b, KV, b"a").as_deref(), Some(&b"v"[..]));
+    assert_eq!(get(&b, KV, b"b"), None);
+    assert_eq!(get(&b, KV, b"c"), None);
+    assert_eq!(get(&b, KV, b"d"), None);
+    assert_eq!(get(&b, KV, b"e"), None);
+}
+
+#[tokio::test]
+async fn delete_range_with_empty_start_and_empty_end_deletes_all() {
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    for k in [b"a", b"b", b"c"] {
+        put(&b, KV, k, b"v").await;
+    }
+
+    let mut batch = b.begin_batch().unwrap();
+    batch.delete_range(KV, b"", b"").unwrap();
+    let _ = b.commit_batch(batch, true).await.unwrap();
+
+    assert_eq!(get(&b, KV, b"a"), None);
+    assert_eq!(get(&b, KV, b"b"), None);
+    assert_eq!(get(&b, KV, b"c"), None);
+}
+
+#[tokio::test]
+async fn delete_range_allows_empty_end_with_any_start() {
+    // `validate_ops` rejects `start > end` only when `end` is
+    // non-empty. This tests the skip-path: start = "z" (very high),
+    // end = "" (unbounded upper) must NOT be rejected as
+    // `InvalidRange("start > end")`.
+    let tmp = TempDir::new().unwrap();
+    let b = open(&tmp);
+    b.register_bucket("kv", KV).unwrap();
+    for k in [b"a", b"y", b"z"] {
+        put(&b, KV, k, b"v").await;
+    }
+
+    let mut batch = b.begin_batch().unwrap();
+    batch.delete_range(KV, b"z", b"").unwrap();
+    // Commit MUST succeed — must not error as InvalidRange.
+    let _ = b.commit_batch(batch, true).await.unwrap();
+
+    assert_eq!(get(&b, KV, b"a").as_deref(), Some(&b"v"[..]));
+    assert_eq!(get(&b, KV, b"y").as_deref(), Some(&b"v"[..]));
+    assert_eq!(get(&b, KV, b"z"), None);
+}
+
+#[tokio::test]
 async fn unknown_bucket_on_put_errors_from_commit() {
     let tmp = TempDir::new().unwrap();
     let b = open(&tmp);


### PR DESCRIPTION
## Summary

**Partial implementation** of plan §9 commits 8–12 for ROADMAP:819 — this PR closes out the bbolt differential harness.

Two commits landed so far on the foundation layer:

1. **`db5c76d` — wrapper fix: `DeleteRange` empty-end means unbounded upper.** Before this commit, `retain_in(b"b"..b"", _)` on redb was the empty range and deleted nothing, while bbolt with `len(end) == 0` deleted everything from `start` onward. Silent divergence the moment any consumer passed an empty `end`. Fixed at the wrapper (`src/redb/mod.rs::apply_staged`), not the harness, because the `Backend::DeleteRange` contract is public and every consumer has the same surprise today.
2. **`3c92339` — `normalize_err` for symmetric commit errors.** Harness-level string normalizer that strips `"backend: "` (redb `BackendError` Display prefix) and any `"app: <Method>: "` (Go oracle wire wrapper), then runs a 2-entry alias map (`"key required"` ↔ `"empty key"`, `"value cannot be nil"` ↔ `"empty value"`). Plumbed into `apply_op`'s `Commit` symmetric-error arm — required for commit 8's error-triggering ops (`PutNilKey`).

Follow-up commits will layer on:
- Commit 8: `Case` → `Option<T>` restructure (per rust-expert NIT-3, because `GoOracle::spawn` and `RedbBackend::open` are not idle — both acquire file locks), four new `DiffOp` variants (`CommitGroup` / `CloseReopen` / `Defragment` / `PutNilKey`), `commit_group_inner_strat`, widened `op_strat` to `1..=40`, `apply_op` branches, `close_and_reopen` method, `smoke_advanced_ops_no_divergence`.
- Commits 9–12: failure artifacts under `target/differential-failures/<ts>-<hash8>/` with `ops.json` / `oracle.db` / `mango.redb` / `diff.txt` / `stderr.log`, seed replay driver, CI `differential` job, nightly 10k-case cron, `verify_harness_catches.sh` gating meta-test, `BBOLT_QUIRKS.md` final pass.

**Parent plan:** `.planning/differential-backend-vs-bbolt.plan.md` (v2, APPROVED). **PR-B plan:** `.planning/differential-vs-bbolt-advanced.plan.md` (rust-expert APPROVE_WITH_NITS; all 7 nits folded in before implementation began).
**Predecessor PR:** #53 (merged `ee63ce3`) — shipped commits 1–7 of the parent plan.
**Roadmap item:** `ROADMAP.md:819` — _Differential-test harness vs bbolt_. Line flips to `- [x]` when this PR merges.

This PR is **draft** — opened early so CI and rust-expert can start reviewing the foundation while the remaining commit-8–12 work is layered on.

## What's in this PR right now

**`db5c76d` — `src/redb/mod.rs`:**

- `apply_staged` branches on `end.is_empty()`: empty case uses `retain_in::<&[u8], _>(start.as_slice().., |_, _| false)` (unbounded upper range, matches bbolt).
- `validate_ops` skips the `start > end` check when `end.is_empty()` — an unbounded end is legal regardless of start.

**`db5c76d` — `tests/redb_backend.rs` (3 new tests):**

- `delete_range_with_empty_end_deletes_to_max` — a,b,c,d,e + `delete_range(KV, b"b", b"")` → only `a` survives.
- `delete_range_with_empty_start_and_empty_end_deletes_all` — `("" , "")` wipes the bucket.
- `delete_range_allows_empty_end_with_any_start` — validate_ops skip-path: `start = "z"`, `end = ""` must not error `InvalidRange`.

**`3c92339` — `tests/differential_vs_bbolt.rs`:**

- `normalize_err(raw: &str) -> String` + `map_alias(s: &str) -> String` helpers.
- Defensive fallthrough: if `main.go` ever emits `"app: foo"` without the inner `": "` separator, still strip `"app: "` (rust-expert NIT-5).
- `apply_op`'s `Commit` symmetric-error branch now requires `normalize_err(redb) == normalize_err(oracle)` rather than failing outright (commit 7 forbade them because no op yet produced them; commit 8 will).
- `normalize_err_unit` test pins seven representative inputs: redb-prefix pass-through, Go-wrapper + alias (3 methods × 2 errors), redb + non-aliased `UnknownBucket`, malformed Go wrapper without method separator, complete pass-through.

## Deliberately not in this PR yet

All of commit 8 step 3 onward: new `DiffOp` variants, `Case` `Option<T>` restructure, `close_and_reopen`, widened strategies, advanced-ops smoke test. Commits 9–12 (failure artifacts, seeds, CI, nightly, BBOLT_QUIRKS.md) also pending. Will layer onto this branch as additional atomic commits; the PR will un-draft once commit 12 lands.

## Test plan

- [x] `cargo clippy -p mango-storage --all-targets -- -D warnings` — clean at HEAD.
- [x] `cargo test -p mango-storage --test redb_backend delete_range` — 5 passed (2 existing + 3 new).
- [x] `MANGO_DIFFERENTIAL_FSYNC=0 cargo test -p mango-storage --test differential_vs_bbolt` — 5 passed in 40.70s (4 existing + `normalize_err_unit`; 256-case proptest sweep clean, 0 divergences).
- [ ] CI on this PR: `fmt`, `clippy`, `test`, `msrv`, `deny`, `bench-harness`. Differential tests skip on jobs that don't build the bbolt oracle (PR #53's skip path).
- [ ] rust-expert final-diff review once commit 12 lands.
- [ ] `MANGO_DIFFERENTIAL_THOROUGH=1` 10k-case run — will run locally before un-draft.

## Key design choices already locked in by the plan

- **Wrapper-layer fix over harness band-aid** for `DeleteRange` empty-end, because the `Backend::DeleteRange` contract is public and affects all consumers, not just the test.
- **Harness normalizer over wire-constant rename** for error-string parity, because coupling `BackendError`'s public Display prefix to bbolt's wire strings is a layering smell — bbolt is an external oracle, not a spec.
- **`Option<T>` + drop-first** (not `mem::replace`) for `close_and_reopen` (landing in a subsequent commit): `GoOracle::spawn` and `RedbBackend::open` both acquire file locks before returning, so constructing the replacement before dropping the old handle would deadlock on flock / panic on `Database::create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
