### PR TITLE
feat(storage): block-level value compression (ROADMAP:830)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+
+[[package]]
 name = "madsim"
 version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +687,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "bytes",
+ "lz4_flex",
  "madsim",
  "madsim-tokio",
  "mango-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,46 @@ thiserror = "2"
 # exemption already present (parking_lot@0.12.5, parking_lot_core@0.9.12).
 parking_lot = "0.12"
 
+# Phase 1 user-data block compression (ROADMAP:830).
+#
+# lz4_flex: pure-Rust LZ4. ADR 0002 §3 names lz4_flex as the
+# workspace's LZ4 library on the Raft-log path; this entry extends
+# that choice to the user-data backend (mango-storage encodes/decodes
+# at the value boundary in the redb backend). ADR 0002 §W5 bans
+# lz4-sys (C FFI), so this is the only library satisfying both
+# pure-Rust and `unsafe_code = "forbid"` for mango's own crates.
+#
+# Pin shape: `=0.13.0` exact (matches redb posture, line 104). A
+# bump to 0.14+ requires refreshing the cargo-vet exemption AND
+# re-audit; Dependabot does NOT auto-bump exact pins.
+#
+# Features:
+# - `default-features = false` drops `frame` (dragging in
+#   `twox-hash`) and `nightly` (no nightly toolchain in CI).
+# - `safe-encode` / `safe-decode` keep the codec on the
+#   `unsafe`-free path. Workspace policy is `unsafe_code = "forbid"`
+#   for mango's own crates; for deps the same posture is enforced
+#   via `cargo-geiger` (ROADMAP:823 baseline). Without these
+#   features, lz4_flex falls back to pointer-arith hot loops with
+#   `unsafe`.
+# - `checked-decode` is the decoder-side bounds-check layer that
+#   lz4_flex's manifest documents as "remove only on trusted
+#   input". Disk bytes are NOT trusted (corruption, partial-write,
+#   future bug) — the decoder must remain robust to adversarial
+#   payloads.
+# - `std` is required for the `Vec<u8>` allocator path.
+#
+# Verify post-add: `cargo tree -e no-dev -p mango-storage |
+# grep -E 'lz4|twox-hash'` must show only `lz4_flex 0.13.0` (no
+# `twox-hash`, no other lz4 crate). cargo-vet exemption recorded
+# in supply-chain/config.toml with a review-by date.
+lz4_flex = { version = "=0.13.0", default-features = false, features = [
+    "safe-encode",
+    "safe-decode",
+    "checked-decode",
+    "std",
+] }
+
 [workspace.package]
 version = "0.1.0"
 edition = "2021"

--- a/crates/mango-storage/Cargo.toml
+++ b/crates/mango-storage/Cargo.toml
@@ -34,6 +34,16 @@ thiserror.workspace = true
 # ROADMAP:817 (Backend impl): parking_lot for the Database RwLock.
 # See Cargo.toml workspace entry for the ban-override rationale.
 parking_lot.workspace = true
+# ROADMAP:830: pure-Rust LZ4 for value-level block compression in
+# the redb backend. See workspace Cargo.toml `lz4_flex` entry for
+# the feature-set rationale (`safe-encode` + `safe-decode` for the
+# unsafe-free path; `checked-decode` for adversarial disk bytes;
+# no `frame` ⇒ no `twox-hash` transitive). Local features MUST
+# stay empty: `features = [...]` would ADD to the workspace set.
+# ADR 0002 §3 (lz4_flex on the Raft-log path) is extended here to
+# the user-data path; ADR 0002 §W5 bans the lz4-sys C FFI
+# alternative.
+lz4_flex.workspace = true
 # ROADMAP:817: tokio::task::spawn_blocking is required so async commit
 # methods do NOT block tokio worker threads with redb's synchronous
 # fsync. `rt` alone covers spawn_blocking — `rt-multi-thread` is

--- a/crates/mango-storage/src/backend.rs
+++ b/crates/mango-storage/src/backend.rs
@@ -12,9 +12,12 @@
 //! # Example
 //!
 //! ```no_run
-//! use mango_storage::{Backend, BackendConfig, BackendError, BucketId};
+//! use mango_storage::{Backend, BackendConfig, BackendError, BucketId, CompressionMode};
 //! # fn example<B: Backend>() -> Result<(), BackendError> {
-//! let cfg = BackendConfig::new("/tmp/mango".into(), false);
+//! // Constructor default is `CompressionMode::None`; opt into LZ4
+//! // explicitly via `with_compression` (ROADMAP:828, ROADMAP:830).
+//! let cfg = BackendConfig::new("/tmp/mango".into(), false)
+//!     .with_compression(CompressionMode::Lz4);
 //! let backend = B::open(cfg)?;
 //! backend.register_bucket("kv", BucketId::new(1))?;
 //! let _snap = backend.snapshot()?;
@@ -152,6 +155,38 @@ impl CommitStamp {
     }
 }
 
+/// Block-level value compression mode for [`Backend`] impls
+/// (ROADMAP:830). Carried on [`BackendConfig`] and consumed by the
+/// engine's write path; reads are config-blind (the on-disk tag
+/// dictates decoding).
+///
+/// Default is [`Self::None`] — the parity-bench setting (ROADMAP:828
+/// and ROADMAP:829). Production callers per ROADMAP:828's "default
+/// compression on" opt into [`Self::Lz4`] explicitly via
+/// [`BackendConfig::with_compression`]. Keeping the **constructor**
+/// default at `None` preserves the existing parity-bench and
+/// differential-test surface; the deployment-time default is a
+/// caller-side choice.
+///
+/// `#[non_exhaustive]` per workspace policy
+/// (`docs/api-stability.md`) and to leave room for a future `Zstd`
+/// variant (deferred — pure-Rust zstd encoder is not widely
+/// available; `zstd-safe` is C FFI and banned by ADR 0002 §W5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum CompressionMode {
+    /// Store values verbatim with a 1-byte `0x00` tag prefix.
+    /// Constructor default; the parity-bench setting (ROADMAP:828,
+    /// ROADMAP:829).
+    #[default]
+    None,
+    /// Compress values with LZ4 above a length and ratio threshold.
+    /// Values that fail either check are stored verbatim with a
+    /// `0x00` tag prefix — the encoder never inflates a value just
+    /// because LZ4 was requested.
+    Lz4,
+}
+
 /// Configuration for [`Backend::open`]. Engine-specific knobs belong
 /// on the impl type, not here; this struct carries only the
 /// portable configuration every backend needs. `#[non_exhaustive]`
@@ -168,18 +203,43 @@ pub struct BackendConfig {
     /// supported")` until the MVCC layer lands. Kept on the struct
     /// so the API is frozen now.
     pub read_only: bool,
+    /// Block-level value compression mode (ROADMAP:830). Default
+    /// [`CompressionMode::None`] — opt into compression via
+    /// [`BackendConfig::with_compression`]. Read paths ignore this
+    /// field (decoding is dispatched on the on-disk tag byte), so
+    /// reopening a database under a different mode does not lose
+    /// data.
+    pub compression: CompressionMode,
 }
 
 impl BackendConfig {
     /// Construct a [`BackendConfig`]. Required because
     /// `#[non_exhaustive]` blocks struct-literal construction from
     /// outside the defining crate.
+    ///
+    /// Two-arg shape preserved for source-compatibility with every
+    /// existing call site; opt into compression via
+    /// [`Self::with_compression`].
     #[must_use]
     pub fn new(data_dir: std::path::PathBuf, read_only: bool) -> Self {
         Self {
             data_dir,
             read_only,
+            compression: CompressionMode::None,
         }
+    }
+
+    /// Set [`Self::compression`] to `mode`. Builder-style override
+    /// of the default; chainable from [`Self::new`].
+    ///
+    /// `#[must_use]` because discarding the returned [`BackendConfig`]
+    /// is almost certainly a bug — the typical site is
+    /// `BackendConfig::new(p, false).with_compression(...)`, and
+    /// dropping the chain would silently revert to the default.
+    #[must_use]
+    pub fn with_compression(mut self, mode: CompressionMode) -> Self {
+        self.compression = mode;
+        self
     }
 }
 

--- a/crates/mango-storage/src/lib.rs
+++ b/crates/mango-storage/src/lib.rs
@@ -32,8 +32,9 @@ mod raft_engine;
 pub mod inmem;
 
 pub use backend::{
-    Backend, BackendConfig, BackendError, BucketId, CommitStamp, HardState, RaftEntry,
-    RaftEntryType, RaftLogStore, RaftSnapshotMetadata, RangeIter, ReadSnapshot, WriteBatch,
+    Backend, BackendConfig, BackendError, BucketId, CommitStamp, CompressionMode, HardState,
+    RaftEntry, RaftEntryType, RaftLogStore, RaftSnapshotMetadata, RangeIter, ReadSnapshot,
+    WriteBatch,
 };
 #[cfg(feature = "test-utils")]
 pub use inmem::{batch::InMemBatch, snapshot::InMemSnapshot, InMemBackend};
@@ -193,5 +194,40 @@ mod tests {
         const KV_BUCKET: BucketId = BucketId::new(1);
         assert_eq!(KV_BUCKET.raw, 1);
         assert_eq!(BucketId::new(7).raw, 7);
+    }
+
+    // --- ROADMAP:830 CompressionMode + builder shape ----------------
+
+    #[test]
+    fn compression_mode_default_is_none() {
+        // Pins the parity-bench surface — ROADMAP:828's
+        // "default compression on" is a deployment-time choice, not
+        // the constructor default. Flipping this default would
+        // silently break the differential-vs-bbolt test (which
+        // pins None explicitly) and Phase 1 parity benches.
+        assert_eq!(CompressionMode::default(), CompressionMode::None);
+    }
+
+    #[test]
+    fn backend_config_constructor_default_is_compression_none() {
+        let cfg = BackendConfig::new(std::path::PathBuf::from("/tmp/x"), false);
+        assert_eq!(cfg.compression, CompressionMode::None);
+    }
+
+    #[test]
+    fn backend_config_with_compression_overrides_default() {
+        let cfg = BackendConfig::new(std::path::PathBuf::from("/tmp/x"), false)
+            .with_compression(CompressionMode::Lz4);
+        assert_eq!(cfg.compression, CompressionMode::Lz4);
+    }
+
+    #[test]
+    fn backend_config_with_compression_is_chainable_and_clone_round_trips() {
+        let cfg = BackendConfig::new(std::path::PathBuf::from("/tmp/x"), true)
+            .with_compression(CompressionMode::Lz4);
+        let cloned = cfg.clone();
+        assert_eq!(cloned.read_only, true);
+        assert_eq!(cloned.compression, CompressionMode::Lz4);
+        assert_eq!(cloned.data_dir, std::path::PathBuf::from("/tmp/x"));
     }
 }

--- a/crates/mango-storage/src/lib.rs
+++ b/crates/mango-storage/src/lib.rs
@@ -226,7 +226,7 @@ mod tests {
         let cfg = BackendConfig::new(std::path::PathBuf::from("/tmp/x"), true)
             .with_compression(CompressionMode::Lz4);
         let cloned = cfg.clone();
-        assert_eq!(cloned.read_only, true);
+        assert!(cloned.read_only);
         assert_eq!(cloned.compression, CompressionMode::Lz4);
         assert_eq!(cloned.data_dir, std::path::PathBuf::from("/tmp/x"));
     }

--- a/crates/mango-storage/src/redb/mod.rs
+++ b/crates/mango-storage/src/redb/mod.rs
@@ -53,7 +53,9 @@ use parking_lot::RwLock;
 // read-write database types can share them.
 use ::redb::{ReadableDatabase, ReadableTable};
 
-use crate::backend::{Backend, BackendConfig, BackendError, BucketId, CommitStamp};
+use crate::backend::{
+    Backend, BackendConfig, BackendError, BucketId, CommitStamp, CompressionMode,
+};
 
 pub(crate) mod batch;
 pub(crate) mod registry;
@@ -114,6 +116,15 @@ pub(crate) struct Inner {
     /// `Database` handle, so `size_on_disk` has to stat the file we
     /// recorded ourselves.
     db_path: PathBuf,
+    /// Block-level value compression mode (ROADMAP:830). Captured
+    /// from [`BackendConfig::compression`] at open time and
+    /// **never mutated** post-open: a backend's compression mode is
+    /// fixed for the lifetime of the handle. Threaded into
+    /// [`apply_staged`] via [`commit_staged`]. The decoder side
+    /// (in [`snapshot::RedbSnapshot`]) is config-blind — the on-disk
+    /// tag byte alone dispatches decoding — so reopening a database
+    /// under a different mode does not lose data.
+    pub(super) compression: CompressionMode,
 }
 
 impl Inner {
@@ -267,7 +278,19 @@ fn validate_ops(registry: &Registry, ops: &[StagedOp]) -> Result<(), BackendErro
 /// Groups by [`BucketId`] via `BTreeMap` so each redb `Table` is
 /// opened exactly once per commit — see the module doc for why this
 /// is correctness-load-bearing, not just a perf trick.
-fn apply_staged(txn: &::redb::WriteTransaction, ops: Vec<StagedOp>) -> Result<(), BackendError> {
+///
+/// `mode` is the [`CompressionMode`] captured at backend-open time
+/// (see [`Inner::compression`]). Every `Put` value flows through
+/// [`value_compression::encode`] before being handed to redb; the
+/// **registry table** write path (`register_bucket`) is NOT routed
+/// through here and therefore stores `&str → u16` rows verbatim, as
+/// pinned by the `registry_table_wire_format_unchanged` integration
+/// test.
+fn apply_staged(
+    txn: &::redb::WriteTransaction,
+    ops: Vec<StagedOp>,
+    mode: CompressionMode,
+) -> Result<(), BackendError> {
     use std::collections::BTreeMap;
 
     let mut by_bucket: BTreeMap<u16, Vec<StagedOp>> = BTreeMap::new();
@@ -282,8 +305,15 @@ fn apply_staged(txn: &::redb::WriteTransaction, ops: Vec<StagedOp>) -> Result<()
         for op in group {
             match op {
                 StagedOp::Put { key, value, .. } => {
+                    // ROADMAP:830: encode through the value-compression
+                    // codec. The codec always emits a 1-byte tag
+                    // prefix; the decoder side (in
+                    // `RedbSnapshot::get` / `RedbRangeIter::next`)
+                    // dispatches on that tag, so a database written
+                    // under one mode is readable under any other.
+                    let encoded = value_compression::encode(mode, &value)?;
                     table
-                        .insert(key.as_slice(), value.as_slice())
+                        .insert(key.as_slice(), encoded.as_slice())
                         .map_err(map_storage_error)?;
                 }
                 StagedOp::Delete { key, .. } => {
@@ -358,6 +388,7 @@ impl Backend for RedbBackend {
                 closed: AtomicBool::new(false),
                 commit_seq: AtomicU64::new(0),
                 db_path,
+                compression: config.compression,
             }),
         })
     }
@@ -558,6 +589,10 @@ impl RedbBackend {
                 closed: AtomicBool::new(false),
                 commit_seq: AtomicU64::new(0),
                 db_path,
+                // The fault-injection constructor does not take a
+                // `BackendConfig`; tests that exercise the compression
+                // path go through `Backend::open` instead.
+                compression: CompressionMode::None,
             }),
         })
     }
@@ -576,7 +611,7 @@ fn commit_staged(inner: &Inner, staged: Vec<StagedOp>) -> Result<CommitStamp, Ba
     let mut txn = db.begin_write().map_err(map_txn_error)?;
     txn.set_durability(::redb::Durability::Immediate)
         .map_err(|e| BackendError::Other(format!("set_durability: {e}")))?;
-    apply_staged(&txn, staged)?;
+    apply_staged(&txn, staged, inner.compression)?;
     txn.commit().map_err(map_commit_error)?;
     drop(guard);
     // Strictly monotonic. `Release` pairs with callers that observe

--- a/crates/mango-storage/src/redb/mod.rs
+++ b/crates/mango-storage/src/redb/mod.rs
@@ -58,6 +58,7 @@ use crate::backend::{Backend, BackendConfig, BackendError, BucketId, CommitStamp
 pub(crate) mod batch;
 pub(crate) mod registry;
 pub(crate) mod snapshot;
+pub(crate) mod value_compression;
 
 use batch::{RedbBatch, StagedOp};
 use registry::{physical_table_name, RegisterOutcome, Registry, REGISTRY_TABLE_NAME};

--- a/crates/mango-storage/src/redb/snapshot.rs
+++ b/crates/mango-storage/src/redb/snapshot.rs
@@ -22,6 +22,7 @@ use bytes::Bytes;
 
 use crate::backend::{BackendError, BucketId, RangeIter, ReadSnapshot};
 use crate::redb::registry::physical_table_name;
+use crate::redb::value_compression;
 use crate::redb::{map_storage_error, map_table_error, Inner};
 
 /// Point-in-time read snapshot. Produced by
@@ -55,7 +56,11 @@ impl ReadSnapshot for RedbSnapshot {
             Err(e) => return Err(map_table_error(e)),
         };
         match table.get(key).map_err(map_storage_error)? {
-            Some(v) => Ok(Some(Bytes::copy_from_slice(v.value()))),
+            // ROADMAP:830: stored bytes carry a 1-byte compression
+            // tag prefix; decode is config-blind (dispatches on the
+            // tag), so a database written under any mode is readable
+            // here. Errors here surface as `BackendError::Corruption`.
+            Some(v) => Ok(Some(value_compression::decode(v.value())?)),
             None => Ok(None),
         }
     }
@@ -108,7 +113,14 @@ impl Iterator for RedbRangeIter {
         match self.inner.next()? {
             Ok((k, v)) => {
                 let kb = Bytes::copy_from_slice(k.value());
-                let vb = Bytes::copy_from_slice(v.value());
+                // ROADMAP:830: see the matching comment in
+                // `RedbSnapshot::get`. Codec corruption surfaces here
+                // as `BackendError::Corruption` and ends iteration on
+                // the caller side as soon as they handle the `Err`.
+                let vb = match value_compression::decode(v.value()) {
+                    Ok(b) => b,
+                    Err(e) => return Some(Err(e)),
+                };
                 Some(Ok((kb, vb)))
             }
             Err(e) => Some(Err(map_storage_error(e))),

--- a/crates/mango-storage/src/redb/value_compression.rs
+++ b/crates/mango-storage/src/redb/value_compression.rs
@@ -1,0 +1,413 @@
+//! Value-level block compression codec for the redb backend
+//! (ROADMAP:830).
+//!
+//! Every value stored in a user bucket through `apply_staged` is run
+//! through [`encode`] before being handed to redb; every value read
+//! back through `RedbSnapshot::get` / `RedbRangeIter::next` is run
+//! through [`decode`]. The codec is the **single** definition of the
+//! on-disk encoding; no other module hand-rolls the tag-byte layout.
+//!
+//! # Encoding
+//!
+//! ```text
+//! stored_bytes := tag_byte || payload
+//! tag_byte ∈ { 0x00, 0x01 }
+//!   0x00 (Raw):  payload is the original value bytes verbatim. Length
+//!                MUST be ≥ 1 — empty values are rejected at
+//!                `WriteBatch::put` (see `redb::batch::EMPTY_VALUE_ERROR`),
+//!                so a stored payload of `[0x00]` (raw tag with no
+//!                body) signals corruption.
+//!   0x01 (Lz4):  payload = lz4_flex::compress_prepend_size(value)
+//!                (4-byte little-endian original-length prefix +
+//!                LZ4 block). Encoder only emits this tag when (a) the
+//!                value is at least [`COMPRESS_MIN_BYTES`] long AND (b)
+//!                the LZ4-encoded payload is **strictly shorter** than
+//!                the raw value. Otherwise the encoder falls back to
+//!                `RAW || value`.
+//! 0x02..=0xff:   reserved for future codecs (e.g. Zstd takes 0x02).
+//!                Readers return [`BackendError::Corruption`] with
+//!                `"compression: unknown tag …"`.
+//! ```
+//!
+//! # Hard contracts
+//!
+//! - The codec **always** prefixes a tag byte. Encoder output length
+//!   is ≤ `value.len() + 1` for any input. There is no tagless path.
+//! - The decoder is **config-blind**: it dispatches on the tag byte
+//!   alone, so a database written under one [`CompressionMode`] is
+//!   readable under any other.
+//! - Every codec-emitted [`BackendError::Corruption`] message starts
+//!   with the literal prefix `"compression: "`. Operators routing on
+//!   corruption-source can grep this prefix to disambiguate from
+//!   redb-internal corruption (`"redb checksum mismatch"`, etc.).
+//! - Tag values are **stable for the life of the project**. Renumbering
+//!   would break every on-disk database. The header-tag stability
+//!   tests pin this.
+
+use bytes::Bytes;
+
+use crate::backend::{BackendError, CompressionMode};
+
+/// Tag byte values. Stable for the life of the project — see the
+/// "Hard contracts" section in the module doc.
+pub(crate) mod tag {
+    /// Raw payload: byte `0x00`, then the value bytes verbatim.
+    pub(crate) const RAW: u8 = 0x00;
+    /// LZ4-compressed payload: byte `0x01`, then
+    /// `lz4_flex::compress_prepend_size(value)`.
+    pub(crate) const LZ4: u8 = 0x01;
+}
+
+/// Value-length floor below which [`encode`] always emits `RAW`,
+/// regardless of [`CompressionMode`]. LZ4 has per-block overhead;
+/// short values consistently fail the ratio check and the floor
+/// avoids paying for the work.
+///
+/// Single tunable in the codec module — adjust here only.
+pub(crate) const COMPRESS_MIN_BYTES: usize = 64;
+
+/// Defensive upper bound on the value size accepted by [`encode`].
+/// `lz4_flex::compress_prepend_size` writes a 4-byte little-endian
+/// length prefix; inputs whose length does not fit in `u32` would
+/// silently truncate. redb's own value-size limit is well below
+/// `u32::MAX` so this is unreachable in practice — the check is
+/// belt-and-suspenders for forward-compat.
+///
+/// Production value of `u32::MAX as usize`; tests override via
+/// [`encode_with_size_limit`] to exercise the guard branch without
+/// allocating 4 GiB.
+const SIZE_LIMIT: usize = u32::MAX as usize;
+
+/// Encode a value for on-disk storage. See the module doc for the
+/// encoding contract.
+///
+/// # Errors
+///
+/// Returns [`BackendError::Other`] if `value.len()` exceeds the
+/// internal [`SIZE_LIMIT`] (unreachable on real redb traffic; redb's
+/// own value-size limit fires first).
+pub(crate) fn encode(mode: CompressionMode, value: &[u8]) -> Result<Vec<u8>, BackendError> {
+    encode_with_size_limit(mode, value, SIZE_LIMIT)
+}
+
+/// Same as [`encode`] but with a caller-supplied size limit. Test-
+/// only path: production callers go through [`encode`].
+fn encode_with_size_limit(
+    mode: CompressionMode,
+    value: &[u8],
+    size_limit: usize,
+) -> Result<Vec<u8>, BackendError> {
+    if value.len() > size_limit {
+        return Err(BackendError::Other(format!(
+            "compression: value too large ({} bytes; limit {} bytes)",
+            value.len(),
+            size_limit,
+        )));
+    }
+    match mode {
+        CompressionMode::None => Ok(emit_raw(value)),
+        CompressionMode::Lz4 => Ok(encode_lz4_with_fallback(value)),
+    }
+}
+
+/// Build a `RAW || value` payload.
+fn emit_raw(value: &[u8]) -> Vec<u8> {
+    // Capacity is exact; saturating_add guards the workspace
+    // arithmetic-side-effects lint without changing the value
+    // (value.len() ≤ SIZE_LIMIT < usize::MAX in real callers).
+    let mut out = Vec::with_capacity(value.len().saturating_add(1));
+    out.push(tag::RAW);
+    out.extend_from_slice(value);
+    out
+}
+
+/// Try LZ4; fall back to RAW if the result is not strictly shorter
+/// than the raw value, or if `value.len() < COMPRESS_MIN_BYTES`.
+fn encode_lz4_with_fallback(value: &[u8]) -> Vec<u8> {
+    if value.len() < COMPRESS_MIN_BYTES {
+        return emit_raw(value);
+    }
+    let compressed = lz4_flex::compress_prepend_size(value);
+    if compressed.len() < value.len() {
+        let mut out = Vec::with_capacity(compressed.len().saturating_add(1));
+        out.push(tag::LZ4);
+        out.extend_from_slice(&compressed);
+        out
+    } else {
+        emit_raw(value)
+    }
+}
+
+/// Decode an on-disk payload to its original value bytes. Config-
+/// blind: dispatches on the tag byte alone.
+///
+/// # Errors
+///
+/// Returns [`BackendError::Corruption`] with a `"compression: "`-
+/// prefixed message on any of:
+///
+/// - empty stored payload (no tag byte);
+/// - `RAW` tag with no body (would imply an empty value, but empty
+///   values are rejected at `WriteBatch::put` so this is corruption);
+/// - unknown tag byte (`0x02..=0xff`);
+/// - LZ4-tagged payload that fails to decompress (truncated frame,
+///   bad size prefix, decoder bounds-check rejection).
+pub(crate) fn decode(stored: &[u8]) -> Result<Bytes, BackendError> {
+    let (tag_byte, body) = stored
+        .split_first()
+        .ok_or_else(|| BackendError::Corruption("compression: empty stored payload".to_owned()))?;
+    match *tag_byte {
+        tag::RAW => {
+            if body.is_empty() {
+                // Per `redb::batch::EMPTY_VALUE_ERROR`, empty values
+                // are rejected at write time. A `[0x00]`-only stored
+                // payload therefore cannot be a legitimately-written
+                // empty value — it's bit-rot or a pre-tag artifact.
+                // Surface as Corruption so the operator sees the
+                // signal rather than receiving `Ok(Bytes::new())`.
+                Err(BackendError::Corruption(
+                    "compression: empty raw payload".to_owned(),
+                ))
+            } else {
+                Ok(Bytes::copy_from_slice(body))
+            }
+        }
+        tag::LZ4 => match lz4_flex::decompress_size_prepended(body) {
+            Ok(decoded) => Ok(Bytes::from(decoded)),
+            Err(e) => Err(BackendError::Corruption(format!(
+                "compression: lz4 decode failed: {e}"
+            ))),
+        },
+        other => Err(BackendError::Corruption(format!(
+            "compression: unknown tag 0x{other:02x}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects
+    )]
+
+    use super::*;
+
+    // --- Round-trip parity -------------------------------------------
+
+    #[test]
+    fn round_trip_none_short_value() {
+        let v = b"hello".to_vec();
+        let enc = encode(CompressionMode::None, &v).unwrap();
+        assert_eq!(enc[0], tag::RAW);
+        let dec = decode(&enc).unwrap();
+        assert_eq!(dec.as_ref(), v.as_slice());
+    }
+
+    #[test]
+    fn round_trip_lz4_long_compressible_value() {
+        let v = vec![0x41_u8; 1024];
+        let enc = encode(CompressionMode::Lz4, &v).unwrap();
+        assert_eq!(enc[0], tag::LZ4, "long compressible input must use LZ4 tag");
+        // Compression actually shrunk it.
+        assert!(
+            enc.len() < v.len() + 1,
+            "encoded length {} should be smaller than raw length {}",
+            enc.len(),
+            v.len()
+        );
+        let dec = decode(&enc).unwrap();
+        assert_eq!(dec.as_ref(), v.as_slice());
+    }
+
+    // --- Threshold floor ---------------------------------------------
+
+    #[test]
+    fn encode_short_input_below_threshold_uses_raw_tag() {
+        // 30 bytes < COMPRESS_MIN_BYTES; even under Lz4 mode the
+        // encoder must emit RAW.
+        let v = vec![0x41_u8; 30];
+        let enc = encode(CompressionMode::Lz4, &v).unwrap();
+        assert_eq!(enc[0], tag::RAW);
+        assert_eq!(&enc[1..], v.as_slice());
+    }
+
+    #[test]
+    fn encode_long_compressible_input_uses_lz4_tag_with_size_prefix() {
+        // [0x41; 100] — comfortably above COMPRESS_MIN_BYTES and
+        // highly compressible. Tag is LZ4; the next four bytes are
+        // the original size in little-endian (lz4_flex
+        // compress_prepend_size convention) — `100` = `0x64` →
+        // [0x64, 0x00, 0x00, 0x00].
+        let v = vec![0x41_u8; 100];
+        let enc = encode(CompressionMode::Lz4, &v).unwrap();
+        assert_eq!(enc[0], tag::LZ4);
+        assert_eq!(&enc[1..5], &[0x64, 0x00, 0x00, 0x00]);
+        let dec = decode(&enc).unwrap();
+        assert_eq!(dec.as_ref(), v.as_slice());
+    }
+
+    #[test]
+    fn encode_incompressible_input_above_threshold_uses_raw_tag() {
+        // 200 effectively-random bytes (xorshift seeded for
+        // determinism). LZ4 can't shrink random data; the encoder
+        // must fall back to RAW so stored payload length is
+        // value.len() + 1 (Hard contract #3).
+        let v: Vec<u8> = {
+            let mut state: u64 = 0xDEAD_BEEF_CAFE_F00D;
+            (0..200_u32)
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+                    (state & 0xFF) as u8
+                })
+                .collect()
+        };
+        let enc = encode(CompressionMode::Lz4, &v).unwrap();
+        assert_eq!(
+            enc[0],
+            tag::RAW,
+            "incompressible input must fall back to RAW tag",
+        );
+        assert_eq!(enc.len(), v.len() + 1);
+        let dec = decode(&enc).unwrap();
+        assert_eq!(dec.as_ref(), v.as_slice());
+    }
+
+    // --- Decoder corruption signalling -------------------------------
+
+    #[test]
+    fn decode_unknown_tag_is_corruption() {
+        let bad = [0xFF, 1, 2, 3];
+        let err = decode(&bad).unwrap_err();
+        match err {
+            BackendError::Corruption(msg) => {
+                assert!(msg.starts_with("compression: "));
+                assert!(msg.contains("unknown tag"));
+                assert!(msg.contains("0xff"));
+            }
+            other => panic!("expected Corruption, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_empty_stored_payload_is_corruption() {
+        let err = decode(&[]).unwrap_err();
+        match err {
+            BackendError::Corruption(msg) => {
+                assert!(msg.starts_with("compression: "));
+                assert!(msg.contains("empty stored payload"));
+            }
+            other => panic!("expected Corruption, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_raw_tag_with_empty_body_is_corruption() {
+        let err = decode(&[tag::RAW]).unwrap_err();
+        match err {
+            BackendError::Corruption(msg) => {
+                assert!(msg.starts_with("compression: "));
+                assert!(msg.contains("empty raw payload"));
+            }
+            other => panic!("expected Corruption, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_truncated_lz4_is_corruption() {
+        // LZ4 tag, valid-looking 4-byte size prefix (says 100), but
+        // no compressed bytes follow. Decoder must return Corruption.
+        let bad = [tag::LZ4, 0x64, 0x00, 0x00, 0x00];
+        let err = decode(&bad).unwrap_err();
+        match err {
+            BackendError::Corruption(msg) => {
+                assert!(msg.starts_with("compression: "));
+                assert!(msg.contains("lz4 decode failed"));
+            }
+            other => panic!("expected Corruption, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_corruption_messages_share_prefix() {
+        // Single test that walks every corruption branch and checks
+        // the shared prefix. Pins Hard contract #6 against future
+        // refactors that add a new corruption arm without the prefix.
+        let cases: Vec<&[u8]> = vec![
+            &[],           // empty payload
+            &[tag::RAW],   // raw tag, no body
+            &[0xFF, 1, 2], // unknown tag
+            // truncated lz4 (size prefix says 100, no body)
+            &[tag::LZ4, 0x64, 0x00, 0x00, 0x00],
+        ];
+        for stored in cases {
+            let err = decode(stored).expect_err("must be Corruption");
+            match err {
+                BackendError::Corruption(msg) => {
+                    assert!(
+                        msg.starts_with("compression: "),
+                        "Corruption message {msg:?} missing 'compression: ' prefix",
+                    );
+                }
+                other => panic!("expected Corruption from {stored:?}, got {other:?}"),
+            }
+        }
+    }
+
+    // --- Defensive size guard ----------------------------------------
+
+    #[test]
+    fn encode_rejects_oversize_value_via_size_limit() {
+        // SIZE_LIMIT in production is u32::MAX; testing that
+        // literally would require allocating 4 GiB. Inject a small
+        // limit via the test-only entry point and verify the guard
+        // branch fires with a "compression: " prefix.
+        let v = vec![0x41_u8; 100];
+        let err = encode_with_size_limit(CompressionMode::Lz4, &v, 50).unwrap_err();
+        match err {
+            BackendError::Other(msg) => {
+                assert!(msg.starts_with("compression: "));
+                assert!(msg.contains("too large"));
+            }
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encode_at_exact_size_limit_succeeds() {
+        // Boundary: value.len() == size_limit is allowed (`>`, not
+        // `>=`, on the guard).
+        let v = vec![0x41_u8; 50];
+        encode_with_size_limit(CompressionMode::None, &v, 50).unwrap();
+    }
+
+    // --- Miri smoke ---------------------------------------------------
+
+    /// Tight encode/decode loop under Miri. Deliberately small (Miri
+    /// is slow); the goal is to drive memory-safety assertions on the
+    /// `lz4_flex` decode path with all codec modes and threshold
+    /// boundaries exercised. Gated `#[cfg(miri)]` so the broader
+    /// release/test runs do not pay for it.
+    #[cfg(miri)]
+    #[test]
+    fn miri_smoke() {
+        let inputs: Vec<Vec<u8>> = vec![
+            vec![0x41; 30],  // below threshold ⇒ RAW
+            vec![0x41; 100], // above threshold, compressible ⇒ LZ4
+            b"hello world".to_vec(),
+            (0..32_u8).collect(),
+        ];
+        for v in inputs {
+            for mode in [CompressionMode::None, CompressionMode::Lz4] {
+                let enc = encode(mode, &v).unwrap();
+                let dec = decode(&enc).unwrap();
+                assert_eq!(dec.as_ref(), v.as_slice());
+            }
+        }
+    }
+}

--- a/crates/mango-storage/tests/differential_vs_bbolt.rs
+++ b/crates/mango-storage/tests/differential_vs_bbolt.rs
@@ -654,8 +654,16 @@ impl Case {
 
         let mut oracle =
             GoOracle::spawn(binary, &db_path, fsync).map_err(|e| format!("oracle spawn: {e}"))?;
-        let redb = RedbBackend::open(BackendConfig::new(redb_dir.path().to_path_buf(), false))
-            .map_err(|e| format!("redb open: {e}"))?;
+        // ROADMAP:830: pin compression OFF for cross-engine parity.
+        // The differential oracle compares raw bytes through bbolt
+        // (which has no value-compression layer). Flipping the
+        // constructor default would silently break this test, so the
+        // bind is explicit.
+        let redb = RedbBackend::open(
+            BackendConfig::new(redb_dir.path().to_path_buf(), false)
+                .with_compression(mango_storage::CompressionMode::None),
+        )
+        .map_err(|e| format!("redb open: {e}"))?;
 
         for (idx, name) in BUCKET_NAMES.iter().enumerate() {
             let id = BucketId::new((idx + 1) as u16);

--- a/crates/mango-storage/tests/redb_compression.rs
+++ b/crates/mango-storage/tests/redb_compression.rs
@@ -229,14 +229,15 @@ async fn lz4_shrinks_size_on_disk_for_compressible_payload() {
 
 #[test]
 fn registry_table_wire_format_unchanged_under_lz4_mode() {
-    let tmp = TempDir::new().unwrap();
+    use ::redb::ReadableDatabase as _;
 
-    // Use a non-trivial id so a tag byte (0x00 / 0x01) added in front
+    // Use non-trivial ids so a tag byte (0x00 / 0x01) added in front
     // would corrupt the value into a different u16 — making the
     // test sensitive to silent re-routing of the registry path.
     const ID_A: BucketId = BucketId::new(0x1234);
     const ID_B: BucketId = BucketId::new(0x5678);
 
+    let tmp = TempDir::new().unwrap();
     {
         let b = open_with(&tmp, CompressionMode::Lz4);
         b.register_bucket("kv", ID_A).unwrap();
@@ -246,7 +247,6 @@ fn registry_table_wire_format_unchanged_under_lz4_mode() {
 
     // Open the file directly via the `redb` crate.
     let db_path = tmp.path().join("mango.redb");
-    use ::redb::ReadableDatabase as _;
     let db = ::redb::Database::open(&db_path).expect("redb open");
     let txn = db.begin_read().expect("begin_read");
     // Same TableDefinition the production code uses; if the registry

--- a/crates/mango-storage/tests/redb_compression.rs
+++ b/crates/mango-storage/tests/redb_compression.rs
@@ -1,0 +1,332 @@
+//! Integration tests for ROADMAP:830 block-level compression.
+//!
+//! Exercises the production `RedbBackend` write+read path under both
+//! [`CompressionMode::None`] and [`CompressionMode::Lz4`]; pins the
+//! cross-mode read contract (a database written under one mode is
+//! readable under the other, in either direction) so the codec stays
+//! config-blind for the life of the project.
+//!
+//! Under `--cfg madsim` this file is excluded — same reasoning as
+//! `redb_backend.rs` (madsim-tokio does not expose the multi-thread
+//! runtime; redb's real mmap+fsync is incompatible with virtual time).
+
+#![cfg(not(madsim))]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_truncation
+)]
+
+use mango_storage::{
+    Backend, BackendConfig, BucketId, CompressionMode, ReadSnapshot, RedbBackend, WriteBatch,
+};
+use tempfile::TempDir;
+
+const KV: BucketId = BucketId::new(1);
+
+fn open_with(dir: &TempDir, mode: CompressionMode) -> RedbBackend {
+    RedbBackend::open(BackendConfig::new(dir.path().to_path_buf(), false).with_compression(mode))
+        .expect("open")
+}
+
+async fn put(b: &RedbBackend, k: &[u8], v: &[u8]) {
+    let mut batch = b.begin_batch().expect("begin_batch");
+    batch.put(KV, k, v).expect("put");
+    let _ = b.commit_batch(batch, true).await.expect("commit");
+}
+
+fn get(b: &RedbBackend, k: &[u8]) -> Option<Vec<u8>> {
+    let snap = b.snapshot().expect("snapshot");
+    snap.get(KV, k).expect("get").map(|bytes| bytes.to_vec())
+}
+
+/// A 256-byte highly compressible payload: one byte repeated. Long
+/// enough to clear the `COMPRESS_MIN_BYTES` floor and to give LZ4 a
+/// shot at meaningful shrinkage.
+fn compressible(seed: u8, len: usize) -> Vec<u8> {
+    vec![seed; len]
+}
+
+// ---------- round-trip both modes ------------------------------------
+
+#[tokio::test]
+async fn roundtrip_compression_none() {
+    let tmp = TempDir::new().unwrap();
+    let b = open_with(&tmp, CompressionMode::None);
+    b.register_bucket("kv", KV).unwrap();
+    put(&b, b"k", b"v").await;
+    assert_eq!(get(&b, b"k").as_deref(), Some(&b"v"[..]));
+}
+
+#[tokio::test]
+async fn roundtrip_compression_lz4() {
+    let tmp = TempDir::new().unwrap();
+    let b = open_with(&tmp, CompressionMode::Lz4);
+    b.register_bucket("kv", KV).unwrap();
+    let payload = compressible(0xAA, 1024);
+    put(&b, b"k", &payload).await;
+    assert_eq!(get(&b, b"k").as_deref(), Some(payload.as_slice()));
+}
+
+// ---------- cross-mode reads -----------------------------------------
+//
+// The decoder is config-blind (dispatches on the on-disk tag byte
+// alone), so a database opened under any `CompressionMode` must be
+// able to read every value previously stored under any other mode.
+// Both directions are pinned here — and we round-trip THROUGH a
+// close so the read backend is genuinely the second open of the
+// same on-disk file, not an Arc-shared in-process state.
+
+#[tokio::test]
+async fn cross_mode_lz4_written_none_read() {
+    let tmp = TempDir::new().unwrap();
+    let payload = compressible(0x11, 2048);
+    {
+        let b = open_with(&tmp, CompressionMode::Lz4);
+        b.register_bucket("kv", KV).unwrap();
+        put(&b, b"k", &payload).await;
+        b.close().unwrap();
+    }
+    let b2 = open_with(&tmp, CompressionMode::None);
+    assert_eq!(get(&b2, b"k").as_deref(), Some(payload.as_slice()));
+}
+
+#[tokio::test]
+async fn cross_mode_none_written_lz4_read() {
+    let tmp = TempDir::new().unwrap();
+    let payload = compressible(0x22, 2048);
+    {
+        let b = open_with(&tmp, CompressionMode::None);
+        b.register_bucket("kv", KV).unwrap();
+        put(&b, b"k", &payload).await;
+        b.close().unwrap();
+    }
+    let b2 = open_with(&tmp, CompressionMode::Lz4);
+    assert_eq!(get(&b2, b"k").as_deref(), Some(payload.as_slice()));
+}
+
+// ---------- mixed-tag range scan -------------------------------------
+//
+// Writes some rows under `None`, then reopens under `Lz4` and writes
+// more rows. A range scan on a single backend (the second one) must
+// return both the RAW-tagged and LZ4-tagged values intermixed and
+// fully decoded. Pins the iterator's per-row decode dispatch.
+
+#[tokio::test]
+async fn range_scan_mixed_tags_decodes_each_row() {
+    let tmp = TempDir::new().unwrap();
+    // First open: write rows whose stored bytes will be RAW-tagged.
+    {
+        let b = open_with(&tmp, CompressionMode::None);
+        b.register_bucket("kv", KV).unwrap();
+        put(&b, b"a", b"alpha").await;
+        put(&b, b"c", b"charlie").await;
+        b.close().unwrap();
+    }
+    // Second open under Lz4: writes will be LZ4-tagged. The same
+    // table now contains both tag flavors. Use a payload long enough
+    // to clear COMPRESS_MIN_BYTES so the encoder actually picks LZ4.
+    let b = open_with(&tmp, CompressionMode::Lz4);
+    let big_b = compressible(0xBB, 1024);
+    let big_d = compressible(0xDD, 1024);
+    put(&b, b"b", &big_b).await;
+    put(&b, b"d", &big_d).await;
+
+    // Existing redb_backend tests use a high-byte sentinel for
+    // "everything"; matching that convention so the read covers all
+    // four rows.
+    let snap = b.snapshot().expect("snapshot");
+    let iter = snap
+        .range(KV, b"", b"\xff\xff\xff\xff\xff\xff\xff\xff")
+        .expect("range");
+    let collected: Vec<(Vec<u8>, Vec<u8>)> = iter
+        .map(|r| {
+            let (k, v) = r.expect("row");
+            (k.to_vec(), v.to_vec())
+        })
+        .collect();
+
+    assert_eq!(collected.len(), 4, "saw rows: {collected:?}");
+    assert_eq!(collected[0].0, b"a");
+    assert_eq!(collected[0].1, b"alpha");
+    assert_eq!(collected[1].0, b"b");
+    assert_eq!(collected[1].1, big_b);
+    assert_eq!(collected[2].0, b"c");
+    assert_eq!(collected[2].1, b"charlie");
+    assert_eq!(collected[3].0, b"d");
+    assert_eq!(collected[3].1, big_d);
+}
+
+// ---------- on-disk size shrinkage -----------------------------------
+//
+// Pins ROADMAP:830's "size-comparison number" intent: with
+// compression on, a highly compressible payload occupies strictly
+// fewer bytes on disk than the same payload stored raw. This is the
+// existence proof that the codec is actually engaged in the write
+// path; it is NOT a benchmark and does not assert a specific ratio.
+//
+// We compact both files before measuring — redb's append-mostly
+// layout means an uncompacted file can easily be larger than its
+// payload, regardless of compression. After `defragment`, the file
+// is dense.
+
+#[tokio::test]
+async fn lz4_shrinks_size_on_disk_for_compressible_payload() {
+    // 64 KiB of a single byte: compresses to a few hundred bytes.
+    let payload = compressible(0x55, 64 * 1024);
+
+    let none_size = {
+        let tmp = TempDir::new().unwrap();
+        let b = open_with(&tmp, CompressionMode::None);
+        b.register_bucket("kv", KV).unwrap();
+        for i in 0u16..16 {
+            let key = i.to_be_bytes();
+            put(&b, &key, &payload).await;
+        }
+        b.defragment().await.expect("defragment");
+        let s = b.size_on_disk().expect("size_on_disk");
+        b.close().unwrap();
+        s
+    };
+
+    let lz4_size = {
+        let tmp = TempDir::new().unwrap();
+        let b = open_with(&tmp, CompressionMode::Lz4);
+        b.register_bucket("kv", KV).unwrap();
+        for i in 0u16..16 {
+            let key = i.to_be_bytes();
+            put(&b, &key, &payload).await;
+        }
+        b.defragment().await.expect("defragment");
+        let s = b.size_on_disk().expect("size_on_disk");
+        b.close().unwrap();
+        s
+    };
+
+    assert!(
+        lz4_size < none_size,
+        "expected LZ4 file < None file; got lz4={lz4_size} none={none_size}"
+    );
+}
+
+// ---------- registry table wire format unchanged ---------------------
+//
+// The bucket-name registry on disk is `&str → u16`. It is persisted
+// by `register_bucket` through a dedicated code path that does NOT
+// flow through `apply_staged` — and therefore is NOT routed through
+// the value-compression codec. If a future refactor were to
+// accidentally re-route registry writes through the user-data write
+// path, the stored u16 would be tag-prefixed and this test would
+// fail (because the redb-side `&str → u16` decoder expects exactly
+// 2 bytes for the value).
+//
+// We pin this by opening the redb file directly (bypassing
+// `RedbBackend`) and reading the registry table via the same
+// `TableDefinition` the production code uses.
+
+#[test]
+fn registry_table_wire_format_unchanged_under_lz4_mode() {
+    let tmp = TempDir::new().unwrap();
+
+    // Use a non-trivial id so a tag byte (0x00 / 0x01) added in front
+    // would corrupt the value into a different u16 — making the
+    // test sensitive to silent re-routing of the registry path.
+    const ID_A: BucketId = BucketId::new(0x1234);
+    const ID_B: BucketId = BucketId::new(0x5678);
+
+    {
+        let b = open_with(&tmp, CompressionMode::Lz4);
+        b.register_bucket("kv", ID_A).unwrap();
+        b.register_bucket("meta", ID_B).unwrap();
+        b.close().unwrap();
+    }
+
+    // Open the file directly via the `redb` crate.
+    let db_path = tmp.path().join("mango.redb");
+    use ::redb::ReadableDatabase as _;
+    let db = ::redb::Database::open(&db_path).expect("redb open");
+    let txn = db.begin_read().expect("begin_read");
+    // Same TableDefinition the production code uses; if the registry
+    // path were ever wrapped in the compression codec, the value
+    // bytes would no longer fit a `u16` decoding and this open or
+    // get would error.
+    let table_def: ::redb::TableDefinition<&str, u16> =
+        ::redb::TableDefinition::new("__mango_bucket_registry");
+    let table = txn.open_table(table_def).expect("open registry table");
+
+    let kv_id = table
+        .get("kv")
+        .expect("registry get kv")
+        .expect("kv present")
+        .value();
+    let meta_id = table
+        .get("meta")
+        .expect("registry get meta")
+        .expect("meta present")
+        .value();
+
+    assert_eq!(kv_id, ID_A.raw, "kv id corrupted: 0x{kv_id:04x}");
+    assert_eq!(meta_id, ID_B.raw, "meta id corrupted: 0x{meta_id:04x}");
+}
+
+// ---------- proptest round-trip --------------------------------------
+//
+// Random bytes through the production write+read path under Lz4.
+// Covers inputs below the threshold floor (RAW tag) and above it
+// (RAW or LZ4 tag depending on compressibility). The cap on size and
+// case count keeps the test fast in default mode; bumping
+// `MANGO_COMPRESSION_THOROUGH=1` raises the cap.
+
+// Plain `#[test]` (NOT `#[tokio::test]`): proptest's runner is
+// synchronous, and nesting `block_on` inside a tokio test runtime
+// panics with "Cannot start a runtime from within a runtime". Owning
+// the runtime here side-steps that.
+#[test]
+fn proptest_random_bytes_roundtrip_under_lz4() {
+    use proptest::prelude::*;
+
+    let cases = if std::env::var("MANGO_COMPRESSION_THOROUGH").is_ok() {
+        2_000
+    } else {
+        128
+    };
+
+    let mut runner = proptest::test_runner::TestRunner::new(proptest::test_runner::Config {
+        cases,
+        ..proptest::test_runner::Config::default()
+    });
+
+    let strat = (
+        proptest::collection::vec(any::<u8>(), 0..1024),
+        proptest::collection::vec(any::<u8>(), 0..1024),
+    );
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let tmp = TempDir::new().unwrap();
+    let b = open_with(&tmp, CompressionMode::Lz4);
+    b.register_bucket("kv", KV).unwrap();
+
+    runner
+        .run(&strat, |(key, value)| {
+            // Drop empty keys: redb rejects them under our
+            // TableDefinition. The codec itself is tested for empty
+            // values in unit tests.
+            if key.is_empty() {
+                return Ok(());
+            }
+            rt.block_on(async {
+                put(&b, &key, &value).await;
+            });
+            let read = get(&b, &key);
+            prop_assert_eq!(read.as_deref(), Some(value.as_slice()));
+            Ok(())
+        })
+        .unwrap();
+}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -335,6 +335,11 @@ version = "0.7.2"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — tokio-rs, exact-pinned for determinism"
 
+[[exemptions.lz4_flex]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-11-03 — pseitz/lz4_flex pure-Rust LZ4 implementation. Direct workspace dep for ROADMAP:830 user-data block compression in mango-storage. ADR 0002 §3 names lz4_flex as the workspace's pure-Rust LZ4 library (vs. lz4-sys C FFI banned by §W5). Consumed with `default-features = false, features = [\"safe-encode\", \"safe-decode\", \"checked-decode\", \"std\"]` — `safe-*` keeps the codec on the unsafe-free path (cargo-geiger ROADMAP:823 baseline ⇒ 0); `checked-decode` is the decoder-side bounds-check layer for adversarial disk bytes; no `frame` feature ⇒ no `twox-hash` transitive. Verify post-add: `cargo tree -e no-dev | grep -E 'lz4|twox-hash'` shows only `lz4_flex 0.13.0`. Exact-version pin (`=0.13.0`) — bump requires this exemption refresh + re-audit; Dependabot does not auto-bump exact pins."
+
 [[exemptions.madsim]]
 version = "0.2.30"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

Implements **ROADMAP:830** — block-level value compression for the redb backend. Disabled by default for cross-engine parity, opt-in via `BackendConfig::with_compression(CompressionMode::Lz4)`.

- New 1-byte tag scheme: `0x00 = RAW`, `0x01 = LZ4`. Decoder is config-blind so a database written under one mode remains readable under any other (in either direction).
- Codec lives in `crates/mango-storage/src/redb/value_compression.rs` with 12 unit tests. Threshold floor (`COMPRESS_MIN_BYTES = 64`) and ratio-aware fallback prevent a worst-case `value.len() + 1` overhead growing further.
- Wires through `apply_staged` (write) and `RedbSnapshot::get` + `RedbRangeIter::next` (read).
- Pure-Rust (`lz4_flex 0.13.0` with `safe-encode` + `safe-decode` + `checked-decode`, no `frame` ⇒ no `twox-hash`); ADR 0002 §W5 ban on `lz4-sys` C FFI honored.
- `differential_vs_bbolt` pinned to `with_compression(None)` so a future default flip cannot silently break the bbolt parity oracle.
- 8 new integration tests in `tests/redb_compression.rs` cover round-trip both modes, cross-mode reads (both directions), mixed-tag range scan, on-disk size shrinkage proof, registry-table wire-format invariant, and a 128-case proptest over random key/value bytes.

## Test plan

- [x] `cargo test -p mango-storage` — 172 passed, 7 ignored (was 164, +8 new compression tests)
- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets` — no issues
- [x] `cargo fmt --check` — clean
- [x] `cargo tree -e no-dev -p mango-storage | grep -iE 'lz4|twox'` — only `lz4_flex v0.13.0` (no twox-hash, no lz4-sys)
- [x] Cross-mode read contract pinned in both directions
- [x] Registry-table wire format pinned via direct redb reopen
- [x] Differential vs bbolt explicitly bound to `CompressionMode::None`

Refs ROADMAP:830, ADR 0002 §3 + §W5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable value-level data compression to the storage backend, supporting both compressed and uncompressed modes for flexible storage optimization.

* **Tests**
  * Added comprehensive integration tests covering compression round-trips, cross-mode compatibility, and on-disk size behavior.

* **Chores**
  * Added compression library dependency and corresponding supply-chain exemption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->