### PR TITLE
refactor(mvcc): ArcSwap<Snapshot> publication primitive (L846)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +793,7 @@ name = "mango-mvcc"
 version = "0.1.0"
 dependencies = [
  "ahash",
+ "arc-swap",
  "bytes",
  "loom",
  "madsim-tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,6 +261,20 @@ lz4_flex = { version = "=0.13.0", default-features = false, features = [
     "std",
 ] }
 
+# Phase 2 lock-free snapshot publication primitive (ROADMAP:846).
+#
+# arc-swap: Atomic swap of `Arc<T>` — the publication primitive
+# named in ROADMAP.md:846 for `MvccStore`'s `(rev, compacted)`
+# snapshot, and the read-side foundation for L854's gRPC server
+# (Concurrency axis #2). `ArcSwap<T>` is `ArcSwapAny<Arc<T>>` — the
+# right spelling is `ArcSwap<Snapshot>` (NOT `ArcSwap<Arc<Snapshot>>`,
+# which would be a double-Arc). Internally uses unsafe; exposes a
+# safe API and is `forbid(unsafe_code)`-friendly from our side.
+# Stable 1.x supports rustc 1.61+, comfortably under our
+# `rust-version.workspace = "1.89"`. cargo-vet exemption recorded
+# in supply-chain/config.toml.
+arc-swap = "1.9"
+
 [workspace.package]
 version = "0.1.0"
 edition = "2021"

--- a/crates/mango-mvcc/Cargo.toml
+++ b/crates/mango-mvcc/Cargo.toml
@@ -35,6 +35,13 @@ parking_lot = { workspace = true }
 # `madsim-tokio`; under default builds this is real tokio's `sync`
 # module. See `.planning/l844-mvcc-kv-api.plan.md` §4.1.
 tokio = { workspace = true, features = ["sync"] }
+# `arc_swap::ArcSwap<Snapshot>` for L846 lock-free snapshot
+# publication. `arc-swap` is `forbid(unsafe_code)`-friendly from
+# our side (it uses unsafe internally but exposes a safe API),
+# loom-aware upstream, and the workspace-blessed primitive named
+# in ROADMAP.md:846. Stable 1.x supports rustc 1.61+, well under
+# our `rust-version.workspace = "1.89"`.
+arc-swap = "1"
 # Optional `proptest::Arbitrary`-style strategies for `Revision` and
 # `KeyKind`. Gated so the dep is invisible in default builds. L851's
 # model proptest will turn this on as a dev-dep feature.

--- a/crates/mango-mvcc/Cargo.toml
+++ b/crates/mango-mvcc/Cargo.toml
@@ -36,12 +36,8 @@ parking_lot = { workspace = true }
 # module. See `.planning/l844-mvcc-kv-api.plan.md` §4.1.
 tokio = { workspace = true, features = ["sync"] }
 # `arc_swap::ArcSwap<Snapshot>` for L846 lock-free snapshot
-# publication. `arc-swap` is `forbid(unsafe_code)`-friendly from
-# our side (it uses unsafe internally but exposes a safe API),
-# loom-aware upstream, and the workspace-blessed primitive named
-# in ROADMAP.md:846. Stable 1.x supports rustc 1.61+, well under
-# our `rust-version.workspace = "1.89"`.
-arc-swap = "1"
+# publication. Workspace-blessed; rationale in workspace Cargo.toml.
+arc-swap = { workspace = true }
 # Optional `proptest::Arbitrary`-style strategies for `Revision` and
 # `KeyKind`. Gated so the dep is invisible in default builds. L851's
 # model proptest will turn this on as a dev-dep feature.

--- a/crates/mango-mvcc/src/lib.rs
+++ b/crates/mango-mvcc/src/lib.rs
@@ -45,5 +45,5 @@ pub use revision::Revision;
 pub use sharded_key_index::{KeyIndexError, ShardedKeyIndex};
 pub use store::{
     Compare, CompareOp, KeyValue, LeaseId, RangeRequest, RangeResult, RequestOp, ResponseOp,
-    TxnRequest, TxnResponse,
+    Snapshot, TxnRequest, TxnResponse,
 };

--- a/crates/mango-mvcc/src/store/mod.rs
+++ b/crates/mango-mvcc/src/store/mod.rs
@@ -20,12 +20,13 @@
 //!   live-key set used by `Range`. **No `.await` is held under
 //!   this lock.** `BTreeMap` (not `BTreeSet`) so a future watch
 //!   cache can extend the value side without re-typing.
-//! - `current_main: AtomicI64` — highest fully-published revision.
-//!   Release-stored at end of every successful commit; Acquire-
-//!   loaded by `Range` and `current_revision`.
-//! - `compacted: AtomicI64` — compacted floor. Release-stored
-//!   after the on-disk delete commit in `Compact`; Acquire-loaded
-//!   by `Range`. Zero = none.
+//! - `snapshot: arc_swap::ArcSwap<Snapshot>` — atomically
+//!   published `(rev, compacted)` pair. Replaces the prior pair
+//!   of independent `AtomicI64`s (L846). Every successful writer
+//!   builds a new `Arc<Snapshot>` and swaps it in under the
+//!   `writer` mutex; readers take one `load_full()` and observe
+//!   a coherent pair. See [`crate::store::snapshot`] for the
+//!   `load_full()` vs `load()` discipline.
 //!
 //! # Lock ordering
 //!
@@ -53,8 +54,9 @@ pub use txn::{Compare, CompareOp, RequestOp, ResponseOp, TxnRequest, TxnResponse
 
 use std::collections::{BTreeMap, HashSet};
 use std::ops::Bound;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use bytes::Bytes;
 use mango_storage::{Backend, ReadSnapshot, WriteBatch};
 
@@ -172,21 +174,23 @@ pub struct MvccStore<B: Backend> {
     /// is held across `commit_batch().await` (`parking_lot` guards
     /// are `!Send`).
     writer: tokio::sync::Mutex<WriterState>,
-    /// Highest fully-published revision. Release-stored at end of
-    /// every successful commit; Acquire-loaded by `Range` /
-    /// [`Self::current_revision`].
-    current_main: AtomicI64,
-    /// Compacted floor. Release-stored after the on-disk delete
-    /// commit in [`Self::compact`]; Acquire-loaded by `Range`.
-    /// `0` = none.
-    compacted: AtomicI64,
+    /// Atomically-published `(rev, compacted)` pair (L846).
+    /// Replaces the prior `current_main` + `compacted` atomic
+    /// fields. Every successful writer (`put`, `delete_range`,
+    /// mutating `txn`, `compact`) builds a new `Arc<Snapshot>`
+    /// and `store`s it into this slot before returning, while
+    /// holding the `writer` mutex — so the
+    /// `load_full -> mutate -> store` pattern is a CAS in spirit
+    /// even though `ArcSwap::store` itself is not.
+    snapshot: ArcSwap<Snapshot>,
 }
 
 impl<B: Backend> std::fmt::Debug for MvccStore<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let snap = self.snapshot.load();
         f.debug_struct("MvccStore")
-            .field("current_main", &self.current_main.load(Ordering::Relaxed))
-            .field("compacted", &self.compacted.load(Ordering::Relaxed))
+            .field("rev", &snap.rev)
+            .field("compacted", &snap.compacted)
             .finish_non_exhaustive()
     }
 }
@@ -237,19 +241,41 @@ impl<B: Backend> MvccStore<B> {
             index: ShardedKeyIndex::new(),
             keys_in_order,
             writer: tokio::sync::Mutex::new(WriterState::new()),
-            current_main: AtomicI64::new(0),
-            compacted: AtomicI64::new(0),
+            snapshot: ArcSwap::from_pointee(Snapshot::empty()),
         })
     }
 
     /// Highest fully-published revision. Returns `0` on a fresh
     /// store.
     ///
-    /// Acquire-loaded; pairs with the writer's Release-store at
-    /// the end of every successful commit.
+    /// Reads through the published [`Snapshot`]; the `Acquire`
+    /// pair is provided by `arc_swap::ArcSwap::load`.
     #[must_use]
     pub fn current_revision(&self) -> i64 {
-        self.current_main.load(Ordering::Acquire)
+        // `load()` returns a Guard; we copy out `rev` (i64) and
+        // drop immediately. Long-lived reader paths use
+        // `current_snapshot()` instead.
+        self.snapshot.load().rev
+    }
+
+    /// Snapshot of the current `(rev, compacted)` pair, as one
+    /// `Arc<Snapshot>`.
+    ///
+    /// Use this when:
+    ///
+    /// - You need to read more than one field from the snapshot
+    ///   (so the pair stays coherent).
+    /// - You're holding the value across a long scan (>1000 keys)
+    ///   or across `.await` points.
+    ///
+    /// Use [`Self::current_revision`] for one-shot revision reads
+    /// — it goes through `ArcSwap::load` (a `Guard`), which
+    /// avoids the refcount-bump but expects a short scope.
+    ///
+    /// See [`crate::store::snapshot`] for the discipline.
+    #[must_use]
+    pub fn current_snapshot(&self) -> Arc<Snapshot> {
+        self.snapshot.load_full()
     }
 
     /// Borrow the underlying backend. Used by writer impls in
@@ -341,9 +367,16 @@ impl<B: Backend> MvccStore<B> {
         })?;
         state.next_main = next;
 
-        // Release-store: pairs with the Acquire-load in
-        // `current_revision` and (later) `Range`.
-        self.current_main.store(rev.main(), Ordering::Release);
+        // Publish the new snapshot under the writer mutex
+        // (L846): atomic `(rev, compacted)` pair, ArcSwap's
+        // `store` is the Release that pairs with readers'
+        // `load`/`load_full` Acquire. `compacted` carries
+        // forward unchanged — Put never advances the floor.
+        let prev = self.snapshot.load_full();
+        self.snapshot.store(Arc::new(Snapshot {
+            rev: rev.main(),
+            compacted: prev.compacted,
+        }));
 
         Ok(rev)
     }
@@ -409,9 +442,13 @@ impl<B: Backend> MvccStore<B> {
             count_only,
         } = req;
 
-        let current = self.current_main.load(Ordering::Acquire);
+        // L846: one snapshot load → coherent (rev, compacted)
+        // pair. Held across the whole Range so the floor check
+        // and the index walk see the same publish point.
+        let snap = self.snapshot.load_full();
+        let current = snap.rev;
         let rev = req_revision.unwrap_or(current);
-        let floor = self.compacted.load(Ordering::Acquire);
+        let floor = snap.compacted;
 
         if rev < floor {
             return Err(MvccError::Compacted {
@@ -557,7 +594,10 @@ impl<B: Backend> MvccStore<B> {
     ///   invariant says it must accept.
     pub async fn delete_range(&self, key: &[u8], end: &[u8]) -> Result<(u64, Revision), MvccError> {
         let mut state = self.writer.lock().await;
-        let current = self.current_main.load(Ordering::Acquire);
+        // L846: take one snapshot for the rev side. The compacted
+        // floor stays unchanged across this op (DeleteRange does
+        // not advance compaction); we re-read it at publish time.
+        let current = self.snapshot.load().rev;
 
         // Step 3: candidate match set under the read lock; drop
         // the guard before any further work.
@@ -648,9 +688,14 @@ impl<B: Backend> MvccStore<B> {
         })?;
         state.next_main = next;
 
-        // Release-store: pairs with the Acquire-load in `Range` /
-        // `current_revision`.
-        self.current_main.store(rev.main(), Ordering::Release);
+        // L846: publish the new snapshot under the writer mutex.
+        // `compacted` carries forward unchanged — DeleteRange
+        // does not advance the floor.
+        let prev = self.snapshot.load_full();
+        self.snapshot.store(Arc::new(Snapshot {
+            rev: rev.main(),
+            compacted: prev.compacted,
+        }));
 
         Ok((deleted, rev))
     }
@@ -719,7 +764,10 @@ impl<B: Backend> MvccStore<B> {
         // different primitive and the cost of the async lock
         // acquisition is dwarfed by the work the txn does.
         let mut state = self.writer.lock().await;
-        let current = self.current_main.load(Ordering::Acquire);
+        // L846: one rev read for the whole txn — compares,
+        // branch evaluation, and any nested Range ops all see
+        // this. Republished at the end if any writes happened.
+        let current = self.snapshot.load().rev;
 
         let outcomes = self.evaluate_compares(&req.compare)?;
         let succeeded = outcomes.iter().all(|&b| b);
@@ -748,10 +796,14 @@ impl<B: Backend> MvccStore<B> {
             context: "next_main overflow",
         })?;
         state.next_main = next;
-        // Release-store: pairs with the Acquire-load in `Range` /
-        // `current_revision`. Range ops below now see the post-
-        // commit state.
-        self.current_main.store(head_rev.main(), Ordering::Release);
+        // L846: publish the new snapshot under the writer mutex.
+        // Range ops queued after this txn see the post-commit
+        // rev. `compacted` carries forward unchanged.
+        let prev = self.snapshot.load_full();
+        self.snapshot.store(Arc::new(Snapshot {
+            rev: head_rev.main(),
+            compacted: prev.compacted,
+        }));
 
         let responses = self.build_txn_responses_mutating(branch, &plan)?;
 
@@ -1026,8 +1078,10 @@ impl<B: Backend> MvccStore<B> {
     ///   fails to decode (indicates backend corruption).
     pub async fn compact(&self, rev: i64) -> Result<(), MvccError> {
         let _state = self.writer.lock().await;
-        let current = self.current_main.load(Ordering::Acquire);
-        let floor = self.compacted.load(Ordering::Acquire);
+        // L846: coherent (rev, compacted) read.
+        let snap = self.snapshot.load_full();
+        let current = snap.rev;
+        let floor = snap.compacted;
 
         if rev <= floor {
             return Ok(());
@@ -1042,11 +1096,18 @@ impl<B: Backend> MvccStore<B> {
         let available = self.compute_available(rev);
         self.commit_compaction_deletes(rev, &available).await?;
 
-        // Step 9: advance the floor. Done BEFORE the in-mem
-        // compaction so a concurrent `Range` reader observing
-        // the new floor will reject `rev < floor` reads — the
-        // on-disk state is already physically advanced to match.
-        self.compacted.store(rev, Ordering::Release);
+        // Step 9: publish the new floor as part of an
+        // atomically-published Snapshot (L846). Done BEFORE the
+        // in-mem compaction so a concurrent `Range` reader
+        // observing the new floor will reject `rev < floor`
+        // reads — the on-disk state is already physically
+        // advanced to match. `rev` (revision head) is unchanged
+        // by compact; `current` was captured under the writer
+        // mutex above.
+        self.snapshot.store(Arc::new(Snapshot {
+            rev: current,
+            compacted: rev,
+        }));
 
         // Step 10: in-mem compaction. `ShardedKeyIndex::compact`
         // drops entries whose history becomes empty. Walk
@@ -1169,9 +1230,12 @@ impl<B: Backend> MvccStore<B> {
     ///   non-`RevisionNotFound` index errors (those two are the
     ///   "absent" path — not errors).
     pub(super) fn evaluate_compares(&self, compares: &[Compare]) -> Result<Vec<bool>, MvccError> {
-        let current = self.current_main.load(Ordering::Acquire);
-        // Snapshot is only needed for `Compare::Value`; skip
-        // snapshot acquisition if no value compares appear.
+        // Caller (`txn`) holds the writer mutex, so the snapshot
+        // value is stable across this call. L846: read rev via
+        // the published Snapshot, not a separate atomic.
+        let current = self.snapshot.load().rev;
+        // Backend snapshot is only needed for `Compare::Value`;
+        // skip snapshot acquisition if no value compares appear.
         let snap = if compares.iter().any(|c| matches!(c, Compare::Value { .. })) {
             Some(self.backend.snapshot()?)
         } else {
@@ -1265,10 +1329,11 @@ mod tests {
         clippy::indexing_slicing
     )]
 
-    use super::MvccStore;
+    use super::{MvccStore, Snapshot};
     use crate::bucket::{KEY_BUCKET_ID, KEY_INDEX_BUCKET_ID};
     use crate::error::OpenError;
     use mango_storage::{Backend, BackendConfig, InMemBackend, ReadSnapshot};
+    use std::sync::Arc;
 
     /// Compile-time check: `MvccStore<InMemBackend>` is
     /// `Send + Sync`. A future change that breaks this (e.g.
@@ -1679,12 +1744,15 @@ mod tests {
             revision: Some(2),
             ..RangeRequest::default()
         };
-        // current_main is still 1 (we tombstoned through the
-        // index only); rev=2 would be FutureRevision. Bump head
-        // via the test hook to avoid the future-rev path.
-        store
-            .current_main
-            .store(2, std::sync::atomic::Ordering::Release);
+        // Snapshot.rev is still 1 (we tombstoned through the
+        // index only); rev=2 would be FutureRevision. Bump the
+        // published snapshot directly to avoid the future-rev
+        // path. L846: writes go through ArcSwap, not an atomic.
+        let prev = store.snapshot.load_full();
+        store.snapshot.store(Arc::new(Snapshot {
+            rev: 2,
+            compacted: prev.compacted,
+        }));
         let r = store.range(req).expect("range");
         assert!(r.kvs.is_empty(), "tombstoned key must not appear");
         assert_eq!(r.count, 0);

--- a/crates/mango-mvcc/src/store/mod.rs
+++ b/crates/mango-mvcc/src/store/mod.rs
@@ -162,8 +162,11 @@ pub struct MvccStore<B: Backend> {
     /// Per-key revision history. Point-lookup; sharded.
     index: ShardedKeyIndex,
     /// Ordered live-key set, used by `Range`. The L846 substrate
-    /// (will be wrapped in `arc_swap::ArcSwap<Arc<...>>` then),
-    /// not a stopgap. Map (not Set) so the watch cache can extend
+    /// (a future commit may wrap the ordered key set in
+    /// `arc_swap::ArcSwap<...>` — note: `ArcSwap<T>` already wraps
+    /// `Arc<T>`, so the spelling is `ArcSwap<...>`, not
+    /// `ArcSwap<Arc<...>>`), not a stopgap. Map (not Set) so the
+    /// watch cache can extend
     /// the value side without a re-typing migration. The
     /// `zero_sized_map_values` clippy lint flags the `()` value
     /// type — silenced here because the type is forward-design
@@ -305,7 +308,9 @@ impl<B: Backend> MvccStore<B> {
     ///    writer-lock invariant; surfaces as
     ///    [`MvccError::Internal`] if violated).
     /// 6. Bump `next_main` (checked).
-    /// 7. Release-store `current_main` so readers see the new head.
+    /// 7. Publish a fresh `Arc<Snapshot>` via
+    ///    [`arc_swap::ArcSwap::store`] so readers observe the new
+    ///    head with the existing compaction floor (L846).
     ///
     /// # Errors
     ///
@@ -330,8 +335,8 @@ impl<B: Backend> MvccStore<B> {
         // No `.await` is held under either of the in-memory locks
         // below. Ordering is **index first, then `keys_in_order`**
         // (rust-expert PR #75 review R1): a concurrent reader
-        // observing the new `current_main` (Release-stored at the
-        // end of this fn) can scan `keys_in_order` and probe the
+        // observing the new `Snapshot` (published via `ArcSwap` at
+        // the end of this fn) can scan `keys_in_order` and probe the
         // index. If we set `keys_in_order` first, there is a
         // sub-microsecond window where a reader sees the new key
         // in the ordered set but `index.get` returns
@@ -419,7 +424,7 @@ impl<B: Backend> MvccStore<B> {
     /// - [`MvccError::Compacted`] if `rev < compacted_floor`
     ///   (strict `<`; the floor itself remains readable per etcd
     ///   parity, plan review item B1).
-    /// - [`MvccError::FutureRevision`] if `rev > current_main`.
+    /// - [`MvccError::FutureRevision`] if `rev > snap.rev`.
     /// - [`MvccError::InvalidRange`] if `req.end` is non-empty
     ///   and `req.end < req.key`. Equal bounds are allowed (yield
     ///   an empty result).
@@ -724,8 +729,8 @@ impl<B: Backend> MvccStore<B> {
     ///
     /// `Range` responses inside a mutating branch see the
     /// **post-commit** state — they are evaluated after the
-    /// batch commits and `current_main` advances (plan §5.5
-    /// step 11).
+    /// batch commits and the snapshot is republished with the
+    /// new `rev` (plan §5.5 step 11).
     ///
     /// # Intra-branch visibility caveat
     ///
@@ -787,7 +792,7 @@ impl<B: Backend> MvccStore<B> {
         }
 
         // Mutating: allocate the single main, commit the batch,
-        // apply in-mem updates, then advance current_main.
+        // apply in-mem updates, then republish the snapshot.
         let head_rev = Revision::new(txn_main, 0);
         self.commit_txn_batch(&plan).await?;
         self.apply_txn_in_mem(&plan)?;
@@ -1071,7 +1076,7 @@ impl<B: Backend> MvccStore<B> {
     ///
     /// # Errors
     ///
-    /// - [`MvccError::FutureRevision`] if `rev > current_main`.
+    /// - [`MvccError::FutureRevision`] if `rev > snap.rev`.
     /// - [`MvccError::Backend`] from snapshot acquisition,
     ///   `begin_batch`, `commit_batch`, or range iteration.
     /// - [`MvccError::KeyDecode`] if an on-disk encoded key

--- a/crates/mango-mvcc/src/store/mod.rs
+++ b/crates/mango-mvcc/src/store/mod.rs
@@ -2562,4 +2562,101 @@ mod tests {
             "fully-tombstoned key must be reaped from keys_in_order"
         );
     }
+
+    // === L846 snapshot publication coherence (plan §"New tokio test") ===
+
+    /// Concurrent writer + readers — every observed snapshot
+    /// satisfies `compacted <= rev`, and both fields are
+    /// monotonically non-decreasing across reader iterations.
+    ///
+    /// Iteration-counted (not wall-clock) so the same work runs
+    /// on slow CI runners and fast laptops; readers run on
+    /// `spawn_blocking` so they sit on dedicated threads instead
+    /// of being multiplexed onto the writer's worker. The
+    /// readers' tight `spin_loop()` loop maximises the chance of
+    /// observing a torn pair if one were possible.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn snapshot_publish_is_coherent_pair() {
+        use std::sync::atomic::{AtomicBool, Ordering as Ord};
+
+        let store = Arc::new(MvccStore::open(fresh_backend()).expect("open"));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        // Writer: 5_000 puts with periodic compact at rev/2.
+        // 5_000 (not 50_000 from the plan draft) keeps the test
+        // under nextest's 60s default and still gives readers
+        // tens of millions of snapshot loads under the
+        // multi-thread runtime.
+        let writer = {
+            let s = Arc::clone(&store);
+            let stop = Arc::clone(&stop);
+            tokio::spawn(async move {
+                for i in 0_i64..5_000 {
+                    let key = format!("k{i}");
+                    s.put(key.as_bytes(), b"v").await.expect("put");
+                    if i % 16 == 15 {
+                        let target = s.current_revision() / 2;
+                        if target > 0 {
+                            s.compact(target).await.expect("compact");
+                        }
+                    }
+                }
+                stop.store(true, Ord::Relaxed);
+            })
+        };
+
+        // Readers: spawn_blocking so they sit on dedicated
+        // threads — under the multi-thread runtime each reader
+        // races the writer concurrently.
+        let mut readers = Vec::new();
+        for _ in 0..3 {
+            let s = Arc::clone(&store);
+            let stop = Arc::clone(&stop);
+            readers.push(tokio::task::spawn_blocking(move || {
+                let mut prev_rev: i64 = 0;
+                let mut prev_compacted: i64 = 0;
+                while !stop.load(Ord::Relaxed) {
+                    let snap = s.current_snapshot();
+                    assert!(
+                        snap.compacted <= snap.rev,
+                        "torn pair: compacted={} > rev={}",
+                        snap.compacted,
+                        snap.rev,
+                    );
+                    assert!(
+                        snap.rev >= prev_rev,
+                        "rev went backwards: {} -> {}",
+                        prev_rev,
+                        snap.rev,
+                    );
+                    assert!(
+                        snap.compacted >= prev_compacted,
+                        "compacted went backwards: {} -> {}",
+                        prev_compacted,
+                        snap.compacted,
+                    );
+                    prev_rev = snap.rev;
+                    prev_compacted = snap.compacted;
+                    std::hint::spin_loop();
+                }
+            }));
+        }
+
+        writer.await.expect("writer task");
+        for r in readers {
+            r.await.expect("reader task");
+        }
+
+        // Sanity: writer ran to completion; final snapshot has
+        // a non-trivial rev and a compacted floor strictly less
+        // than rev (the writer compacted at rev/2 throughout).
+        let final_snap = store.current_snapshot();
+        assert!(final_snap.rev > 0, "writer did at least one put");
+        assert!(
+            final_snap.compacted < final_snap.rev,
+            "compaction floor strictly below head: rev={}, compacted={}",
+            final_snap.rev,
+            final_snap.compacted,
+        );
+    }
 }

--- a/crates/mango-mvcc/src/store/mod.rs
+++ b/crates/mango-mvcc/src/store/mod.rs
@@ -42,11 +42,13 @@
 
 pub mod lease;
 pub mod range;
+pub mod snapshot;
 pub mod txn;
 mod writer;
 
 pub use lease::LeaseId;
 pub use range::{KeyValue, RangeRequest, RangeResult};
+pub use snapshot::Snapshot;
 pub use txn::{Compare, CompareOp, RequestOp, ResponseOp, TxnRequest, TxnResponse};
 
 use std::collections::{BTreeMap, HashSet};

--- a/crates/mango-mvcc/src/store/snapshot.rs
+++ b/crates/mango-mvcc/src/store/snapshot.rs
@@ -91,10 +91,6 @@ impl Snapshot {
     /// snapshots directly — they observe them via
     /// [`crate::MvccStore::current_snapshot`].
     #[must_use]
-    #[allow(
-        dead_code,
-        reason = "wired into MvccStore::open in the next commit; kept here so the type is self-contained"
-    )]
     pub(crate) fn empty() -> Self {
         Self {
             rev: 0,

--- a/crates/mango-mvcc/src/store/snapshot.rs
+++ b/crates/mango-mvcc/src/store/snapshot.rs
@@ -1,4 +1,4 @@
-//! Immutable read-side view of [`crate::MvccStore`] (L846).
+//! Immutable read-side view of [`crate::store::MvccStore`] (L846).
 //!
 //! [`Snapshot`] is the type published via [`arc_swap::ArcSwap`] on
 //! every successful writer commit. Readers acquire the latest
@@ -24,14 +24,13 @@
 //!
 //! - Puts only **add** revisions to a key's history; an older
 //!   `snap.rev` cannot see a put it wasn't published with — the
-//!   per-key version walk in
-//!   [`crate::ShardedKeyIndex::get`]`(k, snap.rev)` filters by
-//!   `version_main <= snap.rev`.
+//!   per-key version walk in [`crate::ShardedKeyIndex::get`]
+//!   filters by `version_main <= snap.rev`.
 //! - Compacts only **drop** revisions `<= floor`; observing the
 //!   older `compacted` floor is conservative — the reader sees
 //!   slightly more history than strictly necessary, which is safe.
 //! - The pair `(rev, compacted)` is published atomically via
-//!   `ArcSwap`, so the [`crate::MvccStore::range`] entry-point
+//!   `ArcSwap`, so the [`crate::store::MvccStore::range`] entry-point
 //!   sees a consistent floor for its rev.
 //!
 //! Subsequent ROADMAP items may add fields (lease epoch, watcher
@@ -61,15 +60,15 @@
 //! - One-shot field reads → `load()` is fine; the `Guard` drops
 //!   immediately.
 
-/// Immutable read-side view of [`crate::MvccStore`].
+/// Immutable read-side view of [`crate::store::MvccStore`].
 ///
 /// See module-level docs for the publication protocol and the
 /// rationale for what is (and isn't) in the snapshot.
 ///
 /// `#[non_exhaustive]` blocks struct-expression init from outside
 /// the crate. To construct one for testing inside the crate, use
-/// [`Snapshot::empty`] or build through the writer paths in
-/// [`crate::MvccStore`].
+/// the crate-private `Snapshot::empty` constructor or build
+/// through the writer paths in [`crate::store::MvccStore`].
 ///
 /// **No `Copy`**: future fields (e.g. `Arc<KeyIndex>`) will be
 /// non-`Copy`; deriving `Copy` today would silently break every
@@ -89,7 +88,7 @@ impl Snapshot {
     /// Construct the initial snapshot for a fresh store: rev = 0,
     /// compacted = 0. `pub(crate)` because user code never builds
     /// snapshots directly — they observe them via
-    /// [`crate::MvccStore::current_snapshot`].
+    /// [`crate::store::MvccStore::current_snapshot`].
     #[must_use]
     pub(crate) fn empty() -> Self {
         Self {
@@ -101,7 +100,12 @@ impl Snapshot {
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing
+    )]
 
     use super::*;
 

--- a/crates/mango-mvcc/src/store/snapshot.rs
+++ b/crates/mango-mvcc/src/store/snapshot.rs
@@ -1,0 +1,128 @@
+//! Immutable read-side view of [`crate::MvccStore`] (L846).
+//!
+//! [`Snapshot`] is the type published via [`arc_swap::ArcSwap`] on
+//! every successful writer commit. Readers acquire the latest
+//! snapshot with one `load_full()` and observe a coherent
+//! `(rev, compacted)` pair — replacing the prior pair of
+//! independent atomics on `MvccStore` (`current_main: AtomicI64`
+//! and `compacted: AtomicI64`).
+//!
+//! # What the snapshot contains
+//!
+//! - [`Snapshot::rev`] — highest fully-published revision.
+//! - [`Snapshot::compacted`] — compaction floor. Reads at
+//!   `revision < compacted` return [`crate::MvccError::Compacted`].
+//!
+//! # What the snapshot does NOT contain
+//!
+//! The key index ([`crate::ShardedKeyIndex`]) and `keys_in_order`
+//! `BTreeMap` are **not** in this snapshot. They are read through
+//! their own concurrency primitives (per-shard `RwLock` and a
+//! single `RwLock<BTreeMap<...>>` respectively).
+//!
+//! This is sound because:
+//!
+//! - Puts only **add** revisions to a key's history; an older
+//!   `snap.rev` cannot see a put it wasn't published with — the
+//!   per-key version walk in
+//!   [`crate::ShardedKeyIndex::get`]`(k, snap.rev)` filters by
+//!   `version_main <= snap.rev`.
+//! - Compacts only **drop** revisions `<= floor`; observing the
+//!   older `compacted` floor is conservative — the reader sees
+//!   slightly more history than strictly necessary, which is safe.
+//! - The pair `(rev, compacted)` is published atomically via
+//!   `ArcSwap`, so the [`crate::MvccStore::range`] entry-point
+//!   sees a consistent floor for its rev.
+//!
+//! Subsequent ROADMAP items may add fields (lease epoch, watcher
+//! cursor, cache generation). [`Snapshot`] carries
+//! `#[non_exhaustive]` so future fields don't break downstream
+//! crates' struct-expression init.
+//!
+//! # `load_full()` vs `load()` discipline
+//!
+//! Per `arc-swap` 1.x:
+//!
+//! - `load()` returns a `Guard<Arc<Snapshot>>`, fast on the hot
+//!   path because no refcount is bumped.
+//! - `load_full()` returns a plain `Arc<Snapshot>`, costing one
+//!   atomic refcount-inc.
+//!
+//! Holding a `Guard` does **not** block writers — the `store()`
+//! path is wait-free regardless. The real cost of holding a
+//! `Guard` across many iterations or `.await` points is
+//! per-thread fast-slot pool exhaustion, falling back to a slower
+//! path (still correct, but loses the hot-path optimization).
+//!
+//! Rule of thumb (matches ROADMAP.md:846):
+//!
+//! - Long scans (>1000 keys) or values held across `.await` →
+//!   `load_full()`.
+//! - One-shot field reads → `load()` is fine; the `Guard` drops
+//!   immediately.
+
+/// Immutable read-side view of [`crate::MvccStore`].
+///
+/// See module-level docs for the publication protocol and the
+/// rationale for what is (and isn't) in the snapshot.
+///
+/// `#[non_exhaustive]` blocks struct-expression init from outside
+/// the crate. To construct one for testing inside the crate, use
+/// [`Snapshot::empty`] or build through the writer paths in
+/// [`crate::MvccStore`].
+///
+/// **No `Copy`**: future fields (e.g. `Arc<KeyIndex>`) will be
+/// non-`Copy`; deriving `Copy` today would silently break every
+/// call-site when those land.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Snapshot {
+    /// Highest fully-published revision. `0` on a fresh store.
+    pub rev: i64,
+    /// Compaction floor. Reads at `revision < compacted` return
+    /// [`crate::MvccError::Compacted`]. `0` = no compaction has
+    /// happened.
+    pub compacted: i64,
+}
+
+impl Snapshot {
+    /// Construct the initial snapshot for a fresh store: rev = 0,
+    /// compacted = 0. `pub(crate)` because user code never builds
+    /// snapshots directly — they observe them via
+    /// [`crate::MvccStore::current_snapshot`].
+    #[must_use]
+    #[allow(
+        dead_code,
+        reason = "wired into MvccStore::open in the next commit; kept here so the type is self-contained"
+    )]
+    pub(crate) fn empty() -> Self {
+        Self {
+            rev: 0,
+            compacted: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+    use super::*;
+
+    #[test]
+    fn empty_is_zero_zero() {
+        let s = Snapshot::empty();
+        assert_eq!(s.rev, 0);
+        assert_eq!(s.compacted, 0);
+    }
+
+    #[test]
+    fn clone_preserves_pair() {
+        let s = Snapshot {
+            rev: 42,
+            compacted: 10,
+        };
+        let c = s.clone();
+        assert_eq!(c, s);
+    }
+}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -80,6 +80,11 @@ version = "1.0.102"
 criteria = "safe-to-deploy"
 notes = "review-by: 2026-10-23 — error-handling, dtolnay, audit pending"
 
+[[exemptions.arc-swap]]
+version = "1.9.1"
+criteria = "safe-to-deploy"
+notes = "review-by: 2026-11-03 — direct workspace dep for L846 snapshot publication primitive (ROADMAP.md:846) on the mango-mvcc read path. vorner/arc-swap is the canonical Rust atomic-Arc-swap library; widely deployed (tikv, sled). Internal unsafe is concentrated in the slot-pool fast-path and audited upstream against loom. cargo-vet exemption pending audit; retire when in-house review completes."
+
 [[exemptions.async-channel]]
 version = "2.5.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

ROADMAP.md:846 — replaces the pair of independent atomics on `MvccStore` (`current_main: AtomicI64` + `compacted: AtomicI64`) with a single `arc_swap::ArcSwap<Snapshot>` slot. Every successful writer (`put`, `delete_range`, mutating `txn`, `compact`) publishes a new `Arc<Snapshot>` under the existing writer mutex. Readers take one `load`/`load_full` and observe a coherent `(rev, compacted)` pair.

This is Phase 2's read-side foundation and L854's forward-shape work — the gRPC server's per-core scaling bar (Concurrency axis #2) names `ArcSwap<Snapshot>` as the publication primitive.

**Why this is a refactor, not a behavior change:** today the pair was always coherent under the `compacted <= current_main` invariant, but the coherence argument required reading the writer's serialization rules. With ArcSwap publication, the invariant is structural — readers get exactly one publish point per call.

## Commits

1. `feat(mvcc): Snapshot type + arc-swap dep` — new `Snapshot { rev, compacted }` type with `#[non_exhaustive]`, no `Copy` derive (forward-shape: future fields like `Arc<KeyIndex>` won't be `Copy`); add `arc-swap = "1"`. No behavior change.
2. `refactor(mvcc): replace current_main/compacted atomics with ArcSwap<Snapshot>` — field swap, four writer publish points, all reader call-sites updated. New `pub fn current_snapshot(&self) -> Arc<Snapshot>` for callers that need both fields or hold the value across long scans / `.await` points. (Method named `current_snapshot` not `snapshot` — collides with `Backend::snapshot()`.)
3. `test(mvcc): coherence of (rev, compacted) under concurrent put+compact` — new tokio test, 5_000 puts + periodic `compact(rev/2)` racing 3 `spawn_blocking` readers spinning with `std::hint::spin_loop()`. Pins: `compacted <= rev`, monotonic `rev`, monotonic `compacted` across reader iterations.

## Plan deviation: loom test deferred

The plan called for a `#[cfg(loom)]` model. After implementation I concluded a loom test here would be **synthetic, not load-bearing**:

- `arc-swap` 1.9.1 exposes no `loom` feature to downstream — its loom-aware atomics are an internal arc-swap concern.
- Modeling the publish/load via `loom::sync::atomic::AtomicI64` (the plan's suggestion) is a different primitive than what we ship; it tests a pattern, not the production code path.
- arc-swap has its own loom suite upstream that pins the primitive's correctness; duplicating that here adds no signal.

The 5_000-iteration concurrent tokio test in commit 3 is the empirical coherence pin (writer + 3 readers, multi-thread runtime, `spawn_blocking` for dedicated reader threads, `spin_loop()` to maximize observation density). Happy to add a `loom::sync::Mutex<Arc<Snapshot>>` model in a follow-up if reviewer disagrees.

## Surface changes

- New field on `MvccStore`: `snapshot: ArcSwap<Snapshot>`
- Removed: `current_main: AtomicI64`, `compacted: AtomicI64`
- New public method: `current_snapshot(&self) -> Arc<Snapshot>`
- `current_revision()` reads through `self.snapshot.load().rev` (signature unchanged)

## Test plan

- [x] `cargo nextest run -p mango-mvcc -p mango-storage` — 353/353 pass (prior 352 + new coherence test)
- [x] `cargo clippy -p mango-mvcc --all-targets -- -D warnings` — clean
- [x] No `unsafe` introduced (workspace `forbid(unsafe_code)`)
- [x] No `unwrap`/`expect`/`panic` in non-test code
- [x] `Snapshot` is `#[non_exhaustive]` — future fields won't break downstream

Refs: ROADMAP.md:846 ; `.planning/l846-arcswap-snapshot.plan.md`

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Snapshot view exposing coherent revision and compaction state
  * Added current_snapshot() for long-lived, atomic snapshot retrieval

* **Bug Fixes / Reliability**
  * Ensures revision and compaction remain consistent and monotonic under concurrent readers/writers, reducing race-related read anomalies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->