### PR TITLE
test(mvcc): pin compaction physical-removal at byte level (L849)

### DIFF
--- a/crates/mango-mvcc/src/store/mod.rs
+++ b/crates/mango-mvcc/src/store/mod.rs
@@ -2568,6 +2568,138 @@ mod tests {
         );
     }
 
+    // === L849 compaction physical-removal byte-level identity ===
+    //
+    // The three tests above verify post-compact reads, but every
+    // assertion goes through the in-memory index. A regression that
+    // removed `commit_compaction_deletes` (`store/mod.rs:1144-1168`)
+    // entirely would still pass them — old on-disk bytes would just
+    // leak silently. The three tests below probe the backend
+    // directly, asserting the exact decoded survivor set: rev, kind,
+    // and value bytes.
+
+    /// Decoded snapshot of every record in `KEY_BUCKET_ID`, in
+    /// backend iteration order (lex over encoded keys).
+    ///
+    /// Returns `(Revision, KeyKind, value bytes)` per record. The
+    /// helper exists for L849 byte-level identity checks; counting
+    /// alone is too weak (a regression that deletes the right rev
+    /// and writes a different one preserves the count).
+    fn key_bucket_survivors<B: Backend>(
+        b: &B,
+    ) -> Result<
+        Vec<(crate::revision::Revision, crate::encoding::KeyKind, Vec<u8>)>,
+        mango_storage::BackendError,
+    > {
+        let snap = b.snapshot()?;
+        let iter = snap.range(KEY_BUCKET_ID, &[], super::NON_EMPTY_PROBE_END)?;
+        let mut out = Vec::new();
+        for item in iter {
+            let (k, v) = item?;
+            let (rev, kind) = crate::encoding::decode_key(&k).expect("on-disk key must decode");
+            out.push((rev, kind, v.to_vec()));
+        }
+        Ok(out)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn compact_physically_removes_old_revs_from_backend() {
+        let store = MvccStore::open(fresh_backend()).expect("open");
+
+        let r1 = store.put(b"k", b"v1").await.expect("put1");
+        let r2 = store.put(b"k", b"v2").await.expect("put2");
+        let r3 = store.put(b"k", b"v3").await.expect("put3");
+        assert_eq!((r1.main(), r2.main(), r3.main()), (1, 2, 3));
+
+        let before = key_bucket_survivors(store.backend()).expect("probe");
+        assert_eq!(before.len(), 3, "3 puts → 3 backend records");
+
+        store.compact(3).await.expect("compact");
+
+        let after = key_bucket_survivors(store.backend()).expect("probe");
+        assert_eq!(
+            after,
+            vec![(
+                crate::revision::Revision::new(3, 0),
+                crate::encoding::KeyKind::Put,
+                b"v3".to_vec(),
+            )],
+            "compact at HEAD must keep exactly the latest Put on-disk, byte-for-byte",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn compact_at_head_keeps_only_latest_per_key() {
+        let store = MvccStore::open(fresh_backend()).expect("open");
+        for round in 0..3 {
+            for k in [b"a".as_slice(), b"b", b"c"] {
+                let _ = store
+                    .put(k, format!("v{round}").as_bytes())
+                    .await
+                    .expect("put");
+            }
+        }
+        let before = key_bucket_survivors(store.backend()).expect("probe");
+        assert_eq!(before.len(), 9, "3 keys × 3 rounds → 9 records");
+
+        let head = store.current_revision();
+        assert_eq!(head, 9);
+        store.compact(head).await.expect("compact");
+
+        // Round 2 wrote v2 to all three keys at revs 7, 8, 9.
+        let after = key_bucket_survivors(store.backend()).expect("probe");
+        assert_eq!(
+            after,
+            vec![
+                (
+                    crate::revision::Revision::new(7, 0),
+                    crate::encoding::KeyKind::Put,
+                    b"v2".to_vec(),
+                ),
+                (
+                    crate::revision::Revision::new(8, 0),
+                    crate::encoding::KeyKind::Put,
+                    b"v2".to_vec(),
+                ),
+                (
+                    crate::revision::Revision::new(9, 0),
+                    crate::encoding::KeyKind::Put,
+                    b"v2".to_vec(),
+                ),
+            ],
+            "compact at HEAD keeps exactly the live KV per key, by rev",
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn compact_removes_tombstone_bytes_when_keep_drops_them() {
+        // The strongest of the three: pins the asymmetry between
+        // `KeyHistory::keep` (drops trailing-tombstone-of-non-final-
+        // generation) and per-key `KeyHistory::compact` (retains
+        // it). `compute_available` uses `keep`, so the on-disk
+        // tombstone IS deleted even though the per-key compact
+        // would have retained it. If `commit_compaction_deletes`
+        // regresses to a no-op this test fails loudest.
+        let store = MvccStore::open(fresh_backend()).expect("open");
+        let _ = store.put(b"k", b"v").await.expect("put");
+        let _ = store.delete_range(b"k", &[]).await.expect("del");
+        let head = store.current_revision();
+        assert_eq!(head, 2);
+
+        let before = key_bucket_survivors(store.backend()).expect("probe");
+        assert_eq!(before.len(), 2, "1 put + 1 tombstone = 2 backend records");
+        assert_eq!(before[0].1, crate::encoding::KeyKind::Put);
+        assert_eq!(before[1].1, crate::encoding::KeyKind::Tombstone);
+
+        store.compact(head).await.expect("compact");
+
+        let after = key_bucket_survivors(store.backend()).expect("probe");
+        assert!(
+            after.is_empty(),
+            "tombstone-only key compacted at head leaves zero bytes (got {after:?})",
+        );
+    }
+
     // === L846 snapshot publication coherence (plan §"New tokio test") ===
 
     /// Concurrent writer + readers — every observed snapshot


### PR DESCRIPTION
## Summary

Closes ROADMAP.md:849 (`Compaction: physically removes old revisions; Range against a compacted revision returns ErrCompacted`).

The ErrCompacted half is already pinned by `compact_then_range_below_floor_returns_compacted_err` (`store/mod.rs:2500-2520`). The "physically removes old revisions" half was **not pinned at the byte level** — every existing assertion goes through the in-memory index. A regression that dropped `commit_compaction_deletes` (`store/mod.rs:1144-1168`) entirely would still pass all 187 tests, because the in-memory index reads latest values fine and the old on-disk bytes would just leak silently.

## What changed

Three new tests in `mod tests`, plus a `key_bucket_survivors` helper that probes the backend directly and returns the **exact decoded survivor set** (`(Revision, KeyKind, value bytes)` per record), not just a count.

- `compact_physically_removes_old_revs_from_backend` — 3 puts on one key; after compact at rev 3, the on-disk store contains exactly `[(rev=3, sub=0, Put, b"v3")]`.
- `compact_at_head_keeps_only_latest_per_key` — 3 keys × 3 rounds; pre-count 9, post-compact survivors are exactly the round-2 rev=7/8/9 records with `b"v2"` payloads. Catches the regression where the byte probe is coincidentally right because there's only one key.
- `compact_removes_tombstone_bytes_when_keep_drops_them` — pins the asymmetry between `KeyHistory::keep` (drops trailing tombstone of non-final generation, used by `compute_available`) and per-key `KeyHistory::compact` (retains it). Put + Delete + compact at the tombstone rev → both records physically deleted. The strongest of the three — if `commit_compaction_deletes` regresses to a no-op, this fails loudest.

## Why identity, not count

rust-expert REVISE B1: a regression that deletes the correct rev and writes a different one preserves the count but corrupts identity. The helper returns `Vec<(Revision, KeyKind, Vec<u8>)>` so each test asserts the exact survivor set.

## Why reuse the existing sentinel

rust-expert REVISE B2: existing `NON_EMPTY_PROBE_END = &[0xFF; 32]` at `store/mod.rs:86` already covers all 17/18-byte encoded keys. No new constant.

## What's NOT in this PR

- No production source change — `commit_compaction_deletes` is already correct.
- No bench (L850 / L854).
- No fuzz target (L853).

## Test plan

- [x] `cargo nextest run -p mango-mvcc` — 190 tests, 0 skipped, 0 failed.
- [x] All three new tests pass on first run.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] `RUSTDOCFLAGS=-D warnings cargo doc -p mango-mvcc --no-deps` clean.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced compaction validation with new test coverage verifying physical on-disk storage outcomes, including proper handling of key cleanup and tombstone removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->