### PR TITLE
feat(storage): engine-swap dry-run test + InMemBackend reference impl (ROADMAP:821)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
  "bytes",
  "madsim",
  "madsim-tokio",
+ "mango-storage",
  "parking_lot",
  "proptest",
  "raft",

--- a/crates/mango-storage/Cargo.toml
+++ b/crates/mango-storage/Cargo.toml
@@ -43,7 +43,22 @@ parking_lot.workspace = true
 # the deterministic simulator. See docs/madsim.md.
 tokio = { workspace = true, features = ["rt"] }
 
+[features]
+# ROADMAP:821 engine-swap dry-run. Gates the in-memory reference
+# `Backend` impl (`crate::inmem`) so it is invisible in default
+# builds. Tests opt in via the self-referential dev-dependency
+# below; downstream crates that want the in-mem impl for their own
+# tests do `mango-storage = { path = "...", features = ["test-utils"] }`
+# in their own dev-dependencies.
+test-utils = []
+
 [dev-dependencies]
+# ROADMAP:821: enable the `test-utils` feature when this crate is
+# built as a dev-dep of itself, so integration tests in
+# `crates/mango-storage/tests/` see `mango_storage::InMemBackend`
+# without any per-test-target gymnastics. Self-referential dev-deps
+# are a recognized Cargo idiom (rust-bitcoin, serde, others).
+mango-storage = { path = ".", features = ["test-utils"] }
 # ROADMAP:817 integration tests open a real redb on disk in a
 # tempdir; tempfile is the workspace-standard primitive. Exemption
 # already present in supply-chain/config.toml (tempfile@3.27.0).

--- a/crates/mango-storage/src/backend.rs
+++ b/crates/mango-storage/src/backend.rs
@@ -341,6 +341,10 @@ pub trait Backend: Send + Sync + 'static {
 
     /// Acquire a read snapshot. Cheap — no I/O.
     ///
+    /// The returned snapshot freezes bucket **data** at this call;
+    /// the bucket-id **registry** is read live on each access. See
+    /// [`ReadSnapshot`] "Registry semantics" for the precise rule.
+    ///
     /// # Errors
     /// [`BackendError::Closed`] after [`Self::close`].
     fn snapshot(&self) -> Result<Self::Snapshot, BackendError>;
@@ -620,9 +624,14 @@ pub trait RaftLogStore: Send + Sync + 'static {
 /// rustc version) — well before any downstream cross-crate
 /// matcher's `_` arm can hide it.
 ///
+/// Compiled unconditionally (no `#[cfg(test)]`) so the guard fires
+/// on `cargo check` / `cargo build` / `cargo clippy`, not only on
+/// `cargo test` — strictly the earliest build to add a new variant
+/// is the one that should fail. `#[allow(dead_code)]` because the
+/// function is purely a build-time assertion; nothing calls it.
+///
 /// The body is intentionally trivial; the load-bearing piece is
 /// the explicit pattern list.
-#[cfg(test)]
 #[allow(dead_code)]
 fn _backend_error_taxonomy_is_exhaustive(e: &BackendError) {
     match e {

--- a/crates/mango-storage/src/backend.rs
+++ b/crates/mango-storage/src/backend.rs
@@ -188,13 +188,34 @@ impl BackendConfig {
 /// against the same `Self` observe a consistent view even if
 /// commits land concurrently. `Send + Sync` so a snapshot can be
 /// moved across tasks and shared between reader threads.
+///
+/// # Registry semantics (data vs. registry)
+///
+/// Snapshot isolation applies to bucket **data** only. The
+/// bucket-id **registry** (the set of registered ids) is read
+/// **live** at call time, not frozen at `Backend::snapshot()`. The
+/// registry is monotonically growing — bucket ids are never
+/// unregistered — so this is well-defined: a bucket id registered
+/// AFTER the snapshot was taken is observable through this
+/// snapshot's [`Self::get`] / [`Self::range`] as `Ok(None)` /
+/// empty-iterator (the data side of the snapshot is the pre-
+/// registration cut, where the bucket has no entries yet). A
+/// bucket id never registered on the originating backend yields
+/// [`BackendError::UnknownBucket`].
+///
+/// Both shipped impls (`RedbSnapshot`, `InMemSnapshot`) implement
+/// this contract; the engine-swap dry-run test
+/// (`tests/engine_swap_dryrun.rs`) pins it.
 pub trait ReadSnapshot: Send + Sync {
     /// Point lookup. Returns `Ok(None)` if the key is absent from
-    /// the bucket at the snapshot's cut.
+    /// the bucket at the snapshot's cut, or if the bucket was
+    /// registered AFTER this snapshot was taken (see "Registry
+    /// semantics" on the trait).
     ///
     /// # Errors
-    /// Returns [`BackendError::UnknownBucket`] if `bucket` was never
-    /// registered; [`BackendError::Io`] on engine-level I/O error.
+    /// Returns [`BackendError::UnknownBucket`] if `bucket` is not
+    /// registered on the originating backend at the time of the
+    /// call; [`BackendError::Io`] on engine-level I/O error.
     fn get(&self, bucket: BucketId, key: &[u8]) -> Result<Option<Bytes>, BackendError>;
 
     /// Forward range iterator over the half-open interval
@@ -207,10 +228,16 @@ pub trait ReadSnapshot: Send + Sync {
     /// requiring a GAT on `ReadSnapshot` (which would block trait
     /// objects).
     ///
+    /// Returns an empty iterator if the bucket is registered but
+    /// holds no data at the snapshot's cut, INCLUDING the case
+    /// where the bucket was registered AFTER this snapshot was
+    /// taken (see "Registry semantics" on the trait).
+    ///
     /// # Errors
-    /// Returns [`BackendError::UnknownBucket`] or
-    /// [`BackendError::InvalidRange`] on caller errors; other
-    /// variants on engine-level faults.
+    /// Returns [`BackendError::UnknownBucket`] if `bucket` is not
+    /// registered on the originating backend at the time of the
+    /// call, or [`BackendError::InvalidRange`] when `start > end`;
+    /// other variants on engine-level faults.
     fn range<'a>(
         &'a self,
         bucket: BucketId,
@@ -572,4 +599,40 @@ pub trait RaftLogStore: Send + Sync + 'static {
     /// [`BackendError::Io`] on engine-level I/O error;
     /// [`BackendError::Corruption`] on decode failure.
     fn hard_state(&self) -> Result<HardState, BackendError>;
+}
+
+/// Compile-time exhaustive [`BackendError`] taxonomy guard.
+///
+/// `BackendError` is `#[non_exhaustive]`, so cross-crate match
+/// expressions (the `tag()` helper in `tests/engine_swap_dryrun.rs`
+/// is one) MUST carry a wildcard arm. That wildcard would silently
+/// absorb a freshly-added variant, weakening the engine-swap
+/// taxonomy assertion (T3) to "fails open" — a new variant
+/// returned by both backends would tag as the same `Future`
+/// sentinel and pass.
+///
+/// This intra-crate function is the structural backstop: it lives
+/// inside `mango-storage`, so the wildcard rule does not apply, and
+/// the match arm list is the complete enumeration of variants.
+/// Adding a `BackendError` variant without updating this match
+/// fails the build inside the defining crate (`E0004`,
+/// `non_exhaustive_omitted_patterns` lint, or both depending on
+/// rustc version) — well before any downstream cross-crate
+/// matcher's `_` arm can hide it.
+///
+/// The body is intentionally trivial; the load-bearing piece is
+/// the explicit pattern list.
+#[cfg(test)]
+#[allow(dead_code)]
+fn _backend_error_taxonomy_is_exhaustive(e: &BackendError) {
+    match e {
+        BackendError::Io(_)
+        | BackendError::Corruption(_)
+        | BackendError::UnknownBucket(_)
+        | BackendError::InvalidRange(_)
+        | BackendError::Closed
+        | BackendError::BucketConflict { .. }
+        | BackendError::BucketNameConflict { .. }
+        | BackendError::Other(_) => {}
+    }
 }

--- a/crates/mango-storage/src/inmem/batch.rs
+++ b/crates/mango-storage/src/inmem/batch.rs
@@ -1,0 +1,241 @@
+//! [`WriteBatch`] impl for the in-memory reference backend
+//! (ROADMAP:821).
+//!
+//! Mirrors the staging-buffer shape of [`crate::redb::batch::RedbBatch`]
+//! (`crates/mango-storage/src/redb/batch.rs`). Both batch types
+//! exist purely to decouple op construction from the apply
+//! critical section; the in-mem batch's apply path is just a
+//! `BTreeMap` mutation, but it MUST honor the same staging
+//! invariants — empty-key/empty-value rejection, `delete_range`
+//! tolerance of empty bounds — so the engine-swap dry-run test
+//! (`tests/engine_swap_dryrun.rs`) sees identical observable
+//! behavior across the two backends.
+//!
+//! # Send-ness
+//!
+//! [`InMemBatch`] is deliberately `!Send + !Sync` via a
+//! `PhantomData<*const ()>` marker, mirroring `RedbBatch`. The
+//! trait contract in `mango_storage::WriteBatch` permits this.
+//! The `compile_fail` doctest below pins the invariant.
+//!
+//! ```compile_fail
+//! fn needs_send<T: Send>() {}
+//! needs_send::<mango_storage::InMemBatch>();
+//! ```
+
+use std::marker::PhantomData;
+
+use crate::backend::{BackendError, BucketId, WriteBatch};
+use crate::redb::batch::{EMPTY_KEY_ERROR, EMPTY_VALUE_ERROR};
+
+/// A single staged mutation. Carries owned byte vectors for the
+/// same reason as [`crate::redb::batch::StagedOp`]: the batch
+/// outlives the caller's buffer references.
+#[derive(Debug, Clone)]
+pub(super) enum StagedOp {
+    /// Insert-or-overwrite a key in `bucket`.
+    Put {
+        /// Target bucket id.
+        bucket: BucketId,
+        /// Owned key bytes.
+        key: Vec<u8>,
+        /// Owned value bytes.
+        value: Vec<u8>,
+    },
+    /// Remove a single key. No-op at apply time if absent.
+    Delete {
+        /// Target bucket id.
+        bucket: BucketId,
+        /// Owned key bytes.
+        key: Vec<u8>,
+    },
+    /// Remove every key in the half-open interval `[start, end)`,
+    /// with `end == []` meaning "unbounded upper" per the
+    /// engine-neutral `DeleteRange` contract (matches bbolt's
+    /// `len(end) == 0` semantics — see
+    /// `crates/mango-storage/src/redb/mod.rs::apply_staged` lines
+    /// 296-310 for the canonical definition).
+    DeleteRange {
+        /// Target bucket id.
+        bucket: BucketId,
+        /// Owned start-bound bytes (inclusive).
+        start: Vec<u8>,
+        /// Owned end-bound bytes (exclusive; empty = unbounded).
+        end: Vec<u8>,
+    },
+}
+
+/// Staging-buffer write batch for the in-memory reference
+/// backend. Produced by [`crate::Backend::begin_batch`]; consumed
+/// by [`crate::Backend::commit_batch`] or
+/// [`crate::Backend::commit_group`].
+///
+/// See the module-level docs for the Send-ness rationale.
+#[derive(Debug, Default)]
+pub struct InMemBatch {
+    pub(super) staged: Vec<StagedOp>,
+    /// `PhantomData<*const ()>` is the canonical `!Send + !Sync`
+    /// marker. Same shape as `RedbBatch`.
+    _not_send_sync: PhantomData<*const ()>,
+}
+
+impl InMemBatch {
+    /// Construct an empty batch. Called only from
+    /// [`crate::Backend::begin_batch`].
+    #[must_use]
+    pub(super) fn new() -> Self {
+        Self {
+            staged: Vec::new(),
+            _not_send_sync: PhantomData,
+        }
+    }
+
+    /// Consume the batch and return its staged ops. Called by the
+    /// commit paths in the sync prologue, *before* any future is
+    /// constructed, so the `!Send` marker on [`InMemBatch`] does
+    /// not propagate into the `Future + Send` return type.
+    pub(super) fn into_staged(self) -> Vec<StagedOp> {
+        self.staged
+    }
+
+    /// Observability for tests. Counts staged ops without revealing
+    /// the op variant.
+    #[cfg(test)]
+    pub(super) fn staged_len(&self) -> usize {
+        self.staged.len()
+    }
+}
+
+impl WriteBatch for InMemBatch {
+    fn put(&mut self, bucket: BucketId, key: &[u8], value: &[u8]) -> Result<(), BackendError> {
+        // Mirror RedbBatch: empty key/value rejected at stage time
+        // with byte-identical error messages
+        // (EMPTY_KEY_ERROR / EMPTY_VALUE_ERROR re-used). Necessary
+        // for trait parity in the engine-swap dry-run.
+        if key.is_empty() {
+            return Err(BackendError::Other(EMPTY_KEY_ERROR.to_owned()));
+        }
+        if value.is_empty() {
+            return Err(BackendError::Other(EMPTY_VALUE_ERROR.to_owned()));
+        }
+        self.staged.push(StagedOp::Put {
+            bucket,
+            key: key.to_vec(),
+            value: value.to_vec(),
+        });
+        Ok(())
+    }
+
+    fn delete(&mut self, bucket: BucketId, key: &[u8]) -> Result<(), BackendError> {
+        if key.is_empty() {
+            return Err(BackendError::Other(EMPTY_KEY_ERROR.to_owned()));
+        }
+        self.staged.push(StagedOp::Delete {
+            bucket,
+            key: key.to_vec(),
+        });
+        Ok(())
+    }
+
+    fn delete_range(
+        &mut self,
+        bucket: BucketId,
+        start: &[u8],
+        end: &[u8],
+    ) -> Result<(), BackendError> {
+        // `start = []` means "from the min of the keyspace";
+        // `end = []` means "unbounded upper". Both legal at stage
+        // time; redb mirror in `redb/batch.rs::delete_range`.
+        self.staged.push(StagedOp::DeleteRange {
+            bucket,
+            start: start.to_vec(),
+            end: end.to_vec(),
+        });
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing
+    )]
+
+    use super::*;
+
+    #[test]
+    fn empty_batch_has_no_staged_ops() {
+        let b = InMemBatch::new();
+        assert_eq!(b.staged_len(), 0);
+    }
+
+    #[test]
+    fn put_delete_delete_range_all_stage_without_io() {
+        let mut b = InMemBatch::new();
+        b.put(BucketId::new(1), b"k", b"v").unwrap();
+        b.delete(BucketId::new(1), b"k").unwrap();
+        b.delete_range(BucketId::new(1), b"a", b"z").unwrap();
+        assert_eq!(b.staged_len(), 3);
+    }
+
+    #[test]
+    fn put_empty_key_is_rejected_with_redb_parity_message() {
+        let mut b = InMemBatch::new();
+        let err = b.put(BucketId::new(1), b"", b"v").unwrap_err();
+        match err {
+            BackendError::Other(msg) => assert_eq!(msg, EMPTY_KEY_ERROR),
+            other => panic!("expected Other(empty key), got {other:?}"),
+        }
+        assert_eq!(b.staged_len(), 0);
+    }
+
+    #[test]
+    fn put_empty_value_is_rejected_with_redb_parity_message() {
+        let mut b = InMemBatch::new();
+        let err = b.put(BucketId::new(1), b"k", b"").unwrap_err();
+        match err {
+            BackendError::Other(msg) => assert_eq!(msg, EMPTY_VALUE_ERROR),
+            other => panic!("expected Other(empty value), got {other:?}"),
+        }
+        assert_eq!(b.staged_len(), 0);
+    }
+
+    #[test]
+    fn delete_empty_key_is_rejected() {
+        let mut b = InMemBatch::new();
+        let err = b.delete(BucketId::new(1), b"").unwrap_err();
+        match err {
+            BackendError::Other(msg) => assert_eq!(msg, EMPTY_KEY_ERROR),
+            other => panic!("expected Other(empty key), got {other:?}"),
+        }
+        assert_eq!(b.staged_len(), 0);
+    }
+
+    #[test]
+    fn delete_range_tolerates_empty_bounds() {
+        let mut b = InMemBatch::new();
+        b.delete_range(BucketId::new(1), b"", b"").unwrap();
+        b.delete_range(BucketId::new(1), b"", b"z").unwrap();
+        b.delete_range(BucketId::new(1), b"a", b"").unwrap();
+        assert_eq!(b.staged_len(), 3);
+    }
+
+    #[test]
+    fn into_staged_consumes_and_returns() {
+        let mut b = InMemBatch::new();
+        b.put(BucketId::new(1), b"k", b"v").unwrap();
+        let ops = b.into_staged();
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            StagedOp::Put { bucket, key, value } => {
+                assert_eq!(*bucket, BucketId::new(1));
+                assert_eq!(key, b"k");
+                assert_eq!(value, b"v");
+            }
+            other => panic!("expected Put, got {other:?}"),
+        }
+    }
+}

--- a/crates/mango-storage/src/inmem/mod.rs
+++ b/crates/mango-storage/src/inmem/mod.rs
@@ -40,7 +40,7 @@
 pub(crate) mod batch;
 pub(crate) mod snapshot;
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Bound;
 use std::sync::Arc;
 
@@ -53,10 +53,14 @@ use snapshot::{InMemSnapshot, SnapshotBuckets};
 
 /// Shared state. Held behind `Arc<RwLock<…>>` so the public
 /// `InMemBackend` handle can be cheaply cloned and `close()` can
-/// take `&self`.
+/// take `&self`. The `snapshot` submodule reads the live registry
+/// through this state (mirrors `RedbSnapshot`'s live
+/// `inner.registry` access — see `inmem::snapshot` module docs).
+/// Child modules can see this private struct through Rust's
+/// "descendants can see private items of their ancestors" rule.
 #[derive(Debug)]
-struct InMemState {
-    buckets_by_id: HashMap<BucketId, BucketEntry>,
+pub(crate) struct InMemState {
+    pub(super) buckets_by_id: HashMap<BucketId, BucketEntry>,
     buckets_by_name: HashMap<String, BucketId>,
     closed: bool,
     /// Strictly-monotonic commit cursor. Always returned from
@@ -67,7 +71,7 @@ struct InMemState {
 }
 
 #[derive(Debug, Clone)]
-struct BucketEntry {
+pub(super) struct BucketEntry {
     name: String,
     data: BTreeMap<Vec<u8>, Bytes>,
 }
@@ -79,15 +83,11 @@ pub struct InMemBackend {
 }
 
 impl InMemBackend {
-    /// Snapshot the registered bucket-id set under a read lock.
-    /// Used by `snapshot()` to give `InMemSnapshot::range`/`get`
-    /// faithful `UnknownBucket` errors even for buckets registered
-    /// after the snapshot's clone of `buckets_by_id`.
-    fn registered_ids_locked(state: &InMemState) -> Arc<HashSet<BucketId>> {
-        Arc::new(state.buckets_by_id.keys().copied().collect())
-    }
-
-    /// Snapshot the bucket data forest under a read lock.
+    /// Snapshot the bucket data forest under a read lock. The
+    /// registered-id set is NOT cloned: snapshots read the registry
+    /// **live** through their `Arc<RwLock<InMemState>>` handle, so
+    /// post-snapshot `register_bucket` is observable as `Ok(None)`
+    /// (matches `RedbSnapshot`).
     fn buckets_locked(state: &InMemState) -> SnapshotBuckets {
         let map: HashMap<BucketId, BTreeMap<Vec<u8>, Bytes>> = state
             .buckets_by_id
@@ -175,8 +175,8 @@ impl Backend for InMemBackend {
             return Err(BackendError::Closed);
         }
         let buckets = Self::buckets_locked(&s);
-        let registered_ids = Self::registered_ids_locked(&s);
-        Ok(InMemSnapshot::new(buckets, registered_ids))
+        drop(s);
+        Ok(InMemSnapshot::new(buckets, Arc::clone(&self.state)))
     }
 
     fn begin_batch(&self) -> Result<Self::Batch, BackendError> {

--- a/crates/mango-storage/src/inmem/mod.rs
+++ b/crates/mango-storage/src/inmem/mod.rs
@@ -1,0 +1,627 @@
+//! In-memory reference [`crate::Backend`] impl (ROADMAP:821).
+//!
+//! `InMemBackend` is a `BTreeMap`-backed second `Backend` impl.
+//! Its purpose is to validate the trait boundary frozen in ADR
+//! 0002 §6 — the engine-swap dry-run test
+//! (`tests/engine_swap_dryrun.rs`) migrates state from a
+//! [`crate::RedbBackend`] into an `InMemBackend` and asserts every
+//! observable read and every error variant agrees. If the trait
+//! ever leaks engine-specific behavior, this is where it surfaces.
+//!
+//! It is NOT a production engine. There is no durability, no
+//! crash recovery, and no concurrency model beyond a single
+//! `parking_lot::RwLock`. The on-disk size accessor returns 0;
+//! `defragment` is a no-op; `force_fsync = true` is observably a
+//! no-op (documented; exercised in T2 of the dry-run).
+//!
+//! # Visibility
+//!
+//! Gated behind the `test-utils` Cargo feature so the public
+//! surface of `mango-storage` under default features is
+//! unaffected. `cargo-public-api` (workspace policy) sees no
+//! addition.
+//!
+//! # Atomicity
+//!
+//! `commit_batch` and `commit_group` use **stage-then-swap** —
+//! ops are applied to a clone of every touched bucket, validated
+//! end-to-end, and the touched entries are atomically replaced
+//! into `InMemState.buckets_by_id`. A panic mid-apply leaves the
+//! visible state untouched, matching `RedbBackend`'s transactional
+//! commit contract.
+//!
+//! # Lock discipline
+//!
+//! `parking_lot::RwLock` is non-poisoning and non-reentrant. The
+//! apply loop never calls any `&self` method that would re-enter
+//! the lock (it operates on owned clones until the final swap),
+//! so deadlock is impossible.
+
+pub(crate) mod batch;
+pub(crate) mod snapshot;
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::ops::Bound;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use parking_lot::RwLock;
+
+use crate::backend::{Backend, BackendConfig, BackendError, BucketId, CommitStamp};
+use batch::{InMemBatch, StagedOp};
+use snapshot::{InMemSnapshot, SnapshotBuckets};
+
+/// Shared state. Held behind `Arc<RwLock<…>>` so the public
+/// `InMemBackend` handle can be cheaply cloned and `close()` can
+/// take `&self`.
+#[derive(Debug)]
+struct InMemState {
+    buckets_by_id: HashMap<BucketId, BucketEntry>,
+    buckets_by_name: HashMap<String, BucketId>,
+    closed: bool,
+    /// Strictly-monotonic commit cursor. Always returned from
+    /// `commit_batch`/`commit_group` via `checked_add(1)` —
+    /// workspace `arithmetic_side_effects = deny` rejects naked
+    /// `+= 1`. Mirrors `RedbBackend::commit_seq` semantics.
+    next_seq: u64,
+}
+
+#[derive(Debug, Clone)]
+struct BucketEntry {
+    name: String,
+    data: BTreeMap<Vec<u8>, Bytes>,
+}
+
+/// In-memory `Backend` implementation. See module docs.
+#[derive(Debug, Clone)]
+pub struct InMemBackend {
+    state: Arc<RwLock<InMemState>>,
+}
+
+impl InMemBackend {
+    /// Snapshot the registered bucket-id set under a read lock.
+    /// Used by `snapshot()` to give `InMemSnapshot::range`/`get`
+    /// faithful `UnknownBucket` errors even for buckets registered
+    /// after the snapshot's clone of `buckets_by_id`.
+    fn registered_ids_locked(state: &InMemState) -> Arc<HashSet<BucketId>> {
+        Arc::new(state.buckets_by_id.keys().copied().collect())
+    }
+
+    /// Snapshot the bucket data forest under a read lock.
+    fn buckets_locked(state: &InMemState) -> SnapshotBuckets {
+        let map: HashMap<BucketId, BTreeMap<Vec<u8>, Bytes>> = state
+            .buckets_by_id
+            .iter()
+            .map(|(id, entry)| (*id, entry.data.clone()))
+            .collect();
+        Arc::new(map)
+    }
+}
+
+impl Backend for InMemBackend {
+    type Snapshot = InMemSnapshot;
+    type Batch = InMemBatch;
+
+    fn open(config: BackendConfig) -> Result<Self, BackendError> {
+        // Mirror RedbBackend's read-only rejection so error-taxonomy
+        // parity holds in T3. When the MVCC layer formalizes
+        // read-only, both impls update together.
+        if config.read_only {
+            return Err(BackendError::Other(
+                "read-only not yet supported; see ROADMAP:817 follow-up".to_owned(),
+            ));
+        }
+        // `data_dir` is ignored — InMem has no on-disk backing.
+        let _ = config.data_dir;
+        Ok(Self {
+            state: Arc::new(RwLock::new(InMemState {
+                buckets_by_id: HashMap::new(),
+                buckets_by_name: HashMap::new(),
+                closed: false,
+                next_seq: 0,
+            })),
+        })
+    }
+
+    fn close(&self) -> Result<(), BackendError> {
+        // Idempotent. Setting `closed = true` is the single
+        // observable effect; no resources to release.
+        let mut s = self.state.write();
+        s.closed = true;
+        Ok(())
+    }
+
+    fn register_bucket(&self, name: &str, id: BucketId) -> Result<(), BackendError> {
+        let mut s = self.state.write();
+        if s.closed {
+            return Err(BackendError::Closed);
+        }
+        // Conflict precedence pinned to RedbBackend's registry
+        // (`crates/mango-storage/src/redb/registry.rs::check_only`):
+        // 1. id-rebind to a different name -> BucketConflict.
+        // 2. name-rebind to a different id -> BucketNameConflict.
+        // 3. matching (name, id) -> Ok(()) (idempotent).
+        if let Some(existing) = s.buckets_by_id.get(&id) {
+            if existing.name == name {
+                return Ok(());
+            }
+            return Err(BackendError::BucketConflict {
+                id,
+                existing: existing.name.clone(),
+                requested: name.to_owned(),
+            });
+        }
+        if let Some(existing_id) = s.buckets_by_name.get(name) {
+            return Err(BackendError::BucketNameConflict {
+                name: name.to_owned(),
+                existing_id: *existing_id,
+                requested_id: id,
+            });
+        }
+        s.buckets_by_id.insert(
+            id,
+            BucketEntry {
+                name: name.to_owned(),
+                data: BTreeMap::new(),
+            },
+        );
+        s.buckets_by_name.insert(name.to_owned(), id);
+        Ok(())
+    }
+
+    fn snapshot(&self) -> Result<Self::Snapshot, BackendError> {
+        let s = self.state.read();
+        if s.closed {
+            return Err(BackendError::Closed);
+        }
+        let buckets = Self::buckets_locked(&s);
+        let registered_ids = Self::registered_ids_locked(&s);
+        Ok(InMemSnapshot::new(buckets, registered_ids))
+    }
+
+    fn begin_batch(&self) -> Result<Self::Batch, BackendError> {
+        let s = self.state.read();
+        if s.closed {
+            return Err(BackendError::Closed);
+        }
+        Ok(InMemBatch::new())
+    }
+
+    fn commit_batch(
+        &self,
+        batch: Self::Batch,
+        force_fsync: bool,
+    ) -> impl core::future::Future<Output = Result<CommitStamp, BackendError>> + Send {
+        // Sync prologue: extract staged ops BEFORE constructing the
+        // future, so the `!Send` `InMemBatch` never enters the
+        // future's capture set. Mirrors the RedbBackend pattern.
+        let staged = batch.into_staged();
+        let state = Arc::clone(&self.state);
+        // No durable medium; `force_fsync` is observably a no-op
+        // (T2 of the dry-run pins this contract).
+        let _ = force_fsync;
+        async move { commit_staged(&state, staged) }
+    }
+
+    fn commit_group(
+        &self,
+        batches: Vec<Self::Batch>,
+    ) -> impl core::future::Future<Output = Result<CommitStamp, BackendError>> + Send {
+        let mut merged: Vec<StagedOp> = Vec::new();
+        for b in batches {
+            merged.extend(b.into_staged());
+        }
+        let state = Arc::clone(&self.state);
+        async move { commit_staged(&state, merged) }
+    }
+
+    fn size_on_disk(&self) -> Result<u64, BackendError> {
+        let s = self.state.read();
+        if s.closed {
+            return Err(BackendError::Closed);
+        }
+        // Documented contract: in-mem has no disk.
+        Ok(0)
+    }
+
+    fn defragment(&self) -> impl core::future::Future<Output = Result<(), BackendError>> + Send {
+        let state = Arc::clone(&self.state);
+        async move {
+            let s = state.read();
+            if s.closed {
+                return Err(BackendError::Closed);
+            }
+            // Documented no-op.
+            Ok(())
+        }
+    }
+}
+
+/// Apply staged ops with stage-then-swap atomicity.
+///
+/// 1. Acquire write lock; capture `closed` cut.
+/// 2. Validate every op (`UnknownBucket`, `InvalidRange`) BEFORE any
+///    mutation. Validation errors leave state untouched.
+/// 3. Clone every `BucketEntry.data` whose `BucketId` is touched
+///    by any op. The clones are the staging area.
+/// 4. Apply ops to the staging clones. Empty `end` on
+///    `DeleteRange` means "unbounded upper" per the engine-neutral
+///    contract — see `crate::redb::mod::apply_staged` lines
+///    296-310 for the canonical definition; mirrored here exactly.
+/// 5. Swap the staged clones back into `state.buckets_by_id`.
+/// 6. Bump `next_seq` via `checked_add(1)` and return the new
+///    stamp.
+///
+/// A panic anywhere in steps 3-5 leaves visible state untouched
+/// because the staging clones are in-scope locals; only the final
+/// step writes back. Matches `RedbBackend`'s transactional contract.
+fn commit_staged(
+    state: &Arc<RwLock<InMemState>>,
+    ops: Vec<StagedOp>,
+) -> Result<CommitStamp, BackendError> {
+    let mut s = state.write();
+    if s.closed {
+        return Err(BackendError::Closed);
+    }
+
+    // Validate every op: bucket exists, range bounds sane.
+    for op in &ops {
+        let b = op_bucket(op);
+        if !s.buckets_by_id.contains_key(&b) {
+            return Err(BackendError::UnknownBucket(b));
+        }
+        if let StagedOp::DeleteRange { start, end, .. } = op {
+            // Empty `end` means "unbounded upper"; any start is
+            // legal in that case (mirrors validate_ops in
+            // crate::redb::mod).
+            if !end.is_empty() && start > end {
+                return Err(BackendError::InvalidRange("start > end"));
+            }
+        }
+    }
+
+    // Stage: clone touched buckets. Use the Entry API so the
+    // existence-validated lookup happens exactly once per bucket
+    // and we never call `expect()` on the result.
+    let mut touched: HashMap<BucketId, BTreeMap<Vec<u8>, Bytes>> = HashMap::new();
+    for op in &ops {
+        let b = op_bucket(op);
+        if let std::collections::hash_map::Entry::Vacant(slot) = touched.entry(b) {
+            // Existence validated in the loop above; an absent
+            // entry here would be a logic bug, surfaced as
+            // `UnknownBucket` rather than a panic.
+            let Some(entry) = s.buckets_by_id.get(&b) else {
+                return Err(BackendError::UnknownBucket(b));
+            };
+            slot.insert(entry.data.clone());
+        }
+    }
+
+    // Apply ops to the clones.
+    for op in ops {
+        let b = op_bucket(&op);
+        let Some(map) = touched.get_mut(&b) else {
+            // Same logic-bug surface as above; convert to error
+            // rather than panic.
+            return Err(BackendError::UnknownBucket(b));
+        };
+        match op {
+            StagedOp::Put { key, value, .. } => {
+                map.insert(key, Bytes::from(value));
+            }
+            StagedOp::Delete { key, .. } => {
+                map.remove(&key);
+            }
+            StagedOp::DeleteRange { start, end, .. } => {
+                if end.is_empty() {
+                    // Unbounded upper.
+                    let to_remove: Vec<Vec<u8>> = map
+                        .range::<[u8], _>((Bound::Included(start.as_slice()), Bound::Unbounded))
+                        .map(|(k, _)| k.clone())
+                        .collect();
+                    for k in to_remove {
+                        map.remove(&k);
+                    }
+                } else {
+                    let to_remove: Vec<Vec<u8>> = map
+                        .range::<[u8], _>((
+                            Bound::Included(start.as_slice()),
+                            Bound::Excluded(end.as_slice()),
+                        ))
+                        .map(|(k, _)| k.clone())
+                        .collect();
+                    for k in to_remove {
+                        map.remove(&k);
+                    }
+                }
+            }
+        }
+    }
+
+    // Swap: replace touched buckets atomically (under the same
+    // write lock).
+    for (b, data) in touched {
+        if let Some(entry) = s.buckets_by_id.get_mut(&b) {
+            entry.data = data;
+        }
+    }
+
+    // Mint a strictly-monotonic stamp. Empty commit also bumps —
+    // matches RedbBackend (`commit_staged` in redb/mod.rs:527).
+    let prev = s.next_seq;
+    let next = prev
+        .checked_add(1)
+        .ok_or_else(|| BackendError::Other("commit_seq overflow".to_owned()))?;
+    s.next_seq = next;
+    Ok(CommitStamp::new(next))
+}
+
+/// Extract the `BucketId` from any `StagedOp` variant.
+fn op_bucket(op: &StagedOp) -> BucketId {
+    match *op {
+        StagedOp::Put { bucket, .. }
+        | StagedOp::Delete { bucket, .. }
+        | StagedOp::DeleteRange { bucket, .. } => bucket,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )]
+
+    use super::*;
+    use crate::backend::{ReadSnapshot, WriteBatch};
+
+    #[allow(dead_code)]
+    fn _assert_inmem_backend_send_sync_static() {
+        fn needs<T: Send + Sync + 'static>() {}
+        needs::<InMemBackend>();
+    }
+
+    fn open() -> InMemBackend {
+        InMemBackend::open(BackendConfig::new("/unused".into(), false)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn open_read_only_is_rejected() {
+        let err =
+            InMemBackend::open(BackendConfig::new("/unused".into(), true)).expect_err("rejected");
+        match err {
+            BackendError::Other(msg) => {
+                assert!(msg.contains("read-only"), "msg = {msg}");
+            }
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_bucket_idempotent_then_id_conflict() {
+        let b = open();
+        b.register_bucket("kv", BucketId::new(1)).unwrap();
+        b.register_bucket("kv", BucketId::new(1)).unwrap(); // idempotent
+        let err = b
+            .register_bucket("meta", BucketId::new(1))
+            .expect_err("conflict");
+        match err {
+            BackendError::BucketConflict {
+                id,
+                existing,
+                requested,
+            } => {
+                assert_eq!(id, BucketId::new(1));
+                assert_eq!(existing, "kv");
+                assert_eq!(requested, "meta");
+            }
+            other => panic!("expected BucketConflict, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_bucket_name_conflict() {
+        let b = open();
+        b.register_bucket("kv", BucketId::new(1)).unwrap();
+        let err = b
+            .register_bucket("kv", BucketId::new(2))
+            .expect_err("name conflict");
+        match err {
+            BackendError::BucketNameConflict {
+                name,
+                existing_id,
+                requested_id,
+            } => {
+                assert_eq!(name, "kv");
+                assert_eq!(existing_id, BucketId::new(1));
+                assert_eq!(requested_id, BucketId::new(2));
+            }
+            other => panic!("expected BucketNameConflict, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn id_conflict_checked_before_name_conflict() {
+        let b = open();
+        b.register_bucket("a", BucketId::new(1)).unwrap();
+        b.register_bucket("b", BucketId::new(2)).unwrap();
+        let err = b
+            .register_bucket("a", BucketId::new(2))
+            .expect_err("id conflict wins");
+        match err {
+            BackendError::BucketConflict { existing, .. } => assert_eq!(existing, "b"),
+            other => panic!("expected BucketConflict, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_round_trip_via_commit_then_snapshot() {
+        let b = open();
+        b.register_bucket("kv", BucketId::new(1)).unwrap();
+        let mut batch = b.begin_batch().unwrap();
+        batch.put(BucketId::new(1), b"k1", b"v1").unwrap();
+        batch.put(BucketId::new(1), b"k2", b"v2").unwrap();
+        let stamp1 = b.commit_batch(batch, false).await.unwrap();
+        assert_eq!(stamp1, CommitStamp::new(1));
+
+        let snap = b.snapshot().unwrap();
+        assert_eq!(
+            snap.get(BucketId::new(1), b"k1").unwrap(),
+            Some(Bytes::from_static(b"v1"))
+        );
+        assert_eq!(
+            snap.get(BucketId::new(1), b"k2").unwrap(),
+            Some(Bytes::from_static(b"v2"))
+        );
+        assert_eq!(snap.get(BucketId::new(1), b"absent").unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn force_fsync_true_is_observable_noop_returning_ok() {
+        let b = open();
+        b.register_bucket("kv", BucketId::new(1)).unwrap();
+        let mut batch = b.begin_batch().unwrap();
+        batch.put(BucketId::new(1), b"k", b"v").unwrap();
+        let s = b.commit_batch(batch, true).await.unwrap();
+        assert_eq!(s, CommitStamp::new(1));
+    }
+
+    #[tokio::test]
+    async fn empty_commit_bumps_seq_strictly() {
+        let b = open();
+        let s1 = b
+            .commit_batch(b.begin_batch().unwrap(), false)
+            .await
+            .unwrap();
+        let s2 = b
+            .commit_batch(b.begin_batch().unwrap(), false)
+            .await
+            .unwrap();
+        assert!(s1 < s2);
+        assert_eq!(s2.seq, s1.seq + 1);
+    }
+
+    #[tokio::test]
+    async fn unknown_bucket_on_get() {
+        let b = open();
+        let snap = b.snapshot().unwrap();
+        let err = snap.get(BucketId::new(99), b"k").expect_err("unknown");
+        assert!(matches!(err, BackendError::UnknownBucket(id) if id == BucketId::new(99)));
+    }
+
+    #[tokio::test]
+    async fn invalid_range_on_snapshot_range() {
+        let b = open();
+        b.register_bucket("kv", BucketId::new(1)).unwrap();
+        let snap = b.snapshot().unwrap();
+        let err = snap
+            .range(BucketId::new(1), b"z", b"a")
+            .err()
+            .expect("invalid");
+        assert!(matches!(err, BackendError::InvalidRange(_)));
+    }
+
+    #[tokio::test]
+    async fn delete_range_unbounded_upper_with_empty_end() {
+        // Mirrors redb behavior: end == [] in DeleteRange means
+        // "delete from start to +infinity".
+        let b = open();
+        b.register_bucket("kv", BucketId::new(1)).unwrap();
+        let mut batch = b.begin_batch().unwrap();
+        batch.put(BucketId::new(1), b"a", b"1").unwrap();
+        batch.put(BucketId::new(1), b"m", b"2").unwrap();
+        batch.put(BucketId::new(1), b"z", b"3").unwrap();
+        let _ = b.commit_batch(batch, false).await.unwrap();
+
+        let mut batch = b.begin_batch().unwrap();
+        batch.delete_range(BucketId::new(1), b"m", b"").unwrap();
+        let _ = b.commit_batch(batch, false).await.unwrap();
+
+        let snap = b.snapshot().unwrap();
+        assert_eq!(
+            snap.get(BucketId::new(1), b"a").unwrap(),
+            Some(Bytes::from_static(b"1"))
+        );
+        assert_eq!(snap.get(BucketId::new(1), b"m").unwrap(), None);
+        assert_eq!(snap.get(BucketId::new(1), b"z").unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn close_is_idempotent_and_blocks_subsequent_ops() {
+        let b = open();
+        b.register_bucket("kv", BucketId::new(1)).unwrap();
+        b.close().unwrap();
+        b.close().unwrap();
+        let err = b.snapshot().expect_err("closed");
+        assert!(matches!(err, BackendError::Closed));
+        let err = b.begin_batch().expect_err("closed");
+        assert!(matches!(err, BackendError::Closed));
+    }
+
+    #[tokio::test]
+    async fn snapshot_isolated_from_post_snapshot_commits() {
+        let b = open();
+        b.register_bucket("kv", BucketId::new(1)).unwrap();
+        let mut batch = b.begin_batch().unwrap();
+        batch.put(BucketId::new(1), b"k", b"v1").unwrap();
+        let _ = b.commit_batch(batch, false).await.unwrap();
+
+        let snap = b.snapshot().unwrap();
+
+        let mut batch = b.begin_batch().unwrap();
+        batch.put(BucketId::new(1), b"k", b"v2").unwrap();
+        let _ = b.commit_batch(batch, false).await.unwrap();
+
+        // Snapshot still sees v1.
+        assert_eq!(
+            snap.get(BucketId::new(1), b"k").unwrap(),
+            Some(Bytes::from_static(b"v1"))
+        );
+    }
+
+    #[tokio::test]
+    async fn size_on_disk_is_zero() {
+        let b = open();
+        assert_eq!(b.size_on_disk().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn defragment_is_noop_ok() {
+        let b = open();
+        b.defragment().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn commit_group_is_atomic_across_batches() {
+        let b = open();
+        b.register_bucket("kv", BucketId::new(1)).unwrap();
+        let mut b1 = b.begin_batch().unwrap();
+        b1.put(BucketId::new(1), b"a", b"1").unwrap();
+        let mut b2 = b.begin_batch().unwrap();
+        b2.put(BucketId::new(1), b"b", b"2").unwrap();
+        let stamp = b.commit_group(vec![b1, b2]).await.unwrap();
+        assert_eq!(stamp, CommitStamp::new(1));
+
+        let snap = b.snapshot().unwrap();
+        assert_eq!(
+            snap.get(BucketId::new(1), b"a").unwrap(),
+            Some(Bytes::from_static(b"1"))
+        );
+        assert_eq!(
+            snap.get(BucketId::new(1), b"b").unwrap(),
+            Some(Bytes::from_static(b"2"))
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_bucket_in_batch_is_rejected_at_commit() {
+        let b = open();
+        let mut batch = b.begin_batch().unwrap();
+        batch.put(BucketId::new(99), b"k", b"v").unwrap();
+        let err = b.commit_batch(batch, false).await.expect_err("unknown");
+        assert!(matches!(err, BackendError::UnknownBucket(id) if id == BucketId::new(99)));
+    }
+}

--- a/crates/mango-storage/src/inmem/snapshot.rs
+++ b/crates/mango-storage/src/inmem/snapshot.rs
@@ -1,0 +1,132 @@
+//! [`ReadSnapshot`] impl for the in-memory reference backend
+//! (ROADMAP:821).
+//!
+//! Snapshot consistency is provided by clone-on-snapshot: the
+//! snapshot owns its own `Arc<HashMap<BucketId, BTreeMap<…>>>`,
+//! cloned from the live backend state at `snapshot()` time.
+//! Subsequent commits never observe the snapshot's clone, and the
+//! snapshot's clone never observes subsequent commits. This is
+//! `O(total_keys)` per snapshot — acceptable for a reference impl.
+//!
+//! Mirrors the lifetime story of
+//! [`crate::redb::snapshot::RedbSnapshot`] (concrete iterator type
+//! is `'static` w.r.t. the dyn-trait `'a`; the borrow ties the
+//! iterator to `&self` via the `BTreeMap` iterator's own `'a`).
+
+use std::collections::{BTreeMap, HashMap};
+use std::ops::Bound;
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use crate::backend::{BackendError, BucketId, RangeIter, ReadSnapshot};
+
+/// Cloned snapshot of every bucket's `BTreeMap`. Held behind
+/// `Arc` so multiple snapshots share the same clone if produced
+/// from the same commit cut (currently they don't — each
+/// `snapshot()` clones afresh — but the type leaves that door
+/// open).
+pub(super) type SnapshotBuckets = Arc<HashMap<BucketId, BTreeMap<Vec<u8>, Bytes>>>;
+
+/// Point-in-time read snapshot of an [`crate::InMemBackend`].
+///
+/// Construction (`InMemBackend::snapshot`) clones the bucket
+/// forest under a read lock; subsequent commits cannot mutate
+/// what this snapshot sees.
+#[derive(Debug)]
+pub struct InMemSnapshot {
+    pub(super) buckets: SnapshotBuckets,
+    /// Snapshot of the registered bucket-id set. Required so
+    /// `get` / `range` against an unregistered bucket return
+    /// `UnknownBucket` even if no commits ever touched the
+    /// `buckets` map for that id.
+    pub(super) registered_ids: Arc<std::collections::HashSet<BucketId>>,
+}
+
+impl InMemSnapshot {
+    pub(super) fn new(
+        buckets: SnapshotBuckets,
+        registered_ids: Arc<std::collections::HashSet<BucketId>>,
+    ) -> Self {
+        Self {
+            buckets,
+            registered_ids,
+        }
+    }
+}
+
+impl ReadSnapshot for InMemSnapshot {
+    fn get(&self, bucket: BucketId, key: &[u8]) -> Result<Option<Bytes>, BackendError> {
+        if !self.registered_ids.contains(&bucket) {
+            return Err(BackendError::UnknownBucket(bucket));
+        }
+        // A registered bucket with no writes yet has no entry in
+        // `buckets`; treat that as "no data" (matches RedbSnapshot's
+        // TableDoesNotExist → None mapping).
+        let Some(map) = self.buckets.get(&bucket) else {
+            return Ok(None);
+        };
+        Ok(map.get(key).cloned())
+    }
+
+    fn range<'a>(
+        &'a self,
+        bucket: BucketId,
+        start: &'a [u8],
+        end: &'a [u8],
+    ) -> Result<Box<dyn RangeIter<'a> + 'a>, BackendError> {
+        // Mirror RedbSnapshot::range precedence exactly:
+        // (1) start > end -> InvalidRange, (2) bucket existence,
+        // (3) empty bucket -> empty iterator. Empty `end` does NOT
+        // mean "unbounded" on the read side (that semantic is
+        // delete_range-only); with non-empty `start` and empty
+        // `end`, byte-comparison gives start > end, so InvalidRange
+        // fires — matching redb.
+        if start > end {
+            return Err(BackendError::InvalidRange("start > end"));
+        }
+        if !self.registered_ids.contains(&bucket) {
+            return Err(BackendError::UnknownBucket(bucket));
+        }
+        let Some(map) = self.buckets.get(&bucket) else {
+            return Ok(Box::new(EmptyRangeIter));
+        };
+        let bounds: (Bound<&[u8]>, Bound<&[u8]>) = (Bound::Included(start), Bound::Excluded(end));
+        let inner = map.range::<[u8], _>(bounds);
+        Ok(Box::new(InMemRangeIter { inner }))
+    }
+}
+
+/// Iterator adapter wrapping `BTreeMap::range`. Lifetime `'a` is
+/// the snapshot's; items are owned `Bytes` clones. `Send` because
+/// `Vec<u8>: Sync` and `Bytes: Sync`.
+struct InMemRangeIter<'a> {
+    inner: std::collections::btree_map::Range<'a, Vec<u8>, Bytes>,
+}
+
+impl Iterator for InMemRangeIter<'_> {
+    type Item = Result<(Bytes, Bytes), BackendError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|(k, v)| Ok((Bytes::copy_from_slice(k), v.clone())))
+    }
+}
+
+impl<'a> RangeIter<'a> for InMemRangeIter<'a> {}
+
+/// Yields nothing. Used when the bucket is registered but no
+/// writes have created its `BTreeMap` entry yet — same shape as
+/// `redb::snapshot::EmptyRangeIter`.
+struct EmptyRangeIter;
+
+impl Iterator for EmptyRangeIter {
+    type Item = Result<(Bytes, Bytes), BackendError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+impl RangeIter<'_> for EmptyRangeIter {}

--- a/crates/mango-storage/src/inmem/snapshot.rs
+++ b/crates/mango-storage/src/inmem/snapshot.rs
@@ -12,14 +12,29 @@
 //! [`crate::redb::snapshot::RedbSnapshot`] (concrete iterator type
 //! is `'static` w.r.t. the dyn-trait `'a`; the borrow ties the
 //! iterator to `&self` via the `BTreeMap` iterator's own `'a`).
+//!
+//! # Registry semantics
+//!
+//! The bucket-id registry is read **live** from the backend's
+//! shared state on every `get`/`range`, mirroring
+//! `RedbSnapshot::get`/`range` which call
+//! `self.inner.registry.read().contains_id(bucket)` per call. The
+//! registry only ever *grows* (bucket ids are never unregistered),
+//! so a read that observes a post-snapshot bucket id against a
+//! pre-snapshot data state correctly returns `Ok(None)` — the key
+//! does not exist in the snapshot's cut. See the trait-doc on
+//! [`crate::backend::ReadSnapshot::get`] /
+//! [`crate::backend::ReadSnapshot::range`] for the pinned contract.
 
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Bound;
 use std::sync::Arc;
 
 use bytes::Bytes;
+use parking_lot::RwLock;
 
 use crate::backend::{BackendError, BucketId, RangeIter, ReadSnapshot};
+use crate::inmem::InMemState;
 
 /// Cloned snapshot of every bucket's `BTreeMap`. Held behind
 /// `Arc` so multiple snapshots share the same clone if produced
@@ -30,39 +45,45 @@ pub(super) type SnapshotBuckets = Arc<HashMap<BucketId, BTreeMap<Vec<u8>, Bytes>
 
 /// Point-in-time read snapshot of an [`crate::InMemBackend`].
 ///
-/// Construction (`InMemBackend::snapshot`) clones the bucket
+/// Construction (`InMemBackend::snapshot`) clones the bucket data
 /// forest under a read lock; subsequent commits cannot mutate
-/// what this snapshot sees.
+/// what this snapshot sees. The bucket-id registry is read **live**
+/// from the backend on each `get`/`range` call (matches
+/// `RedbSnapshot`); see the module-level "Registry semantics" note.
 #[derive(Debug)]
 pub struct InMemSnapshot {
     pub(super) buckets: SnapshotBuckets,
-    /// Snapshot of the registered bucket-id set. Required so
-    /// `get` / `range` against an unregistered bucket return
-    /// `UnknownBucket` even if no commits ever touched the
-    /// `buckets` map for that id.
-    pub(super) registered_ids: Arc<std::collections::HashSet<BucketId>>,
+    /// Shared handle back to the backend's state, used to read the
+    /// live registry on each `get`/`range`. Mirrors
+    /// `RedbSnapshot.inner` (which carries `Arc<Inner>` for the
+    /// same purpose). The lock is held only briefly for a
+    /// `contains_key` check; no long-held read locks here.
+    pub(super) state: Arc<RwLock<InMemState>>,
 }
 
 impl InMemSnapshot {
-    pub(super) fn new(
-        buckets: SnapshotBuckets,
-        registered_ids: Arc<std::collections::HashSet<BucketId>>,
-    ) -> Self {
-        Self {
-            buckets,
-            registered_ids,
-        }
+    pub(super) fn new(buckets: SnapshotBuckets, state: Arc<RwLock<InMemState>>) -> Self {
+        Self { buckets, state }
+    }
+
+    /// Live registry membership check. Acquires `state.read()` for
+    /// the duration of a single `HashMap::contains_key` call —
+    /// brief, never re-entered.
+    fn registered(&self, bucket: BucketId) -> bool {
+        self.state.read().buckets_by_id.contains_key(&bucket)
     }
 }
 
 impl ReadSnapshot for InMemSnapshot {
     fn get(&self, bucket: BucketId, key: &[u8]) -> Result<Option<Bytes>, BackendError> {
-        if !self.registered_ids.contains(&bucket) {
+        if !self.registered(bucket) {
             return Err(BackendError::UnknownBucket(bucket));
         }
         // A registered bucket with no writes yet has no entry in
         // `buckets`; treat that as "no data" (matches RedbSnapshot's
-        // TableDoesNotExist → None mapping).
+        // TableDoesNotExist → None mapping). Buckets registered
+        // *after* the snapshot was taken also land here — see the
+        // module-level "Registry semantics" note.
         let Some(map) = self.buckets.get(&bucket) else {
             return Ok(None);
         };
@@ -85,7 +106,7 @@ impl ReadSnapshot for InMemSnapshot {
         if start > end {
             return Err(BackendError::InvalidRange("start > end"));
         }
-        if !self.registered_ids.contains(&bucket) {
+        if !self.registered(bucket) {
             return Err(BackendError::UnknownBucket(bucket));
         }
         let Some(map) = self.buckets.get(&bucket) else {

--- a/crates/mango-storage/src/lib.rs
+++ b/crates/mango-storage/src/lib.rs
@@ -24,10 +24,19 @@ mod redb;
 // private; only the named types below are public API.
 mod raft_engine;
 
+// ROADMAP:821 in-memory reference Backend impl. Gated behind the
+// `test-utils` Cargo feature so it does NOT appear in the default
+// public surface (`cargo public-api` sees no addition). Tests opt
+// in via the self-referential dev-dependency in `Cargo.toml`.
+#[cfg(feature = "test-utils")]
+pub mod inmem;
+
 pub use backend::{
     Backend, BackendConfig, BackendError, BucketId, CommitStamp, HardState, RaftEntry,
     RaftEntryType, RaftLogStore, RaftSnapshotMetadata, RangeIter, ReadSnapshot, WriteBatch,
 };
+#[cfg(feature = "test-utils")]
+pub use inmem::{batch::InMemBatch, snapshot::InMemSnapshot, InMemBackend};
 pub use raft_engine::{RaftEngineConfig, RaftEngineLogStore, ReadableSize, RecoveryMode};
 pub use redb::{batch::RedbBatch, snapshot::RedbSnapshot, RedbBackend};
 

--- a/crates/mango-storage/tests/engine_swap_dryrun.rs
+++ b/crates/mango-storage/tests/engine_swap_dryrun.rs
@@ -1,0 +1,390 @@
+//! Engine-swap dry-run test (ROADMAP:821).
+//!
+//! Validates the [`mango_storage::Backend`] trait boundary frozen in
+//! ADR 0002 §6 by running two concrete impls side-by-side:
+//!
+//! - [`mango_storage::RedbBackend`] — the production engine.
+//! - [`mango_storage::InMemBackend`] — a `BTreeMap`-backed reference
+//!   impl gated behind the `test-utils` Cargo feature.
+//!
+//! The tests live at the flat path `engine_swap_dryrun.rs` per
+//! rust-expert nit (the literal ROADMAP wording said
+//! `tests/migration/engine_swap_dryrun.rs`, but no other migration
+//! tests are roadmapped to share the directory).
+//!
+//! # Why these tests are not tautologies
+//!
+//! Trait-driven happy-path data round-trip is a tautology if both
+//! impls implement the same trait. The tests below specifically
+//! provoke the surfaces where a trait leak would actually surface:
+//!
+//! - **T1 deterministic** — every op variant including
+//!   `delete_range(end = [])` (unbounded upper), `commit_group`
+//!   atomicity, empty-key/empty-value rejection, and empty-bucket
+//!   commit. Migrates redb → in-mem and asserts byte-for-byte read
+//!   parity over both point lookups and ranges.
+//! - **T2 `force_fsync`** — exercises the `force_fsync = true` path
+//!   on both backends (redb's real fsync; in-mem's no-op) and pins
+//!   the `Ok(stamp)` + monotonicity contract.
+//! - **T3 error taxonomy** — provokes every `BackendError` variant
+//!   that can be triggered through the public API and asserts the
+//!   variant *kind* matches across backends with identical inputs.
+//!   This is the test that actually proves trait portability beyond
+//!   happy-path data.
+//!
+//! # Path / gating
+//!
+//! `#![cfg(not(madsim))]` matches `redb_backend.rs` — madsim's
+//! virtual time + redb's mmap+fsync would be a category error. The
+//! `test-utils` feature is auto-enabled via the self-referential
+//! dev-dep in `crates/mango-storage/Cargo.toml`, so no explicit
+//! `#[cfg(feature = "test-utils")]` is needed here.
+
+#![cfg(not(madsim))]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_truncation,
+    clippy::too_many_lines
+)]
+
+use std::collections::BTreeMap;
+
+use mango_storage::{
+    Backend, BackendConfig, BackendError, BucketId, CommitStamp, InMemBackend, ReadSnapshot,
+    RedbBackend, WriteBatch,
+};
+use tempfile::TempDir;
+
+const KV: BucketId = BucketId::new(1);
+const LEASE: BucketId = BucketId::new(2);
+
+/// Wide-enough bound to cover every script key under a single
+/// `range()` call. The script uses ASCII keys that fit in one byte,
+/// so `[0xFF, 0xFF, 0xFF, 0xFF]` is comfortably above any of them.
+const FULL_RANGE_END: &[u8] = &[0xFF, 0xFF, 0xFF, 0xFF];
+const FULL_RANGE_START: &[u8] = &[0x00];
+
+/// Open a `RedbBackend` against a fresh directory under `tmp`.
+fn open_redb(tmp: &TempDir) -> RedbBackend {
+    RedbBackend::open(BackendConfig::new(tmp.path().to_path_buf(), false)).expect("open redb")
+}
+
+/// Open a fresh `InMemBackend`. Path is unused.
+fn open_inmem() -> InMemBackend {
+    InMemBackend::open(BackendConfig::new("/unused".into(), false)).expect("open inmem")
+}
+
+/// Drain every (key, value) pair in a bucket via `range`.
+fn drain_bucket<S: ReadSnapshot>(snap: &S, bucket: BucketId) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut out = Vec::new();
+    let iter = snap
+        .range(bucket, FULL_RANGE_START, FULL_RANGE_END)
+        .expect("range");
+    for item in iter {
+        let (k, v) = item.expect("range item");
+        out.push((k.to_vec(), v.to_vec()));
+    }
+    out
+}
+
+/// Migrate every bucket from a redb snapshot into a fresh
+/// `InMemBackend` via a single `commit_batch`. Buckets must already
+/// be registered on the target.
+async fn migrate_redb_to_inmem(redb_snap: &mango_storage::RedbSnapshot, target: &InMemBackend) {
+    let mut batch = target.begin_batch().expect("begin migration batch");
+    for bucket in [KV, LEASE] {
+        for (k, v) in drain_bucket(redb_snap, bucket) {
+            batch.put(bucket, &k, &v).expect("put migration");
+        }
+    }
+    let _ = target
+        .commit_batch(batch, false)
+        .await
+        .expect("commit migration");
+}
+
+// =====================================================================
+// T1 — engine_swap_redb_to_inmem_data_survives
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn engine_swap_redb_to_inmem_data_survives() {
+    let tmp = TempDir::new().unwrap();
+    let redb = open_redb(&tmp);
+    redb.register_bucket("kv", KV).unwrap();
+    redb.register_bucket("lease", LEASE).unwrap();
+
+    // Empty-bucket commit (a): a batch with no ops still succeeds
+    // and bumps the seq.
+    let stamp_empty = redb
+        .commit_batch(redb.begin_batch().unwrap(), false)
+        .await
+        .unwrap();
+    assert_eq!(stamp_empty, CommitStamp::new(1));
+
+    // Body of the script (b)..(f): every variant, both buckets.
+    let mut batch = redb.begin_batch().unwrap();
+    // Spread keys: a..z plus a couple suffix variants.
+    for ch in b'a'..=b'z' {
+        batch.put(KV, &[ch], &[ch, b'.', b'v']).unwrap();
+    }
+    for ch in [b'a', b'm', b'z'] {
+        batch.put(LEASE, &[ch, b'-', b'1'], b"lease-1").unwrap();
+    }
+    let _ = redb.commit_batch(batch, false).await.unwrap();
+
+    // Single-key delete + delete_range with explicit upper bound.
+    let mut batch = redb.begin_batch().unwrap();
+    batch.delete(KV, b"a").unwrap();
+    batch.delete_range(KV, b"x", b"z").unwrap(); // deletes x, y; keeps z.
+    let _ = redb.commit_batch(batch, false).await.unwrap();
+
+    // delete_range(start, []) — unbounded upper; deletes the only
+    // remaining key 'z' from KV. Assert it actually fires by adding
+    // 'zz' first then ranging from 'z' onward.
+    let mut batch = redb.begin_batch().unwrap();
+    batch.put(KV, b"zz", b"zz.v").unwrap();
+    let _ = redb.commit_batch(batch, false).await.unwrap();
+    let mut batch = redb.begin_batch().unwrap();
+    batch.delete_range(KV, b"z", b"").unwrap();
+    let _ = redb.commit_batch(batch, false).await.unwrap();
+
+    // commit_group atomicity (e): two batches in one stamp.
+    let mut b1 = redb.begin_batch().unwrap();
+    b1.put(KV, b"GROUP_A", b"1").unwrap();
+    let mut b2 = redb.begin_batch().unwrap();
+    b2.put(LEASE, b"GROUP_B", b"2").unwrap();
+    let _ = redb.commit_group(vec![b1, b2]).await.unwrap();
+
+    // force_fsync=true (f).
+    let mut batch = redb.begin_batch().unwrap();
+    batch.put(KV, b"FSYNC", b"y").unwrap();
+    let _ = redb.commit_batch(batch, true).await.unwrap();
+
+    // Empty-key/empty-value rejection (c) — provoke at stage time
+    // and assert variant + message both match in T3. Here in T1 we
+    // only assert that staging refuses (no commit).
+    let mut probe = redb.begin_batch().unwrap();
+    let err = probe.put(KV, b"", b"v").unwrap_err();
+    assert!(matches!(err, BackendError::Other(_)));
+
+    // Snapshot the redb after the script.
+    let redb_snap = redb.snapshot().unwrap();
+
+    // Migrate.
+    let inmem = open_inmem();
+    inmem.register_bucket("kv", KV).unwrap();
+    inmem.register_bucket("lease", LEASE).unwrap();
+    migrate_redb_to_inmem(&redb_snap, &inmem).await;
+    let inmem_snap = inmem.snapshot().unwrap();
+
+    // (8) Range parity per bucket.
+    for bucket in [KV, LEASE] {
+        let r = drain_bucket(&redb_snap, bucket);
+        let i = drain_bucket(&inmem_snap, bucket);
+        assert_eq!(r, i, "range mismatch on bucket {bucket:?}");
+    }
+
+    // (9) Point parity for every observed key.
+    for bucket in [KV, LEASE] {
+        for (k, _) in drain_bucket(&redb_snap, bucket) {
+            assert_eq!(
+                redb_snap.get(bucket, &k).unwrap(),
+                inmem_snap.get(bucket, &k).unwrap(),
+                "point mismatch on {bucket:?}/{k:?}"
+            );
+        }
+    }
+
+    // (10) Continuation parity: apply 10 more mixed ops to inmem,
+    // maintain a parallel BTreeMap, assert post-state matches.
+    let mut oracle: BTreeMap<Vec<u8>, Vec<u8>> =
+        drain_bucket(&inmem_snap, KV).into_iter().collect();
+    let mut batch = inmem.begin_batch().unwrap();
+    batch.put(KV, b"CONT_1", b"v1").unwrap();
+    oracle.insert(b"CONT_1".to_vec(), b"v1".to_vec());
+    batch.put(KV, b"CONT_2", b"v2").unwrap();
+    oracle.insert(b"CONT_2".to_vec(), b"v2".to_vec());
+    batch.delete(KV, b"GROUP_A").unwrap();
+    oracle.remove(b"GROUP_A".as_slice());
+    batch.delete_range(KV, b"CONT_1", b"CONT_2").unwrap();
+    let to_remove: Vec<_> = oracle
+        .range(b"CONT_1".to_vec()..b"CONT_2".to_vec())
+        .map(|(k, _)| k.clone())
+        .collect();
+    for k in to_remove {
+        oracle.remove(&k);
+    }
+    let _ = inmem.commit_batch(batch, false).await.unwrap();
+
+    let post = inmem.snapshot().unwrap();
+    let observed: BTreeMap<Vec<u8>, Vec<u8>> = drain_bucket(&post, KV).into_iter().collect();
+    assert_eq!(observed, oracle, "continuation oracle drift");
+
+    // (11) size_on_disk parity-by-shape.
+    assert_eq!(inmem.size_on_disk().unwrap(), 0);
+    assert!(redb.size_on_disk().unwrap() > 0);
+
+    // (12) close() idempotence on both.
+    redb.close().unwrap();
+    redb.close().unwrap();
+    inmem.close().unwrap();
+    inmem.close().unwrap();
+    assert!(matches!(redb.snapshot(), Err(BackendError::Closed)));
+    assert!(matches!(inmem.snapshot(), Err(BackendError::Closed)));
+}
+
+// =====================================================================
+// T2 — swap_exercises_force_fsync_path
+// =====================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn swap_exercises_force_fsync_path() {
+    let tmp = TempDir::new().unwrap();
+    let redb = open_redb(&tmp);
+    let inmem = open_inmem();
+    redb.register_bucket("kv", KV).unwrap();
+    inmem.register_bucket("kv", KV).unwrap();
+
+    // Two consecutive force_fsync=true commits on each backend.
+    // Both must return Ok and be strictly monotonic. The InMem
+    // path is documented as a no-op; this test pins that contract.
+    let mut b = redb.begin_batch().unwrap();
+    b.put(KV, b"k", b"v").unwrap();
+    let s_redb_1 = redb.commit_batch(b, true).await.unwrap();
+    let mut b = redb.begin_batch().unwrap();
+    b.put(KV, b"k", b"v2").unwrap();
+    let s_redb_2 = redb.commit_batch(b, true).await.unwrap();
+    assert!(s_redb_1 < s_redb_2, "redb stamps must be monotonic");
+
+    let mut b = inmem.begin_batch().unwrap();
+    b.put(KV, b"k", b"v").unwrap();
+    let s_inmem_1 = inmem.commit_batch(b, true).await.unwrap();
+    let mut b = inmem.begin_batch().unwrap();
+    b.put(KV, b"k", b"v2").unwrap();
+    let s_inmem_2 = inmem.commit_batch(b, true).await.unwrap();
+    assert!(s_inmem_1 < s_inmem_2, "inmem stamps must be monotonic");
+}
+
+// =====================================================================
+// T3 — swap_preserves_error_taxonomy
+// =====================================================================
+
+/// Discriminant tag for `BackendError`. Compared across backends
+/// rather than the full variant value so payload differences (e.g.,
+/// the `&'static str` carried by `InvalidRange`) don't cause spurious
+/// mismatches. The taxonomy itself is what we're enforcing.
+///
+/// `BackendError` is `#[non_exhaustive]`, so the catch-all arm yields
+/// `Future` — a freshly-added variant landing without a corresponding
+/// taxonomy update will surface as `Future != Future` mismatches with
+/// the named variants and the test fails closed.
+#[derive(Debug, PartialEq, Eq)]
+enum ErrTag {
+    Io,
+    Corruption,
+    UnknownBucket,
+    InvalidRange,
+    Closed,
+    BucketConflict,
+    BucketNameConflict,
+    Other,
+    Future,
+}
+
+fn tag(e: &BackendError) -> ErrTag {
+    match e {
+        BackendError::Io(_) => ErrTag::Io,
+        BackendError::Corruption(_) => ErrTag::Corruption,
+        BackendError::UnknownBucket(_) => ErrTag::UnknownBucket,
+        BackendError::InvalidRange(_) => ErrTag::InvalidRange,
+        BackendError::Closed => ErrTag::Closed,
+        BackendError::BucketConflict { .. } => ErrTag::BucketConflict,
+        BackendError::BucketNameConflict { .. } => ErrTag::BucketNameConflict,
+        BackendError::Other(_) => ErrTag::Other,
+        _ => ErrTag::Future,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn swap_preserves_error_taxonomy() {
+    let tmp = TempDir::new().unwrap();
+    let redb = open_redb(&tmp);
+    let inmem = open_inmem();
+
+    // (1) get against unregistered bucket -> UnknownBucket.
+    redb.register_bucket("kv", KV).unwrap();
+    inmem.register_bucket("kv", KV).unwrap();
+    let r_snap = redb.snapshot().unwrap();
+    let i_snap = inmem.snapshot().unwrap();
+    let r = r_snap.get(BucketId::new(99), b"k").unwrap_err();
+    let i = i_snap.get(BucketId::new(99), b"k").unwrap_err();
+    assert_eq!(tag(&r), ErrTag::UnknownBucket);
+    assert_eq!(tag(&r), tag(&i));
+
+    // (2) range with start > end -> InvalidRange.
+    let r = r_snap.range(KV, &[1, 2, 3], &[1, 2]).err().unwrap();
+    let i = i_snap.range(KV, &[1, 2, 3], &[1, 2]).err().unwrap();
+    assert_eq!(tag(&r), ErrTag::InvalidRange);
+    assert_eq!(tag(&r), tag(&i));
+
+    // (3) BucketConflict: id-rebind to different name.
+    let r = redb.register_bucket("other", KV).unwrap_err();
+    let i = inmem.register_bucket("other", KV).unwrap_err();
+    assert_eq!(tag(&r), ErrTag::BucketConflict);
+    assert_eq!(tag(&r), tag(&i));
+
+    // (4) BucketNameConflict: name-rebind to different id.
+    let r = redb.register_bucket("kv", BucketId::new(50)).unwrap_err();
+    let i = inmem.register_bucket("kv", BucketId::new(50)).unwrap_err();
+    assert_eq!(tag(&r), ErrTag::BucketNameConflict);
+    assert_eq!(tag(&r), tag(&i));
+
+    // (5) read after close -> Closed.
+    let redb_for_close = open_redb(&TempDir::new().unwrap());
+    let inmem_for_close = open_inmem();
+    redb_for_close.close().unwrap();
+    inmem_for_close.close().unwrap();
+    let r = redb_for_close.snapshot().unwrap_err();
+    let i = inmem_for_close.snapshot().unwrap_err();
+    assert_eq!(tag(&r), ErrTag::Closed);
+    assert_eq!(tag(&r), tag(&i));
+
+    // (6) read_only=true open -> Other(_) with same message text on
+    // both backends. The exact string is the contract tying the two
+    // together (see InMemBackend::open and RedbBackend::open).
+    let tmp2 = TempDir::new().unwrap();
+    let r = RedbBackend::open(BackendConfig::new(tmp2.path().to_path_buf(), true)).unwrap_err();
+    let i = InMemBackend::open(BackendConfig::new("/unused".into(), true)).unwrap_err();
+    assert_eq!(tag(&r), ErrTag::Other);
+    assert_eq!(tag(&r), tag(&i));
+    if let (BackendError::Other(rm), BackendError::Other(im)) = (&r, &i) {
+        assert_eq!(rm, im, "read-only error messages must match byte-for-byte");
+    } else {
+        panic!("expected Other on both, got {r:?} / {i:?}");
+    }
+
+    // (7) Empty-key put on a batch -> Other(_) with same message.
+    let mut rb = redb.begin_batch().unwrap();
+    let mut ib = inmem.begin_batch().unwrap();
+    let r = rb.put(KV, b"", b"v").unwrap_err();
+    let i = ib.put(KV, b"", b"v").unwrap_err();
+    assert_eq!(tag(&r), ErrTag::Other);
+    assert_eq!(tag(&r), tag(&i));
+    if let (BackendError::Other(rm), BackendError::Other(im)) = (&r, &i) {
+        assert_eq!(rm, im, "empty-key error messages must match");
+    }
+
+    // (8) Empty-value put -> Other(_) with same message.
+    let r = rb.put(KV, b"k", b"").unwrap_err();
+    let i = ib.put(KV, b"k", b"").unwrap_err();
+    assert_eq!(tag(&r), ErrTag::Other);
+    assert_eq!(tag(&r), tag(&i));
+    if let (BackendError::Other(rm), BackendError::Other(im)) = (&r, &i) {
+        assert_eq!(rm, im, "empty-value error messages must match");
+    }
+}

--- a/crates/mango-storage/tests/engine_swap_dryrun.rs
+++ b/crates/mango-storage/tests/engine_swap_dryrun.rs
@@ -279,10 +279,17 @@ async fn swap_exercises_force_fsync_path() {
 /// the `&'static str` carried by `InvalidRange`) don't cause spurious
 /// mismatches. The taxonomy itself is what we're enforcing.
 ///
-/// `BackendError` is `#[non_exhaustive]`, so the catch-all arm yields
-/// `Future` — a freshly-added variant landing without a corresponding
-/// taxonomy update will surface as `Future != Future` mismatches with
-/// the named variants and the test fails closed.
+/// `BackendError` is `#[non_exhaustive]`, so this cross-crate match
+/// MUST carry a `_` arm — that arm collapses any future variant to
+/// `ErrTag::Future`. On its own, that wildcard would let a freshly-
+/// added variant returned by *both* backends silently tag the same
+/// way and pass T3 (fail-open). The structural backstop is the
+/// intra-crate `_backend_error_taxonomy_is_exhaustive` guard inside
+/// `mango-storage` (`src/backend.rs`), which lacks the `_` arm and
+/// fails to compile when a variant is added without an explicit
+/// pattern. Adding a variant therefore breaks the storage crate
+/// build before any cross-crate consumer can hide it — see the
+/// guard's doc comment for details.
 #[derive(Debug, PartialEq, Eq)]
 enum ErrTag {
     Io,
@@ -387,6 +394,54 @@ async fn swap_preserves_error_taxonomy() {
     if let (BackendError::Other(rm), BackendError::Other(im)) = (&r, &i) {
         assert_eq!(rm, im, "empty-value error messages must match");
     }
+
+    // (9) Read against a bucket REGISTERED AFTER the snapshot.
+    //
+    // The trait contract (`ReadSnapshot` "Registry semantics" in
+    // `src/backend.rs`) is: snapshot data is frozen at
+    // `Backend::snapshot()`, but the registry is read live. A
+    // bucket id registered AFTER a snapshot was taken must be
+    // observable through that snapshot's `get`/`range` as
+    // `Ok(None)` / empty-iterator (the snapshot's data cut
+    // pre-dates the registration, so it has no entries).
+    //
+    // This case actually exercises the divergence rust-expert
+    // flagged in the original review: an inmem snapshot that
+    // froze the registry at construction would return
+    // `UnknownBucket` here, while redb (live registry) would
+    // return `Ok(None)`. The taxonomy assertion below
+    // mechanically catches that drift.
+    //
+    // Construct fresh backends so prior steps don't pollute the
+    // post-snapshot registration cut.
+    let tmp_post = TempDir::new().unwrap();
+    let redb_post = open_redb(&tmp_post);
+    let inmem_post = open_inmem();
+    let r_snap_post = redb_post.snapshot().unwrap();
+    let i_snap_post = inmem_post.snapshot().unwrap();
+    redb_post.register_bucket("kv", KV).unwrap();
+    inmem_post.register_bucket("kv", KV).unwrap();
+    let r_get = r_snap_post.get(KV, b"k");
+    let i_get = i_snap_post.get(KV, b"k");
+    assert!(
+        matches!(&r_get, Ok(None)),
+        "redb post-snapshot-registered bucket must read as Ok(None), got {r_get:?}"
+    );
+    assert!(
+        matches!(&i_get, Ok(None)),
+        "inmem post-snapshot-registered bucket must read as Ok(None), got {i_get:?}"
+    );
+    // Range case: empty iterator on both.
+    let r_range = r_snap_post.range(KV, b"\x00", FULL_RANGE_END);
+    let i_range = i_snap_post.range(KV, b"\x00", FULL_RANGE_END);
+    let r_count = r_range
+        .expect("redb empty-iterator on post-snapshot bucket")
+        .count();
+    let i_count = i_range
+        .expect("inmem empty-iterator on post-snapshot bucket")
+        .count();
+    assert_eq!(r_count, 0);
+    assert_eq!(i_count, 0);
 }
 
 // =====================================================================

--- a/crates/mango-storage/tests/engine_swap_dryrun.rs
+++ b/crates/mango-storage/tests/engine_swap_dryrun.rs
@@ -388,3 +388,267 @@ async fn swap_preserves_error_taxonomy() {
         assert_eq!(rm, im, "empty-value error messages must match");
     }
 }
+
+// =====================================================================
+// T4 — swap_preserves_observable_semantics_under_proptest
+// =====================================================================
+//
+// Generates random op scripts (bounded length 30, 16-symbol ASCII
+// alphabet) against `RedbBackend`, then dumps + replays into a fresh
+// `InMemBackend`, then re-executes every read point op (`Get`,
+// `RangeScan`, `Snapshot`) against both backends and asserts they
+// agree byte-for-byte.
+//
+// The op surface and weighting mirror `btreemap_oracle.rs` so a
+// generic-wrapper bug surfaced by either harness has consistent
+// shrink behavior. Default 256 cases; `MANGO_ENGINE_SWAP_THOROUGH=1`
+// bumps to 10 000 (matches `MANGO_BTREEMAP_THOROUGH=1` /
+// `MANGO_DIFFERENTIAL_THOROUGH=1`).
+
+mod proptest_swap {
+    use super::{
+        drain_bucket, BTreeMap, Backend, BackendConfig, InMemBackend, ReadSnapshot, RedbBackend,
+        TempDir, WriteBatch, FULL_RANGE_END, FULL_RANGE_START, KV,
+    };
+    use std::ops::Bound;
+    use std::sync::OnceLock;
+
+    use proptest::prelude::*;
+    use proptest::test_runner::TestCaseResult;
+    use tokio::runtime::Runtime;
+
+    /// 16-symbol alphabet matching `btreemap_oracle.rs` for
+    /// cross-comparable key-shape coverage. All bytes < `0xff` so
+    /// `FULL_RANGE_END = [0xff, 0xff, 0xff, 0xff]` is sound as the
+    /// implicit "snapshot everything" upper bound.
+    const ALPHABET: &[u8] = b"0123456789abcdef";
+
+    /// Reused single-threaded tokio runtime; same rationale as
+    /// `btreemap_oracle.rs::runtime` — `commit_batch`'s
+    /// `spawn_blocking` lands on the blocking pool regardless of
+    /// flavor; leak on process exit is intentional, since sync-drop
+    /// from a worker thread is a known footgun.
+    fn runtime() -> &'static Runtime {
+        static RT: OnceLock<Runtime> = OnceLock::new();
+        RT.get_or_init(|| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build current-thread tokio runtime")
+        })
+    }
+
+    #[derive(Debug, Clone)]
+    enum Op {
+        Put(Vec<u8>, Vec<u8>),
+        Delete(Vec<u8>),
+        DeleteRange { start: Vec<u8>, end: Vec<u8> },
+        Commit,
+    }
+
+    /// One read replayed against both backends.
+    #[derive(Debug, Clone)]
+    enum Read {
+        Get(Vec<u8>),
+        RangeScan { start: Vec<u8>, end: Vec<u8> },
+    }
+
+    fn key_strat() -> impl Strategy<Value = Vec<u8>> {
+        let alpha = (0u8..ALPHABET.len() as u8).prop_map(|i| ALPHABET[i as usize]);
+        prop_oneof![
+            60 => proptest::collection::vec(alpha.clone(), 1..=1),
+            25 => proptest::collection::vec(alpha.clone(), 2..=2),
+            15 => proptest::collection::vec(alpha, 3..=8),
+        ]
+    }
+
+    fn val_strat() -> impl Strategy<Value = Vec<u8>> {
+        proptest::collection::vec(any::<u8>(), 1..=16)
+    }
+
+    fn delete_range_pair_strat() -> impl Strategy<Value = (Vec<u8>, Vec<u8>)> {
+        prop_oneof![
+            90 => (key_strat(), key_strat())
+                .prop_map(|(a, b)| if a <= b { (a, b) } else { (b, a) }),
+            10 => key_strat().prop_map(|start| (start, Vec::new())),
+        ]
+    }
+
+    fn op_strat() -> impl Strategy<Value = Op> {
+        prop_oneof![
+            45 => (key_strat(), val_strat()).prop_map(|(k, v)| Op::Put(k, v)),
+            15 => key_strat().prop_map(Op::Delete),
+            15 => delete_range_pair_strat().prop_map(|(start, end)| Op::DeleteRange { start, end }),
+            25 => Just(Op::Commit),
+        ]
+    }
+
+    fn ops_strat() -> impl Strategy<Value = Vec<Op>> {
+        proptest::collection::vec(op_strat(), 1..=30)
+    }
+
+    fn range_pair_strat() -> impl Strategy<Value = (Vec<u8>, Vec<u8>)> {
+        (key_strat(), key_strat()).prop_map(|(a, b)| if a <= b { (a, b) } else { (b, a) })
+    }
+
+    fn read_strat() -> impl Strategy<Value = Read> {
+        prop_oneof![
+            50 => key_strat().prop_map(Read::Get),
+            50 => range_pair_strat().prop_map(|(start, end)| Read::RangeScan { start, end }),
+        ]
+    }
+
+    fn reads_strat() -> impl Strategy<Value = Vec<Read>> {
+        proptest::collection::vec(read_strat(), 1..=20)
+    }
+
+    /// Apply a write op to a redb batch, swallowing
+    /// empty-key/empty-value rejections so the script generator
+    /// doesn't have to filter them — the same op run against
+    /// `InMemBackend` will be rejected with the same `Other(_)`
+    /// message (T3 pins this), so skipping in lockstep is sound.
+    fn try_apply<B: WriteBatch>(batch: &mut B, op: &Op) {
+        match op {
+            Op::Put(k, v) => {
+                let _ = batch.put(KV, k, v);
+            }
+            Op::Delete(k) => {
+                let _ = batch.delete(KV, k);
+            }
+            Op::DeleteRange { start, end } => {
+                let _ = batch.delete_range(KV, start, end);
+            }
+            Op::Commit => {}
+        }
+    }
+
+    async fn apply_script_redb(redb: &RedbBackend, ops: &[Op]) {
+        let mut batch = redb.begin_batch().expect("begin");
+        for op in ops {
+            if matches!(op, Op::Commit) {
+                let _ = redb.commit_batch(batch, false).await.expect("commit");
+                batch = redb.begin_batch().expect("begin");
+            } else {
+                try_apply(&mut batch, op);
+            }
+        }
+        // Final implicit commit so any tail ops materialize.
+        let _ = redb.commit_batch(batch, false).await.expect("final commit");
+    }
+
+    /// Dump every committed (k, v) pair from `redb_snap`'s `KV`
+    /// bucket and replay into a fresh `InMemBackend`.
+    async fn migrate(redb_snap: &mango_storage::RedbSnapshot, target: &InMemBackend) {
+        let mut batch = target.begin_batch().expect("begin migration");
+        for (k, v) in drain_bucket(redb_snap, KV) {
+            batch.put(KV, &k, &v).expect("migration put");
+        }
+        let _ = target
+            .commit_batch(batch, false)
+            .await
+            .expect("commit migration");
+    }
+
+    fn read_redb<S: ReadSnapshot>(snap: &S, r: &Read) -> ReadResult {
+        match r {
+            Read::Get(k) => {
+                let got = snap.get(KV, k).expect("redb get").map(|b| b.to_vec());
+                ReadResult::Point(got)
+            }
+            Read::RangeScan { start, end } => {
+                let mut out = Vec::new();
+                let iter = snap.range(KV, start, end).expect("redb range");
+                for entry in iter {
+                    let (k, v) = entry.expect("redb range item");
+                    out.push((k.to_vec(), v.to_vec()));
+                }
+                ReadResult::Range(out)
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum ReadResult {
+        Point(Option<Vec<u8>>),
+        Range(Vec<(Vec<u8>, Vec<u8>)>),
+    }
+
+    fn run_case(ops: &[Op], reads: &[Read]) -> TestCaseResult {
+        let rt = runtime();
+        let tmp = TempDir::new().expect("tempdir");
+        let redb = RedbBackend::open(BackendConfig::new(tmp.path().to_path_buf(), false))
+            .expect("open redb");
+        redb.register_bucket("kv", KV).expect("register kv");
+
+        rt.block_on(apply_script_redb(&redb, ops));
+
+        let redb_snap = redb.snapshot().expect("redb snapshot");
+
+        let inmem =
+            InMemBackend::open(BackendConfig::new("/unused".into(), false)).expect("open inmem");
+        inmem.register_bucket("kv", KV).expect("register kv inmem");
+        rt.block_on(migrate(&redb_snap, &inmem));
+        let inmem_snap = inmem.snapshot().expect("inmem snapshot");
+
+        // Full-state diff: identical sets of committed (k, v) pairs.
+        let r_full = drain_bucket(&redb_snap, KV);
+        let i_full = drain_bucket(&inmem_snap, KV);
+        prop_assert_eq!(
+            &r_full,
+            &i_full,
+            "full-state diff after migration: redb len={}, inmem len={}",
+            r_full.len(),
+            i_full.len()
+        );
+
+        // Replay reads on both snapshots and assert agreement.
+        for (i, r) in reads.iter().enumerate() {
+            let r_redb = read_redb(&redb_snap, r);
+            let r_inmem = read_redb(&inmem_snap, r);
+            prop_assert_eq!(&r_redb, &r_inmem, "read #{} {:?} disagreement", i, r);
+        }
+
+        // Finally cross-check the BTreeMap oracle for the inmem
+        // side — proves migration didn't silently drop or reorder
+        // anything.
+        let oracle: BTreeMap<Vec<u8>, Vec<u8>> = i_full.iter().cloned().collect();
+        let bounds = (
+            Bound::Included(FULL_RANGE_START),
+            Bound::Excluded(FULL_RANGE_END),
+        );
+        let oracle_pairs: Vec<(Vec<u8>, Vec<u8>)> = oracle
+            .range::<[u8], _>(bounds)
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        prop_assert_eq!(
+            &i_full,
+            &oracle_pairs,
+            "inmem disagrees with BTreeMap oracle"
+        );
+        Ok(())
+    }
+
+    fn proptest_cases() -> u32 {
+        if std::env::var("MANGO_ENGINE_SWAP_THOROUGH").is_ok() {
+            10_000
+        } else {
+            256
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            cases: proptest_cases(),
+            max_shrink_iters: 4096,
+            ..ProptestConfig::default()
+        })]
+
+        #[test]
+        fn proptest_engine_swap_redb_to_inmem_observable_semantics(
+            ops in ops_strat(),
+            reads in reads_strat(),
+        ) {
+            run_case(&ops, &reads)?;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Lands ROADMAP:821 — the engine-swap dry-run test. Adds `InMemBackend`, a `BTreeMap`-backed second `Backend` impl gated behind a new `test-utils` Cargo feature, and an integration test (`tests/engine_swap_dryrun.rs`) that runs RedbBackend + InMemBackend side-by-side to validate the trait boundary frozen in ADR 0002 §6 is actually swappable.

Why this matters: ADR 0002 budgets a 2-week swap from redb to a runner-up engine (heed, fjall). That budget is only credible if the trait is provably swappable in mechanical, demonstrable steps. Today there's exactly one `Backend` impl. If the trait has secretly leaked engine details, this is where it surfaces — now, not 1 week into a future migration.

Plan: `.planning/engine-swap-dryrun.plan.md` (gitignored, drafted+revised against rust-expert; 11 must-fixes addressed pre-implementation).

## What's in the diff

**Commit 1** — `feat(storage): InMemBackend reference impl, test-utils gated`
- New `crates/mango-storage/src/inmem/{mod,batch,snapshot}.rs`.
- Stage-then-swap atomicity in `commit_staged` so panic-mid-apply leaves visible state untouched (matches redb's transactional contract).
- `delete_range(end=[])` = "unbounded upper" cross-referenced inline with `redb/mod.rs::apply_staged`.
- Empty-key/empty-value rejection re-uses redb's `EMPTY_KEY_ERROR`/`EMPTY_VALUE_ERROR` for byte-identical taxonomy.
- `open(read_only=true)` rejected with the same `Other` message as redb so error-taxonomy parity holds.
- `InMemBatch: !Send + !Sync` via `PhantomData<*const ()>`; commit paths extract `Vec<StagedOp>` in the sync prologue so the future capture set stays `Send`.
- `next_seq` uses `checked_add(1)` (workspace `arithmetic_side_effects = deny`); empty commits also bump.
- 20 unit tests inside the module; compile-time `Send + Sync + 'static` assertion on the type.
- Self-referential `[dev-dependencies] mango-storage = { path = ".", features = ["test-utils"] }` — public surface under default features unchanged (no `cargo public-api` regression).

**Commit 2** — `test(storage): engine-swap dry-run deterministic + force-fsync + error-taxonomy`
- T1 `engine_swap_redb_to_inmem_data_survives`: ~50-op script covering every WriteBatch variant, `delete_range(end=[])`, `commit_group`, `force_fsync=true`, empty-bucket commit; migrates redb→inmem and asserts byte-for-byte read parity (point + range + 10-op continuation oracle + `size_on_disk` shape + `close` idempotence).
- T2 `swap_exercises_force_fsync_path`: pins the InMem no-op contract and the strict monotonicity of `CommitStamp` across two `force_fsync=true` commits.
- T3 `swap_preserves_error_taxonomy`: provokes every `BackendError` variant reachable through the public API on both backends with identical inputs and asserts the variant kind matches by discriminant. `Other(_)` payloads are byte-compared. Includes a `Future` tag for any new `#[non_exhaustive]` variant added without a taxonomy update.

**Commit 3** — `test(storage): proptest swap-semantics oracle`
- T4 256-case proptest: random op script → apply on redb → migrate to inmem → re-execute generated reads on both → assert byte-for-byte parity. Op weighting mirrors `btreemap_oracle.rs` for cross-comparable shrink behavior. `MANGO_ENGINE_SWAP_THOROUGH=1` bumps to 10 000 cases (matches the bbolt / btreemap thorough knobs).

## Test plan

- [x] `cargo nextest run -p mango-storage --features test-utils` — 133 passed, 1 skipped (madsim-gated)
- [x] `cargo nextest run -p mango-storage --test engine_swap_dryrun` — 4 passed (T1, T2, T3, T4 256-case proptest)
- [x] `cargo clippy -p mango-storage --all-targets --features test-utils -- -D warnings` — clean
- [x] `cargo build -p mango-storage` (default features only) — clean; no public surface change
- [ ] CI green on the PR
- [ ] `cargo public-api` shows no addition under default features
- [ ] cargo-geiger `mango-storage` row stays at 0 (InMemBackend uses no `unsafe`)

## Path note

The literal ROADMAP wording said `tests/migration/engine_swap_dryrun.rs`. Per rust-expert nit (promoted to required), the test lives at the flat path `tests/engine_swap_dryrun.rs` to match every other integration test in the crate. No other migration tests are roadmapped to share that subdir.