### PR TITLE
fix(deny): pin version on self-referential mango-storage dev-dep

### DIFF
--- a/crates/mango-storage/Cargo.toml
+++ b/crates/mango-storage/Cargo.toml
@@ -58,7 +58,14 @@ test-utils = []
 # `crates/mango-storage/tests/` see `mango_storage::InMemBackend`
 # without any per-test-target gymnastics. Self-referential dev-deps
 # are a recognized Cargo idiom (rust-bitcoin, serde, others).
-mango-storage = { path = ".", features = ["test-utils"] }
+#
+# `version = "0.1.0"` is required even for `path = "."`: cargo-deny's
+# `wildcard = "deny"` policy flags any dependency without a version
+# requirement, including self-referential path deps. The version
+# string MUST track the package's own `version.workspace = true`
+# (currently 0.1.0 in the workspace root); on the next workspace
+# version bump this also bumps.
+mango-storage = { path = ".", version = "0.1.0", features = ["test-utils"] }
 # ROADMAP:817 integration tests open a real redb on disk in a
 # tempdir; tempfile is the workspace-standard primitive. Exemption
 # already present in supply-chain/config.toml (tempfile@3.27.0).


### PR DESCRIPTION
## Summary

Hotfix for the `deny` job on `main`. The self-referential `mango-storage = { path = "." }` dev-dep introduced in #58 (ROADMAP:821) has no version requirement, which cargo-deny's `wildcard = "deny"` policy flags. Main has been red since #58 merged.

Adds `version = "0.1.0"` to the dev-dep entry. The version tracks the package's own `version.workspace = true` (currently `0.1.0`); a comment names the workspace-version coupling so a future bumper updates it.

## Why a hotfix

This blocks every other PR's merge (the `deny` check is required), and every roadmap follow-up (e.g. PR #60 / ROADMAP:826) depends on green main.

## Test plan

- [x] `cargo build -p mango-storage --tests`: clean
- [x] `cargo nextest run -p mango-storage --locked`: 133/133 PASS
- [x] `cargo deny check bans` (locally): `bans ok` — was `error[wildcard]: found 1 wildcard dependency for crate 'mango-storage'`

## Out of scope

- Any structural change to the self-referential dev-dep idiom.
- The remaining red `clippy` / `test` jobs on `main` (those are downstream of #58 and #59 and are tracked under the next-roadmap-item loop, not this hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
