### PR TITLE
feat(mvcc): unsynced-watcher catch-up path (ROADMAP.md:863)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable, user-visible changes land here. The repo is pre-1.0 — no
+SemVer guarantees yet, but breaking changes are called out so the
+ROADMAP.md item that drove the change is traceable.
+
+## Unreleased
+
+### Changed
+
+- **`mango-mvcc`**: `WatchableStore::watch(range, start_rev)` now
+  accepts `start_rev <= current_revision()` and registers the watcher
+  into a new **unsynced** group. A per-watcher catch-up driver scans
+  history from `start_rev` forward and promotes the watcher to the
+  synced group once it reaches the published revision. Reads at a
+  revision strictly below the compacted floor still return
+  `MvccError::Compacted` (etcd parity). (ROADMAP.md:863)
+
+### Removed
+
+- **`mango-mvcc`**: `MvccError::Unsupported` and the
+  `UnsupportedFeature` enum (incl. `UnsupportedFeature::UnsyncedWatcher`)
+  are removed from the public API. The variant only existed to reject
+  catch-up watch requests; with the path now implemented, the variant
+  has no remaining surface. The `MvccError` enum is `#[non_exhaustive]`
+  so external `_` match arms continue to compile. (ROADMAP.md:863)

--- a/crates/mango-mvcc/src/error.rs
+++ b/crates/mango-mvcc/src/error.rs
@@ -106,34 +106,6 @@ pub enum MvccError {
     /// `key` bucket).
     #[error(transparent)]
     KeyDecode(#[from] KeyDecodeError),
-    /// A feature the caller invoked is not yet wired in this
-    /// ROADMAP phase. Carries an [`UnsupportedFeature`] tag so
-    /// callers can branch on the specific gap rather than parsing
-    /// a string. Phase 3 plan §3 (ROADMAP.md:862).
-    ///
-    /// **Stability.** Adding a variant to [`UnsupportedFeature`]
-    /// is non-breaking (`#[non_exhaustive]`); removing one is the
-    /// desired compile-time signal that the feature has shipped.
-    #[error("unsupported feature: {0:?}")]
-    Unsupported(UnsupportedFeature),
-}
-
-/// Tag for a feature gated off at the current ROADMAP phase.
-/// Pairs with [`MvccError::Unsupported`].
-///
-/// **Intent.** Adding a variant is non-breaking; removing one is
-/// load-bearing — when the gap closes (e.g. ROADMAP.md:863 wires
-/// the unsynced/catch-up watcher path), deleting the variant
-/// makes every matchsite that handles it fail compilation, which
-/// is exactly the signal we want.
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
-#[non_exhaustive]
-pub enum UnsupportedFeature {
-    /// A `watch(start_rev)` with `start_rev <= current_revision()`
-    /// requires the unsynced/catch-up dispatch path. Phase 3 ships
-    /// only the synced (current-rev forward) path; the unsynced
-    /// path lands in ROADMAP.md:863.
-    UnsyncedWatcher,
 }
 
 #[cfg(test)]
@@ -145,7 +117,7 @@ mod tests {
         clippy::indexing_slicing
     )]
 
-    use super::{MvccError, OpenError, UnsupportedFeature};
+    use super::{MvccError, OpenError};
 
     #[test]
     fn open_error_non_empty_backend_message_includes_count() {
@@ -190,28 +162,5 @@ mod tests {
         };
         let msg = format!("{e}");
         assert!(msg.contains("next_main overflow"), "message: {msg}");
-    }
-
-    #[test]
-    fn mvcc_error_unsupported_message_includes_variant_name() {
-        let e = MvccError::Unsupported(UnsupportedFeature::UnsyncedWatcher);
-        let msg = format!("{e}");
-        assert!(
-            msg.contains("UnsyncedWatcher"),
-            "Display passes through the inner Debug-formatted variant: {msg}"
-        );
-        assert!(
-            msg.contains("unsupported feature"),
-            "Display includes the umbrella label: {msg}"
-        );
-    }
-
-    #[test]
-    fn unsupported_feature_is_copy_eq_debug() {
-        let a = UnsupportedFeature::UnsyncedWatcher;
-        let b = a;
-        assert_eq!(a, b);
-        let dbg = format!("{a:?}");
-        assert!(dbg.contains("UnsyncedWatcher"), "Debug: {dbg}");
     }
 }

--- a/crates/mango-mvcc/src/key_history.rs
+++ b/crates/mango-mvcc/src/key_history.rs
@@ -53,6 +53,7 @@ use core::fmt;
 use std::collections::HashSet;
 use std::hash::BuildHasher;
 
+use crate::encoding::KeyKind;
 use crate::Revision;
 
 /// One generation: a contiguous run of revisions for a single key,
@@ -531,6 +532,130 @@ impl KeyHistory {
         (gen_idx, rev_index)
     }
 
+    /// All `(rev, kind)` pairs in this `KeyHistory` whose `main`
+    /// component lies in the inclusive range `[lo, hi]`, yielded in
+    /// ascending order by stored `Revision`.
+    ///
+    /// The last revision of any non-trailing generation is a
+    /// `Tombstone`; every other stored revision is a `Put`. The
+    /// trailing empty generation contributes nothing. The walk is
+    /// bounded by per-key history depth (typically `< 100` under
+    /// realistic workloads), and the caller holds the per-shard
+    /// read-lock for the duration of the walk — so per-key history
+    /// depth bounds the lock-hold time.
+    ///
+    /// The L863 catch-up scan is the sole intended caller; the
+    /// per-key history walk feeds `WatchEvent` synthesis.
+    pub fn events_in_range(
+        &self,
+        lo: i64,
+        hi: i64,
+    ) -> impl Iterator<Item = (Revision, KeyEventKind)> + '_ {
+        let last_gen_idx = self.generations.len().saturating_sub(1);
+        self.generations
+            .iter()
+            .enumerate()
+            .flat_map(move |(gi, g)| {
+                let is_final = gi == last_gen_idx;
+                let revs_len = g.revs.len();
+                g.revs.iter().copied().enumerate().map(move |(ri, r)| {
+                    // The last rev of a non-final gen is the
+                    // tombstone that closed it; every other rev
+                    // (including the only rev of the final gen) is
+                    // a Put. `revs_len.checked_sub(1)` is `None`
+                    // only on an empty gen, which the outer iter
+                    // skips structurally (no revs to walk).
+                    let is_last_in_gen = revs_len.checked_sub(1).is_some_and(|last| ri == last);
+                    let kind = if !is_final && is_last_in_gen {
+                        KeyEventKind::Tombstone
+                    } else {
+                        KeyEventKind::Put
+                    };
+                    (r, kind)
+                })
+            })
+            .filter(move |(r, _)| r.main() >= lo && r.main() <= hi)
+    }
+
+    /// The highest stored `KeyAtRev` whose stored revision is
+    /// **strictly less than** `rev` (lex order on `(main, sub)`).
+    ///
+    /// Cross-generation semantics:
+    ///
+    /// - If the strict predecessor is in the same generation as the
+    ///   anchor for `rev`, return that generation's `KeyAtRev` for
+    ///   the predecessor.
+    /// - If `rev` sits at the start of a generation (no in-gen
+    ///   predecessor) — i.e. the strict predecessor lies in an
+    ///   earlier generation — walk back to that earlier generation.
+    ///   The trailing tombstone of a non-final generation is **not**
+    ///   a live version (see [`KeyHistory::keep`]); skip it and
+    ///   return the `KeyAtRev` for the LAST LIVE rev of that
+    ///   earlier generation.
+    /// - If no prior live rev exists in any generation, return `None`.
+    ///
+    /// Load-bearing for L863's `compute_prev_kv_strict`: without the
+    /// cross-gen walk, a `Put` that opens a new generation (i.e. the
+    /// first put after a tombstone) would always get `prev = None`,
+    /// which is correct only if there is no earlier generation.
+    ///
+    /// # Errors
+    ///
+    /// [`KeyHistoryError::RevisionNotFound`] if the per-generation
+    /// `version` arithmetic underflows. Structurally impossible
+    /// under the lifecycle invariants but propagated for parity with
+    /// [`KeyHistory::get`].
+    pub fn get_strict_lt(&self, rev: Revision) -> Result<Option<KeyAtRev>, KeyHistoryError> {
+        let Some(last_gen_idx) = self.generations.len().checked_sub(1) else {
+            return Ok(None);
+        };
+        let mut gi = last_gen_idx;
+        loop {
+            let Some(g) = self.generations.get(gi) else {
+                return Ok(None);
+            };
+
+            if !g.is_empty() {
+                let is_final = gi == last_gen_idx;
+                // Largest in-gen rev strictly less than `rev`. The
+                // `walk_desc` predicate "rev >= target" returns
+                // `false` exactly at the first (descending) rev
+                // that is strictly less than `target` — its
+                // ascending index is what we want.
+                if let Some(cand_idx) = g.walk_desc(|r| r >= rev) {
+                    let target_idx = if !is_final && g.revs.len().checked_sub(1) == Some(cand_idx) {
+                        // Trailing tombstone of a non-final gen.
+                        // Lifecycle invariant: a non-final gen has
+                        // at least one Put (the put that opened it)
+                        // before the tombstone, so cand_idx >= 1.
+                        cand_idx.checked_sub(1)
+                    } else {
+                        Some(cand_idx)
+                    };
+                    if let Some(idx) = target_idx {
+                        let Some(modified) = g.revs.get(idx).copied() else {
+                            return Ok(None);
+                        };
+                        let version = generation_version_at(g, idx)?;
+                        return Ok(Some(KeyAtRev {
+                            modified,
+                            created: g.created,
+                            version,
+                        }));
+                    }
+                    // Single-rev non-final gen: lifecycle
+                    // violation in steady state. Defensive
+                    // fall-through to the previous gen.
+                }
+            }
+
+            gi = match gi.checked_sub(1) {
+                Some(v) => v,
+                None => return Ok(None),
+            };
+        }
+    }
+
     /// Reconstruct a `KeyHistory` from on-disk state — a single
     /// non-empty generation. Used by the recovery path (L852)
     /// while replaying the `key` bucket.
@@ -644,6 +769,28 @@ pub struct KeyAtRev {
     /// Version number (1-indexed) within the generation. `i64`
     /// matches etcd's wire-format `int64`.
     pub version: i64,
+}
+
+/// Kind of event yielded by [`KeyHistory::events_in_range`] —
+/// distinguishes a live revision (`Put`) from a tombstone
+/// (`Tombstone`) on a per-revision basis. Mirrors the on-disk
+/// distinction expressed by [`KeyKind`].
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
+pub enum KeyEventKind {
+    /// A live revision — the catch-up scan emits a `Put` watch event.
+    Put,
+    /// A tombstone — the catch-up scan emits a `Delete` watch event.
+    Tombstone,
+}
+
+impl From<KeyKind> for KeyEventKind {
+    fn from(kind: KeyKind) -> Self {
+        match kind {
+            KeyKind::Put => Self::Put,
+            KeyKind::Tombstone => Self::Tombstone,
+        }
+    }
 }
 
 /// Reasons a `restore` call may reject its inputs.
@@ -1192,5 +1339,150 @@ mod tests {
             k.keep(at, &mut available);
             prop_assert_eq!(k, snapshot);
         }
+    }
+
+    // === L863 catch-up primitives ===
+
+    /// U1 — `events_in_range` walks across generations in ascending
+    /// order, marking the trailing rev of every non-final generation
+    /// as `Tombstone` and every other rev as `Put`.
+    #[test]
+    fn key_history_events_in_range_walks_generations() {
+        let mut k = KeyHistory::new();
+        k.put(Revision::new(1, 0)).unwrap();
+        k.tombstone(Revision::new(2, 0)).unwrap();
+        k.put(Revision::new(3, 0)).unwrap();
+        k.tombstone(Revision::new(4, 0)).unwrap();
+        k.put(Revision::new(5, 0)).unwrap();
+
+        let all: Vec<(Revision, KeyEventKind)> = k.events_in_range(0, 100).collect();
+        assert_eq!(
+            all,
+            vec![
+                (Revision::new(1, 0), KeyEventKind::Put),
+                (Revision::new(2, 0), KeyEventKind::Tombstone),
+                (Revision::new(3, 0), KeyEventKind::Put),
+                (Revision::new(4, 0), KeyEventKind::Tombstone),
+                (Revision::new(5, 0), KeyEventKind::Put),
+            ]
+        );
+
+        let subset: Vec<(Revision, KeyEventKind)> = k.events_in_range(2, 4).collect();
+        assert_eq!(
+            subset,
+            vec![
+                (Revision::new(2, 0), KeyEventKind::Tombstone),
+                (Revision::new(3, 0), KeyEventKind::Put),
+                (Revision::new(4, 0), KeyEventKind::Tombstone),
+            ]
+        );
+    }
+
+    /// U2 — `events_in_range` filters strictly on `main`, treating
+    /// `lo` and `hi` as inclusive boundaries.
+    #[test]
+    fn key_history_events_in_range_filters_main_revision() {
+        let mut k = KeyHistory::new();
+        k.put(Revision::new(1, 0)).unwrap();
+        k.put(Revision::new(2, 0)).unwrap();
+        k.put(Revision::new(3, 0)).unwrap();
+        k.put(Revision::new(4, 0)).unwrap();
+
+        // Empty range on the low side.
+        let none: Vec<_> = k.events_in_range(10, 20).collect();
+        assert!(none.is_empty());
+
+        // Single-rev window pinned to lo == hi.
+        let one: Vec<_> = k.events_in_range(2, 2).collect();
+        assert_eq!(one, vec![(Revision::new(2, 0), KeyEventKind::Put)]);
+
+        // Hi inclusive — boundary check.
+        let mid: Vec<_> = k.events_in_range(2, 3).collect();
+        assert_eq!(
+            mid,
+            vec![
+                (Revision::new(2, 0), KeyEventKind::Put),
+                (Revision::new(3, 0), KeyEventKind::Put),
+            ]
+        );
+    }
+
+    /// U3 — `events_in_range` on `Put(1)/Tomb(2)` (with the trailing
+    /// empty generation invariant) yields `[(1,Put),(2,Tomb)]`. The
+    /// trailing empty generation contributes nothing.
+    #[test]
+    fn key_history_events_in_range_empty_trailing_generation() {
+        let mut k = KeyHistory::new();
+        k.put(Revision::new(1, 0)).unwrap();
+        k.tombstone(Revision::new(2, 0)).unwrap();
+        assert_eq!(k.generations_len(), 2);
+
+        let events: Vec<_> = k.events_in_range(0, 100).collect();
+        assert_eq!(
+            events,
+            vec![
+                (Revision::new(1, 0), KeyEventKind::Put),
+                (Revision::new(2, 0), KeyEventKind::Tombstone),
+            ]
+        );
+    }
+
+    /// U5a — `get_strict_lt` returns the same-generation predecessor
+    /// when one exists.
+    #[test]
+    fn get_strict_lt_same_generation_predecessor() {
+        let mut k = KeyHistory::new();
+        k.put(Revision::new(7, 0)).unwrap();
+        k.put(Revision::new(7, 1)).unwrap();
+
+        let pred = k.get_strict_lt(Revision::new(7, 1)).unwrap().unwrap();
+        assert_eq!(pred.modified, Revision::new(7, 0));
+        assert_eq!(pred.created, Revision::new(7, 0));
+        assert_eq!(pred.version, 1);
+
+        let none = k.get_strict_lt(Revision::new(7, 0)).unwrap();
+        assert!(none.is_none(), "no predecessor for the very first put");
+    }
+
+    /// U5b — `get_strict_lt` walks back to the previous generation
+    /// when there is no in-gen predecessor, skipping the trailing
+    /// tombstone (which is not a live version).
+    #[test]
+    fn get_strict_lt_cross_generation_predecessor_skips_tombstone() {
+        let mut k = KeyHistory::new();
+        k.put(Revision::new(1, 0)).unwrap();
+        k.tombstone(Revision::new(2, 0)).unwrap();
+        k.put(Revision::new(3, 0)).unwrap();
+
+        // (3,0) is the first rev of gen 1. Strict predecessor is in
+        // gen 0; the tombstone (2,0) is the last rev of gen 0 but is
+        // NOT a live version, so we walk past it to (1,0).
+        let pred = k.get_strict_lt(Revision::new(3, 0)).unwrap().unwrap();
+        assert_eq!(
+            pred.modified,
+            Revision::new(1, 0),
+            "must skip tombstone (2,0) and return the live (1,0)"
+        );
+        assert_eq!(pred.created, Revision::new(1, 0));
+        assert_eq!(pred.version, 1);
+
+        // (1,0) is the very first stored rev; no predecessor.
+        let none = k.get_strict_lt(Revision::new(1, 0)).unwrap();
+        assert!(none.is_none());
+    }
+
+    /// U6 — `Revision`'s `Ord` is lex on `(main, sub)`. The L863
+    /// proof relies on this ordering for `get_strict_lt`. A future
+    /// refactor of `Revision` (e.g. swapping `Ord` for a custom
+    /// impl) must preserve it; this test fails fast if it doesn't.
+    #[test]
+    fn revision_ord_is_main_then_sub() {
+        let a = Revision::new(5, 0);
+        let b = Revision::new(5, 1);
+        let c = Revision::new(6, 0);
+        assert!(a < b);
+        assert!(b < c);
+        assert!(a < c);
+        assert_eq!(a, Revision::new(5, 0));
     }
 }

--- a/crates/mango-mvcc/src/lib.rs
+++ b/crates/mango-mvcc/src/lib.rs
@@ -40,7 +40,7 @@ pub use bucket::{
     register, KEY_BUCKET_ID, KEY_BUCKET_NAME, KEY_INDEX_BUCKET_ID, KEY_INDEX_BUCKET_NAME,
 };
 pub use encoding::{decode_key, encode_key, EncodedKey, KeyDecodeError, KeyKind};
-pub use error::{MvccError, OpenError, UnsupportedFeature};
+pub use error::{MvccError, OpenError};
 pub use key_history::{KeyAtRev, KeyEventKind, KeyHistory, KeyHistoryError, RestoreInvalidReason};
 pub use revision::Revision;
 pub use sharded_key_index::{KeyIndexError, ShardedKeyIndex};

--- a/crates/mango-mvcc/src/lib.rs
+++ b/crates/mango-mvcc/src/lib.rs
@@ -41,7 +41,7 @@ pub use bucket::{
 };
 pub use encoding::{decode_key, encode_key, EncodedKey, KeyDecodeError, KeyKind};
 pub use error::{MvccError, OpenError, UnsupportedFeature};
-pub use key_history::{KeyAtRev, KeyHistory, KeyHistoryError, RestoreInvalidReason};
+pub use key_history::{KeyAtRev, KeyEventKind, KeyHistory, KeyHistoryError, RestoreInvalidReason};
 pub use revision::Revision;
 pub use sharded_key_index::{KeyIndexError, ShardedKeyIndex};
 pub use store::{

--- a/crates/mango-mvcc/src/sharded_key_index.rs
+++ b/crates/mango-mvcc/src/sharded_key_index.rs
@@ -68,7 +68,7 @@ use loom::sync::RwLock;
 #[cfg(not(loom))]
 use parking_lot::RwLock;
 
-use crate::key_history::{KeyAtRev, KeyHistory, KeyHistoryError};
+use crate::key_history::{KeyAtRev, KeyEventKind, KeyHistory, KeyHistoryError};
 use crate::revision::Revision;
 
 /// Number of shards. Power of 2 so we can use a bit-mask instead of
@@ -231,6 +231,53 @@ impl ShardedKeyIndex {
         let guard = read_lock(lock);
         if let Some(entry) = guard.get(key) {
             entry.since_into(since_rev, out);
+        }
+    }
+
+    /// All `(rev, kind)` pairs for `key` whose `main` lies in
+    /// `[lo, hi]`, in ascending order. Returns an empty `Vec` if
+    /// `key` has no entry — the catch-up scan treats "absent" and
+    /// "no events in range" the same.
+    ///
+    /// Materialized into a `Vec` so the per-shard read-lock is
+    /// released before the caller dispatches events on
+    /// `tx.send().await`. Per-key history depth is the cap on
+    /// allocation; under realistic workloads typically `< 100`.
+    #[must_use]
+    pub fn events_in_range(&self, key: &[u8], lo: i64, hi: i64) -> Vec<(Revision, KeyEventKind)> {
+        let shard = self.shard_for(key);
+        let lock = self.shard(shard);
+        let guard = read_lock(lock);
+        match guard.get(key) {
+            Some(entry) => entry.events_in_range(lo, hi).collect(),
+            None => Vec::new(),
+        }
+    }
+
+    /// Highest stored `KeyAtRev` for `key` whose stored revision is
+    /// **strictly less than** `rev` in lex `(main, sub)` order.
+    ///
+    /// Cross-generation walk skips the trailing tombstone of the
+    /// previous generation — see [`KeyHistory::get_strict_lt`] for
+    /// the full semantics. Returns `Ok(None)` if `key` has no
+    /// entry, or if no prior live revision exists in any
+    /// generation.
+    ///
+    /// # Errors
+    ///
+    /// Forwards [`KeyHistoryError`] from the inner walk (only
+    /// reachable on a structurally invalid `KeyHistory`).
+    pub fn get_strict_lt(
+        &self,
+        key: &[u8],
+        rev: Revision,
+    ) -> Result<Option<KeyAtRev>, KeyIndexError> {
+        let shard = self.shard_for(key);
+        let lock = self.shard(shard);
+        let guard = read_lock(lock);
+        match guard.get(key) {
+            Some(entry) => Ok(entry.get_strict_lt(rev)?),
+            None => Ok(None),
         }
     }
 
@@ -711,6 +758,66 @@ mod tests {
                 .unwrap();
         }
         assert_eq!(idx.len(), 10);
+    }
+
+    // === L863 catch-up primitives ===
+
+    /// U4 — `events_in_range` returns an empty `Vec` when the key
+    /// has no entry. The catch-up scan treats "no entry" and "entry
+    /// with no events in range" identically.
+    #[test]
+    fn sharded_key_index_events_in_range_returns_empty_for_missing_key() {
+        let idx = ShardedKeyIndex::new();
+        let events = idx.events_in_range(b"absent", 0, 100);
+        assert!(events.is_empty());
+    }
+
+    /// `events_in_range` round-trip on a present key — returns the
+    /// same sequence the inner `KeyHistory::events_in_range` emits.
+    #[test]
+    fn sharded_key_index_events_in_range_present_key_round_trips() {
+        let idx = ShardedKeyIndex::new();
+        idx.put(b"k", Revision::new(1, 0)).unwrap();
+        idx.put(b"k", Revision::new(2, 0)).unwrap();
+        idx.tombstone(b"k", Revision::new(3, 0)).unwrap();
+        idx.put(b"k", Revision::new(4, 0)).unwrap();
+
+        let events = idx.events_in_range(b"k", 0, 100);
+        assert_eq!(
+            events,
+            vec![
+                (Revision::new(1, 0), KeyEventKind::Put),
+                (Revision::new(2, 0), KeyEventKind::Put),
+                (Revision::new(3, 0), KeyEventKind::Tombstone),
+                (Revision::new(4, 0), KeyEventKind::Put),
+            ]
+        );
+    }
+
+    /// `get_strict_lt` returns `None` when the key has no entry —
+    /// matches the "no entry" arm in `events_in_range`.
+    #[test]
+    fn sharded_key_index_get_strict_lt_missing_key_returns_none() {
+        let idx = ShardedKeyIndex::new();
+        let pred = idx.get_strict_lt(b"absent", Revision::new(5, 0)).unwrap();
+        assert!(pred.is_none());
+    }
+
+    /// `get_strict_lt` cross-gen walk through the index surface —
+    /// pins the same property as `KeyHistory`'s U5b at the
+    /// `ShardedKeyIndex` boundary.
+    #[test]
+    fn sharded_key_index_get_strict_lt_cross_generation() {
+        let idx = ShardedKeyIndex::new();
+        idx.put(b"k", Revision::new(1, 0)).unwrap();
+        idx.tombstone(b"k", Revision::new(2, 0)).unwrap();
+        idx.put(b"k", Revision::new(3, 0)).unwrap();
+
+        let pred = idx
+            .get_strict_lt(b"k", Revision::new(3, 0))
+            .unwrap()
+            .unwrap();
+        assert_eq!(pred.modified, Revision::new(1, 0));
     }
 
     // === Class 2: sharding contract ===

--- a/crates/mango-mvcc/src/store/mod.rs
+++ b/crates/mango-mvcc/src/store/mod.rs
@@ -52,7 +52,7 @@ pub use range::{KeyValue, RangeRequest, RangeResult};
 pub use snapshot::Snapshot;
 pub use txn::{Compare, CompareOp, RequestOp, ResponseOp, TxnRequest, TxnResponse};
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Bound;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -64,7 +64,7 @@ use mango_storage::{Backend, ReadSnapshot, WriteBatch};
 use crate::bucket::{register, KEY_BUCKET_ID};
 use crate::encoding::{decode_key, encode_key, KeyKind};
 use crate::error::{MvccError, OpenError};
-use crate::key_history::KeyHistoryError;
+use crate::key_history::{KeyAtRev, KeyHistoryError};
 use crate::revision::Revision;
 use crate::sharded_key_index::{KeyIndexError, ShardedKeyIndex};
 use crate::watchable_store::{WatchEvent, WatchEventKind, WriteObserver};
@@ -118,19 +118,75 @@ enum OpPlan {
         value: Vec<u8>,
         /// Allocated revision for this put.
         rev: Revision,
+        /// Pre-mutation prev-kv for this put: the live version of
+        /// `key` immediately before this op runs (or `None` if
+        /// the key was absent / tombstoned). Captured BEFORE any
+        /// in-flight or persisted index mutation, so emit-side
+        /// consumers (the watch path in ROADMAP.md:863 follow-up)
+        /// see the right value even when an earlier op in the
+        /// same txn already overwrote `key`.
+        ///
+        /// Phase 3 plan §4.6. In this commit, the field is
+        /// captured but not yet wired into the emitted
+        /// [`WatchEvent`] (commit 3 of the L863 series).
+        prev: Option<KeyValue>,
     },
     /// Zero or more sub-allocated tombstones for a single
     /// [`RequestOp::DeleteRange`]. Empty when no live keys
     /// matched (the op contributes no physical writes).
     Delete {
-        /// `(matched_key, allocated_rev)` pairs in match order.
+        /// One [`Tombstone`] per matched key, in match order.
         tombs: Vec<Tombstone>,
     },
 }
 
-/// One matched-key / allocated-revision pair inside an
-/// [`OpPlan::Delete`] entry.
-type Tombstone = (Box<[u8]>, Revision);
+/// One matched key inside an [`OpPlan::Delete`] entry.
+///
+/// Phase 3 plan §4.6 (ROADMAP.md:863): carries the pre-mutation
+/// `prev` [`KeyValue`] so the watch emit path can publish a
+/// `WatchEvent::Delete { prev: Some(...) }` without re-querying a
+/// post-mutation index. Tombstones are only emitted for live keys,
+/// so `prev` is unconditionally present.
+struct Tombstone {
+    /// Matched user key.
+    key: Box<[u8]>,
+    /// Allocated revision for this tombstone (`(txn_main, sub)`).
+    rev: Revision,
+    /// Pre-mutation prev-kv: the live version of `key`
+    /// immediately before this tombstone runs. Captured BEFORE
+    /// any index mutation. In this commit the field is captured
+    /// but not yet wired into the emitted [`WatchEvent`] — that
+    /// lands in commit 3 of the L863 series, which lets bench
+    /// B2.5 isolate the capture-only overhead from the emit-side
+    /// change. Allow `dead_code` for one commit.
+    #[allow(
+        dead_code,
+        reason = "wired into emit in commit 3 of the L863 series; \
+                  keeping the capture isolated lets bench B2.5 measure \
+                  capture-only cost"
+    )]
+    prev: KeyValue,
+}
+
+/// In-flight per-txn key state used by [`MvccStore::build_txn_plan`]
+/// to resolve `prev_kv` against the most-recent in-flight op rather
+/// than the (post-mutation) index. Phase 3 plan §4.6.
+///
+/// - `Some(Some(kv))` — the key is live with this in-flight value
+///   (a same-txn `Put` overwrote the prior version).
+/// - `Some(None)` — the key was tombstoned earlier in this txn.
+/// - absent — the key has not been touched by any prior op in this
+///   txn; resolve `prev` against the pre-txn index via
+///   [`MvccStore::compute_prev_kv_strict`].
+///
+/// Consulted **only** for `prev_kv` resolution. The `DeleteRange`
+/// match-set is computed against the pre-txn `keys_in_order`
+/// snapshot, exactly as before — same-branch put-then-delete-of-
+/// new-key continues to be a no-op on the second op (existing
+/// documented contract; see [`MvccStore::txn`]).
+struct TentativeState {
+    live: HashMap<Box<[u8]>, Option<KeyValue>>,
+}
 
 /// Increment a per-txn `sub` allocator with overflow surfaced as
 /// [`MvccError::Internal`]. Workspace `arithmetic_side_effects`
@@ -158,15 +214,23 @@ fn checked_add_total(total: usize) -> Result<usize, MvccError> {
 /// - [`OpPlan::Put`] — one [`WatchEventKind::Put`] event with
 ///   `revision = rev` from the plan entry.
 /// - [`OpPlan::Delete`] — one [`WatchEventKind::Delete`] event per
-///   `(key, rev)` pair in `tombs`, in match order; `value` is empty.
+///   [`Tombstone`] in `tombs`, in match order; `value` is empty.
 ///
-/// `prev` is `None` on every event in this PR (populated in
-/// ROADMAP.md:863).
+/// `prev` is `None` on every event in this commit. The plan-level
+/// `prev` capture is wired into the emitted [`WatchEvent`] in
+/// commit 3 of the L863 series — keeping that change isolated
+/// lets bench B2.5 measure the capture-only overhead in isolation
+/// (Phase 3 plan §6 / §5.5).
 fn emit_txn_events(plan: &[OpPlan], buf: &mut Vec<WatchEvent>) {
     for entry in plan {
         match entry {
             OpPlan::Read => {}
-            OpPlan::Put { key, value, rev } => {
+            OpPlan::Put {
+                key,
+                value,
+                rev,
+                prev: _captured_for_l863,
+            } => {
                 buf.push(WatchEvent {
                     kind: WatchEventKind::Put,
                     key: Bytes::copy_from_slice(key),
@@ -176,13 +240,13 @@ fn emit_txn_events(plan: &[OpPlan], buf: &mut Vec<WatchEvent>) {
                 });
             }
             OpPlan::Delete { tombs } => {
-                for (k, key_rev) in tombs {
+                for tomb in tombs {
                     buf.push(WatchEvent {
                         kind: WatchEventKind::Delete,
-                        key: Bytes::copy_from_slice(k),
+                        key: Bytes::copy_from_slice(&tomb.key),
                         value: Bytes::new(),
                         prev: None,
-                        revision: *key_rev,
+                        revision: tomb.rev,
                     });
                 }
             }
@@ -432,6 +496,61 @@ impl<B: Backend> MvccStore<B> {
     #[allow(dead_code)]
     pub(crate) fn backend(&self) -> &B {
         &self.backend
+    }
+
+    /// Pre-mutation prev-kv lookup: the live version of `key`
+    /// strictly before `at_rev`, materialised as a [`KeyValue`]
+    /// against the on-disk snapshot `snap_be`.
+    ///
+    /// Phase 3 plan §3.4 / §4.6 (ROADMAP.md:863). Walks the index
+    /// via [`ShardedKeyIndex::get_strict_lt`] (which crosses
+    /// generations, skipping the closing tombstone), then
+    /// resolves the value bytes from `snap_be`. Returns `None` if
+    /// no prior live revision exists in any generation.
+    ///
+    /// This is the building block for `prev_kv` population on the
+    /// writer hot path (`put`, `delete_range`, `txn`) and on the
+    /// catch-up scan path. The caller threads ONE
+    /// [`Backend::snapshot`] through every prev-kv computation in
+    /// a single writer call, amortising the snapshot cost across
+    /// `N` matched keys.
+    ///
+    /// # Errors
+    ///
+    /// - [`MvccError::KeyIndex`] if the index lookup fails for a
+    ///   reason other than `KeyNotFound` /
+    ///   `History(RevisionNotFound)` (those two are the absent
+    ///   path — not errors here).
+    /// - [`MvccError::Backend`] if the on-disk value fetch fails.
+    pub(crate) fn compute_prev_kv_strict(
+        &self,
+        key: &[u8],
+        at_rev: Revision,
+        snap_be: &B::Snapshot,
+    ) -> Result<Option<KeyValue>, MvccError> {
+        let at = match self.index.get_strict_lt(key, at_rev) {
+            Ok(Some(at)) => at,
+            // Both "no entry" and "no strict-lt predecessor" are
+            // the absent path — return None, not Err.
+            Ok(None)
+            | Err(
+                KeyIndexError::KeyNotFound
+                | KeyIndexError::History(KeyHistoryError::RevisionNotFound),
+            ) => return Ok(None),
+            Err(e) => return Err(MvccError::KeyIndex(e)),
+        };
+        let enc = encode_key(at.modified, KeyKind::Put);
+        let value = snap_be
+            .get(KEY_BUCKET_ID, enc.as_bytes())?
+            .unwrap_or_default();
+        Ok(Some(KeyValue {
+            key: Bytes::copy_from_slice(key),
+            create_revision: at.created,
+            mod_revision: at.modified,
+            version: at.version,
+            value,
+            lease: None,
+        }))
     }
 
     /// Single-key put.
@@ -783,13 +902,15 @@ impl<B: Backend> MvccStore<B> {
             }
         };
 
-        // Step 4: filter to keys live at `current` — already-
-        // tombstoned keys must not consume a sub or appear on disk
-        // a second time.
-        let mut matched: Vec<Box<[u8]>> = Vec::with_capacity(candidates.len());
+        // Step 4: filter to keys live at `current` and CAPTURE
+        // their pre-mutation `KeyAtRev` so prev-kv resolution does
+        // not have to re-query a post-mutation index. Phase 3
+        // plan §4.6 (ROADMAP.md:863). Already-tombstoned keys
+        // must not consume a sub or appear on disk a second time.
+        let mut matched: Vec<(Box<[u8]>, KeyAtRev)> = Vec::with_capacity(candidates.len());
         for k in candidates {
             match self.index.get(&k, current) {
-                Ok(_) => matched.push(k),
+                Ok(at) => matched.push((k, at)),
                 // Already tombstoned at `current` (or before).
                 Err(KeyIndexError::History(KeyHistoryError::RevisionNotFound)) => {}
                 Err(KeyIndexError::KeyNotFound) => {
@@ -810,6 +931,31 @@ impl<B: Backend> MvccStore<B> {
             return Ok((0, Revision::new(current, 0)));
         }
 
+        // Phase 3 plan §4.6 (ROADMAP.md:863): capture `prev` from
+        // a pre-mutation backend snapshot BEFORE any index update.
+        // Tombstones target live keys only, so every match has a
+        // prev value. ONE snapshot per writer call amortises the
+        // cost across N matches. The captured prev is plumbed onto
+        // each `Tombstone` for commit 3 of the L863 series to
+        // surface on the watch path; this commit only captures.
+        let snap_be = self.backend.snapshot()?;
+        let mut prev_kvs: Vec<KeyValue> = Vec::with_capacity(matched.len());
+        for (k, at) in &matched {
+            let enc = encode_key(at.modified, KeyKind::Put);
+            let value = snap_be
+                .get(KEY_BUCKET_ID, enc.as_bytes())?
+                .unwrap_or_default();
+            prev_kvs.push(KeyValue {
+                key: Bytes::copy_from_slice(k),
+                create_revision: at.created,
+                mod_revision: at.modified,
+                version: at.version,
+                value,
+                lease: None,
+            });
+        }
+        drop(snap_be);
+
         // Step 7+: allocate a single main; sub increments per
         // physical write.
         let rev = Revision::new(state.next_main, 0);
@@ -818,16 +964,21 @@ impl<B: Backend> MvccStore<B> {
         let mut sub: i64 = 0;
         // Pair each key with the rev it gets tombstoned at, so the
         // post-commit `index.tombstone` calls reuse the on-disk
-        // assignments verbatim.
+        // assignments verbatim. `prev` rides along on each
+        // [`Tombstone`] for the L863 emit-side wiring (commit 3).
         let mut tombstones: Vec<Tombstone> = Vec::with_capacity(matched.len());
-        for k in matched {
+        for ((k, _at), prev) in matched.into_iter().zip(prev_kvs.into_iter()) {
             let key_rev = Revision::new(rev.main(), sub);
             let encoded = encode_key(key_rev, KeyKind::Tombstone);
             batch.put(KEY_BUCKET_ID, encoded.as_bytes(), TOMBSTONE_VALUE)?;
             sub = sub.checked_add(1).ok_or(MvccError::Internal {
                 context: "delete_range sub overflow",
             })?;
-            tombstones.push((k, key_rev));
+            tombstones.push(Tombstone {
+                key: k,
+                rev: key_rev,
+                prev,
+            });
         }
         // No fsync — Raft's WAL above us owns durability (parity
         // with `Put`).
@@ -838,8 +989,8 @@ impl<B: Backend> MvccStore<B> {
         // (review item R3). `index.tombstone` returning `Err` would
         // indicate the writer-lock invariant is broken (plan
         // §5.4 review item S3).
-        for (k, key_rev) in &tombstones {
-            if let Err(_e) = self.index.tombstone(k, *key_rev) {
+        for tomb in &tombstones {
+            if let Err(_e) = self.index.tombstone(&tomb.key, tomb.rev) {
                 return Err(MvccError::Internal {
                     context: "index.tombstone failed under writer-lock invariant",
                 });
@@ -858,14 +1009,16 @@ impl<B: Backend> MvccStore<B> {
         // Phase 3 plan §4.2 (ROADMAP.md:862): one Delete event per
         // tombstoned key, in match order, sub-revision matching the
         // on-disk assignment. `value` is empty for Delete; `prev`
-        // is `None` (populated in ROADMAP.md:863).
-        for (k, key_rev) in &tombstones {
+        // is captured on each [`Tombstone`] (this commit) and
+        // wired into the emitted event in commit 3 of the L863
+        // series so bench B2.5 can isolate the capture-only cost.
+        for tomb in &tombstones {
             state.emit_buf.push(WatchEvent {
                 kind: WatchEventKind::Delete,
-                key: Bytes::copy_from_slice(k),
+                key: Bytes::copy_from_slice(&tomb.key),
                 value: Bytes::new(),
                 prev: None,
-                revision: *key_rev,
+                revision: tomb.rev,
             });
         }
 
@@ -1018,6 +1171,23 @@ impl<B: Backend> MvccStore<B> {
     /// `DeleteRange`'s match set is computed against the pre-txn
     /// `keys_in_order` snapshot (see `txn` doc, intra-branch
     /// visibility caveat).
+    ///
+    /// Phase 3 plan §4.6 (ROADMAP.md:863): the pass also captures
+    /// `prev_kv` for each physical write into the [`OpPlan`]
+    /// entries. A [`TentativeState`] map threads in-flight
+    /// updates across ops within the same branch so a `Put`
+    /// following an earlier `Put` of the same key sees the
+    /// in-flight value (NOT the post-mutation index) as its
+    /// `prev`. The map is consulted **only** for prev-kv
+    /// resolution; the `DeleteRange` match-set continues to be
+    /// computed against pre-txn `keys_in_order` exactly as
+    /// before. ONE [`Backend::snapshot`] per call amortises
+    /// snapshot cost across N matched keys.
+    ///
+    /// Captured `prev`s are plumbed onto [`OpPlan::Put`] /
+    /// [`Tombstone`] but not yet wired into emitted
+    /// [`WatchEvent`]s — that ride lands in commit 3 of the L863
+    /// series.
     fn build_txn_plan(
         &self,
         branch: &[RequestOp],
@@ -1027,22 +1197,55 @@ impl<B: Backend> MvccStore<B> {
         let mut plan: Vec<OpPlan> = Vec::with_capacity(branch.len());
         let mut sub: i64 = 0;
         let mut total: usize = 0;
+        let mut tentative = TentativeState {
+            live: HashMap::with_capacity(branch.len()),
+        };
+        // Acquire the prev-kv snapshot lazily so the read-only
+        // path (no Puts, no live DeleteRange matches) does not pay
+        // the snapshot cost. Constructed on first need.
+        let mut snap_be: Option<B::Snapshot> = None;
         for op in branch {
             match op {
                 RequestOp::Range(_) => plan.push(OpPlan::Read),
                 RequestOp::Put { key, value } => {
                     let rev = Revision::new(txn_main, sub);
+                    let prev =
+                        self.compute_txn_op_prev_for_put(key, rev, &tentative, &mut snap_be)?;
+                    // Tentative state: the just-pushed Put makes
+                    // the key live with `value` (the in-flight
+                    // version). Build a synthetic `KeyValue` so a
+                    // later op in the same txn that wants `prev`
+                    // resolves against this in-flight write
+                    // instead of the post-mutation index.
+                    let new_kv = KeyValue {
+                        key: Bytes::copy_from_slice(key),
+                        create_revision: prev.as_ref().map_or(rev, |p| p.create_revision),
+                        mod_revision: rev,
+                        version: prev.as_ref().map_or(1, |p| p.version.saturating_add(1)),
+                        value: Bytes::copy_from_slice(value),
+                        lease: None,
+                    };
+                    let _ = tentative.live.insert(key.as_slice().into(), Some(new_kv));
                     sub = checked_add_sub(sub)?;
                     total = checked_add_total(total)?;
                     plan.push(OpPlan::Put {
                         key: key.clone(),
                         value: value.clone(),
                         rev,
+                        prev,
                     });
                 }
                 RequestOp::DeleteRange { key, end } => {
-                    let tombs =
-                        self.plan_delete_range(key, end, current, txn_main, &mut sub, &mut total)?;
+                    let tombs = self.plan_delete_range(
+                        key,
+                        end,
+                        current,
+                        txn_main,
+                        &mut sub,
+                        &mut total,
+                        &mut tentative,
+                        &mut snap_be,
+                    )?;
                     plan.push(OpPlan::Delete { tombs });
                 }
             }
@@ -1050,11 +1253,51 @@ impl<B: Backend> MvccStore<B> {
         Ok((plan, total))
     }
 
+    /// Resolve `prev` for a single `Put` op inside
+    /// [`Self::build_txn_plan`]: prefer the in-flight tentative
+    /// state, fall back to the pre-txn index via
+    /// [`Self::compute_prev_kv_strict`]. Lazily builds `snap_be`
+    /// on first use so a Range-only branch never acquires a
+    /// backend snapshot.
+    fn compute_txn_op_prev_for_put(
+        &self,
+        key: &[u8],
+        at_rev: Revision,
+        tentative: &TentativeState,
+        snap_be: &mut Option<B::Snapshot>,
+    ) -> Result<Option<KeyValue>, MvccError> {
+        match tentative.live.get(key) {
+            Some(Some(prior)) => Ok(Some(prior.clone())),
+            Some(None) => Ok(None),
+            None => {
+                if snap_be.is_none() {
+                    *snap_be = Some(self.backend.snapshot()?);
+                }
+                let snap_ref = snap_be.as_ref().ok_or(MvccError::Internal {
+                    context: "txn snap_be construction logic inconsistency",
+                })?;
+                self.compute_prev_kv_strict(key, at_rev, snap_ref)
+            }
+        }
+    }
+
     /// Compute the matched-key/sub list for a single
     /// [`RequestOp::DeleteRange`] under the writer lock. Filters
     /// already-tombstoned keys (review item S3); allocates one
     /// sub per surviving match and bumps the running sub /
     /// total counters.
+    ///
+    /// Phase 3 plan §4.6 (ROADMAP.md:863): also resolves `prev`
+    /// per match via the supplied [`TentativeState`] (in-flight
+    /// state from earlier ops in the same txn) and falls back to
+    /// the pre-txn index when a match was not touched. A match
+    /// whose tentative state is `Some(None)` (already deleted
+    /// in-flight by a prior op in this txn) is skipped — the
+    /// second tombstone of an already-tombstoned key would
+    /// previously have been rejected by `index.tombstone` at
+    /// apply time as `TombstoneOnEmpty`, so the new path also
+    /// fixes that latent error case.
+    #[allow(clippy::too_many_arguments)]
     fn plan_delete_range(
         &self,
         key: &[u8],
@@ -1063,6 +1306,8 @@ impl<B: Backend> MvccStore<B> {
         txn_main: i64,
         sub: &mut i64,
         total: &mut usize,
+        tentative: &mut TentativeState,
+        snap_be: &mut Option<B::Snapshot>,
     ) -> Result<Vec<Tombstone>, MvccError> {
         let candidates: Vec<Box<[u8]>> = {
             let keys = self.keys_in_order.read();
@@ -1081,13 +1326,54 @@ impl<B: Backend> MvccStore<B> {
         let mut tombs: Vec<Tombstone> = Vec::with_capacity(candidates.len());
         for k in candidates {
             match self.index.get(&k, current) {
-                Ok(_) => {
+                Ok(at) => {
+                    let prev = match tentative.live.get(k.as_ref()) {
+                        Some(Some(prior)) => prior.clone(),
+                        Some(None) => {
+                            // Already deleted in-flight earlier
+                            // in this txn — skip the second
+                            // tombstone (would otherwise hit
+                            // `KeyHistory::TombstoneOnEmpty` at
+                            // apply time).
+                            continue;
+                        }
+                        None => {
+                            // Resolve from pre-txn state via the
+                            // shared backend snapshot. Lazy on
+                            // first need.
+                            if snap_be.is_none() {
+                                *snap_be = Some(self.backend.snapshot()?);
+                            }
+                            let snap_ref = snap_be.as_ref().ok_or(MvccError::Internal {
+                                context: "txn snap_be construction logic inconsistency",
+                            })?;
+                            let enc = encode_key(at.modified, KeyKind::Put);
+                            let value = snap_ref
+                                .get(KEY_BUCKET_ID, enc.as_bytes())?
+                                .unwrap_or_default();
+                            KeyValue {
+                                key: Bytes::copy_from_slice(&k),
+                                create_revision: at.created,
+                                mod_revision: at.modified,
+                                version: at.version,
+                                value,
+                                lease: None,
+                            }
+                        }
+                    };
                     let rev = Revision::new(txn_main, *sub);
                     *sub = checked_add_sub(*sub)?;
                     *total = checked_add_total(*total)?;
-                    tombs.push((k, rev));
+                    let _ = tentative.live.insert(k.clone(), None);
+                    tombs.push(Tombstone { key: k, rev, prev });
                 }
-                Err(KeyIndexError::History(KeyHistoryError::RevisionNotFound)) => {}
+                Err(KeyIndexError::History(KeyHistoryError::RevisionNotFound)) => {
+                    // Already tombstoned at `current` (or before)
+                    // by some PRIOR txn — silently skip exactly
+                    // as `delete_range` does. We do NOT update
+                    // tentative state: the key was never live in
+                    // this txn's branch.
+                }
                 Err(KeyIndexError::KeyNotFound) => {
                     return Err(MvccError::Internal {
                         context: "index/keys_in_order disagree on key presence",
@@ -1111,8 +1397,8 @@ impl<B: Backend> MvccStore<B> {
                     batch.put(KEY_BUCKET_ID, encoded.as_bytes(), value)?;
                 }
                 OpPlan::Delete { tombs } => {
-                    for (_, rev) in tombs {
-                        let encoded = encode_key(*rev, KeyKind::Tombstone);
+                    for tomb in tombs {
+                        let encoded = encode_key(tomb.rev, KeyKind::Tombstone);
                         batch.put(KEY_BUCKET_ID, encoded.as_bytes(), TOMBSTONE_VALUE)?;
                     }
                 }
@@ -1146,8 +1432,8 @@ impl<B: Backend> MvccStore<B> {
                     }
                 }
                 OpPlan::Delete { tombs } => {
-                    for (k, rev) in tombs {
-                        if let Err(_e) = self.index.tombstone(k, *rev) {
+                    for tomb in tombs {
+                        if let Err(_e) = self.index.tombstone(&tomb.key, tomb.rev) {
                             return Err(MvccError::Internal {
                                 context: "index.tombstone failed under txn writer-lock invariant",
                             });

--- a/crates/mango-mvcc/src/store/mod.rs
+++ b/crates/mango-mvcc/src/store/mod.rs
@@ -494,6 +494,50 @@ impl<B: Backend> MvccStore<B> {
         &self.backend
     }
 
+    /// Acquire a coherent `(mvcc_snap, backend_snap)` pair under
+    /// the writer mutex.
+    ///
+    /// Phase 3 plan §4.5 (ROADMAP.md:863). Both snapshots observe
+    /// the same point in time with respect to concurrent writes —
+    /// most importantly [`Self::compact`], whose on-disk delete
+    /// (`commit_batch`) and `snapshot.store(new_floor)` happen
+    /// inside its own writer-lock hold. Acquiring the writer lock
+    /// here means the catch-up driver either sees the pre-compact
+    /// state or the post-compact state, never a torn pair.
+    ///
+    /// The Mvcc snapshot's `rev` is the upper bound for the
+    /// catch-up scan; `compacted` is the floor. Caller reads both
+    /// from this single returned `Arc<Snapshot>` (rust-expert nit
+    /// 3 of v3 review: don't re-load `self.snapshot` after the
+    /// pair is taken).
+    ///
+    /// Cost: one `tokio::sync::Mutex` acquisition + one
+    /// [`ArcSwap::load_full`] + one [`Backend::snapshot`]. The
+    /// writer is stalled for the duration of those three steps;
+    /// on redb the backend snapshot is a single `begin_read()` in
+    /// the µs range, so the stall is bounded. Catch-up driver
+    /// caps total scan attempts at `MAX_CATCHUP_ATTEMPTS` so the
+    /// total stall budget per watcher is bounded.
+    ///
+    /// # Errors
+    ///
+    /// - [`MvccError::Backend`] if `Backend::snapshot()` fails.
+    #[allow(
+        dead_code,
+        reason = "consumed by the catch-up driver in commit 6 of \
+                  the L863 series; landed first as a small isolated \
+                  primitive so its writer-mutex contract is \
+                  reviewed independently of the driver"
+    )]
+    pub(crate) async fn snapshot_pair_under_writer(
+        &self,
+    ) -> Result<(Arc<Snapshot>, B::Snapshot), MvccError> {
+        let _guard = self.writer.lock().await;
+        let mvcc = self.snapshot.load_full();
+        let be = self.backend.snapshot()?;
+        Ok((mvcc, be))
+    }
+
     /// Pre-mutation prev-kv lookup: the live version of `key`
     /// strictly before `at_rev`, materialised as a [`KeyValue`]
     /// against the on-disk snapshot `snap_be`.

--- a/crates/mango-mvcc/src/store/mod.rs
+++ b/crates/mango-mvcc/src/store/mod.rs
@@ -64,7 +64,7 @@ use mango_storage::{Backend, ReadSnapshot, WriteBatch};
 use crate::bucket::{register, KEY_BUCKET_ID};
 use crate::encoding::{decode_key, encode_key, KeyKind};
 use crate::error::{MvccError, OpenError};
-use crate::key_history::{KeyAtRev, KeyHistoryError};
+use crate::key_history::{KeyAtRev, KeyEventKind, KeyHistoryError};
 use crate::revision::Revision;
 use crate::sharded_key_index::{KeyIndexError, ShardedKeyIndex};
 use crate::watchable_store::{WatchEvent, WatchEventKind, WriteObserver};
@@ -443,6 +443,18 @@ impl<B: Backend> MvccStore<B> {
     /// allocation amortizes across writes. The no-observer hot
     /// path is one `Vec::is_empty()` branch + one `ArcSwap::load`
     /// + one `match` + one `Vec::clear`.
+    ///
+    /// INVARIANT W (load-bearing — see `watchable_store.rs` §4.4
+    /// catch-up race proof, ROADMAP.md:863):
+    /// `snapshot.store(new_snap)` and the `obs.on_apply(...)`
+    /// call below MUST run under the same writer-mutex
+    /// acquisition with NO `.await` point between them. The
+    /// catch-up `promote_to_synced` race-proof depends on this
+    /// sequencing. Splitting these calls (e.g. by adding an
+    /// `.await` between them, or by moving `snapshot.store` out
+    /// of the writer-mutex critical section) BREAKS the
+    /// catch-up correctness proof. If you must change this,
+    /// re-derive the proof.
     fn dispatch_observer(&self, emit_buf: &mut Vec<WatchEvent>, at_main: i64) {
         if !emit_buf.is_empty() {
             let observer = self.observer.load();
@@ -522,13 +534,6 @@ impl<B: Backend> MvccStore<B> {
     /// # Errors
     ///
     /// - [`MvccError::Backend`] if `Backend::snapshot()` fails.
-    #[allow(
-        dead_code,
-        reason = "consumed by the catch-up driver in commit 6 of \
-                  the L863 series; landed first as a small isolated \
-                  primitive so its writer-mutex contract is \
-                  reviewed independently of the driver"
-    )]
     pub(crate) async fn snapshot_pair_under_writer(
         &self,
     ) -> Result<(Arc<Snapshot>, B::Snapshot), MvccError> {
@@ -591,6 +596,122 @@ impl<B: Backend> MvccStore<B> {
             value,
             lease: None,
         }))
+    }
+
+    /// Catch-up scan over `[range_start, range_end)` for revisions
+    /// `rev.main() in [lo, hi]`, against the writer-locked
+    /// `(mvcc_snap, snap_be)` pair.
+    ///
+    /// Phase 3 plan §4.5 (ROADMAP.md:863). Used by the unsynced
+    /// watcher's catch-up driver to replay history events between
+    /// `start_rev` (the watcher's requested floor) and `mvcc_snap.rev`
+    /// (the upper bound captured under the writer mutex).
+    ///
+    /// `range_end.is_empty()` selects the single-key case.
+    ///
+    /// Events are emitted in `(rev.main, rev.sub)` ascending order
+    /// across the matched key set — etcd parity. Within one key the
+    /// per-key history walk already yields revs in ascending order
+    /// (`ShardedKeyIndex::events_in_range`); across keys we sort the
+    /// merged list once at the end.
+    ///
+    /// `prev_kv` is computed for every event via
+    /// [`Self::compute_prev_kv_strict`] against the same `snap_be`,
+    /// matching the writer hot path's contract: `Put` events carry
+    /// `Some(...)` only when a strictly-prior live version exists in
+    /// any generation; `Delete` events always carry `Some(...)`
+    /// (tombstones close a live generation).
+    ///
+    /// # Compaction guard
+    ///
+    /// Returns [`MvccError::Compacted`] when `mvcc_snap.compacted >= lo`.
+    /// The driver maps this to a terminal
+    /// `DisconnectReason::Compacted { floor }`.
+    ///
+    /// # Empty / inverted range
+    ///
+    /// Returns `Ok(Vec::new())` when `lo > hi`. The caller treats
+    /// this as "no events to send this iteration; check for promote".
+    ///
+    /// # Errors
+    ///
+    /// - [`MvccError::Compacted`] if the floor advanced past `lo`.
+    /// - [`MvccError::KeyIndex`] / [`MvccError::Backend`] surfaced
+    ///   verbatim — the driver maps these to a terminal
+    ///   `DisconnectReason::Internal` so the watcher sees a typed
+    ///   reason rather than a silent abort.
+    pub(crate) fn catchup_scan(
+        &self,
+        range_start: &[u8],
+        range_end: &[u8],
+        lo: i64,
+        hi: i64,
+        mvcc_snap: &Snapshot,
+        snap_be: &B::Snapshot,
+    ) -> Result<Vec<WatchEvent>, MvccError> {
+        if lo > hi {
+            return Ok(Vec::new());
+        }
+        if mvcc_snap.compacted >= lo {
+            return Err(MvccError::Compacted {
+                requested: lo,
+                floor: mvcc_snap.compacted,
+            });
+        }
+
+        // Snapshot the matched-keys list. Drop the read lock before
+        // any backend / index work so writers are not blocked across
+        // the per-key event walk.
+        let matched: Vec<Box<[u8]>> = {
+            let keys = self.keys_in_order.read();
+            if range_end.is_empty() {
+                if keys.contains_key(range_start) {
+                    vec![range_start.into()]
+                } else {
+                    Vec::new()
+                }
+            } else {
+                keys.range::<[u8], _>((Bound::Included(range_start), Bound::Excluded(range_end)))
+                    .map(|(k, ())| k.clone())
+                    .collect()
+            }
+        };
+
+        let mut events: Vec<WatchEvent> = Vec::new();
+        for key in &matched {
+            let key_events = self.index.events_in_range(key, lo, hi);
+            for (rev, kind) in key_events {
+                let watch_kind = match kind {
+                    KeyEventKind::Put => WatchEventKind::Put,
+                    KeyEventKind::Tombstone => WatchEventKind::Delete,
+                };
+                let value = match watch_kind {
+                    WatchEventKind::Put => {
+                        let enc = encode_key(rev, KeyKind::Put);
+                        snap_be
+                            .get(KEY_BUCKET_ID, enc.as_bytes())?
+                            .unwrap_or_default()
+                    }
+                    WatchEventKind::Delete => Bytes::new(),
+                };
+                let prev = self.compute_prev_kv_strict(key, rev, snap_be)?;
+                events.push(WatchEvent {
+                    kind: watch_kind,
+                    key: Bytes::copy_from_slice(key),
+                    value,
+                    prev,
+                    revision: rev,
+                });
+            }
+        }
+
+        // Cross-key merge: ascending by (main, sub). Within one key
+        // the per-key walk already produces this order; across keys
+        // we resort the combined list. `sort_by` is stable so equal
+        // revisions (impossible by construction — a single rev maps
+        // to one key) keep their input order.
+        events.sort_by(|a, b| a.revision.cmp(&b.revision));
+        Ok(events)
     }
 
     /// Single-key put.

--- a/crates/mango-mvcc/src/store/mod.rs
+++ b/crates/mango-mvcc/src/store/mod.rs
@@ -122,13 +122,11 @@ enum OpPlan {
         /// `key` immediately before this op runs (or `None` if
         /// the key was absent / tombstoned). Captured BEFORE any
         /// in-flight or persisted index mutation, so emit-side
-        /// consumers (the watch path in ROADMAP.md:863 follow-up)
-        /// see the right value even when an earlier op in the
-        /// same txn already overwrote `key`.
+        /// consumers see the right value even when an earlier op
+        /// in the same txn already overwrote `key`.
         ///
-        /// Phase 3 plan §4.6. In this commit, the field is
-        /// captured but not yet wired into the emitted
-        /// [`WatchEvent`] (commit 3 of the L863 series).
+        /// Phase 3 plan §4.6 (ROADMAP.md:863): emitted as-is by
+        /// [`emit_txn_events`].
         prev: Option<KeyValue>,
     },
     /// Zero or more sub-allocated tombstones for a single
@@ -154,17 +152,10 @@ struct Tombstone {
     rev: Revision,
     /// Pre-mutation prev-kv: the live version of `key`
     /// immediately before this tombstone runs. Captured BEFORE
-    /// any index mutation. In this commit the field is captured
-    /// but not yet wired into the emitted [`WatchEvent`] — that
-    /// lands in commit 3 of the L863 series, which lets bench
-    /// B2.5 isolate the capture-only overhead from the emit-side
-    /// change. Allow `dead_code` for one commit.
-    #[allow(
-        dead_code,
-        reason = "wired into emit in commit 3 of the L863 series; \
-                  keeping the capture isolated lets bench B2.5 measure \
-                  capture-only cost"
-    )]
+    /// any index mutation by [`MvccStore::delete_range`] /
+    /// [`MvccStore::build_txn_plan`] and emitted **as-is** by
+    /// [`emit_txn_events`] — no second snapshot or index lookup
+    /// runs on the writer hot path.
     prev: KeyValue,
 }
 
@@ -212,15 +203,20 @@ fn checked_add_total(total: usize) -> Result<usize, MvccError> {
 ///
 /// - [`OpPlan::Read`] — no event (read-only ops are not observable).
 /// - [`OpPlan::Put`] — one [`WatchEventKind::Put`] event with
-///   `revision = rev` from the plan entry.
+///   `revision = rev` from the plan entry. `prev` is the captured
+///   pre-mutation [`KeyValue`] (see [`OpPlan::Put.prev`]) — `None`
+///   if the key was absent or tombstoned at the moment the plan was
+///   built.
 /// - [`OpPlan::Delete`] — one [`WatchEventKind::Delete`] event per
 ///   [`Tombstone`] in `tombs`, in match order; `value` is empty.
+///   `prev` is the tombstone's captured pre-mutation [`KeyValue`]
+///   wrapped in `Some` — tombstones are only emitted for live keys,
+///   so the prev-kv is unconditionally present.
 ///
-/// `prev` is `None` on every event in this commit. The plan-level
-/// `prev` capture is wired into the emitted [`WatchEvent`] in
-/// commit 3 of the L863 series — keeping that change isolated
-/// lets bench B2.5 measure the capture-only overhead in isolation
-/// (Phase 3 plan §6 / §5.5).
+/// Phase 3 plan §4.6 / §6 (ROADMAP.md:863): the captured prev-kvs
+/// are emitted *as-is* — no second backend or index lookup runs on
+/// the writer's hot path. INVARIANT X is asserted at the call site
+/// in [`MvccStore::commit_txn_batch`].
 fn emit_txn_events(plan: &[OpPlan], buf: &mut Vec<WatchEvent>) {
     for entry in plan {
         match entry {
@@ -229,13 +225,13 @@ fn emit_txn_events(plan: &[OpPlan], buf: &mut Vec<WatchEvent>) {
                 key,
                 value,
                 rev,
-                prev: _captured_for_l863,
+                prev,
             } => {
                 buf.push(WatchEvent {
                     kind: WatchEventKind::Put,
                     key: Bytes::copy_from_slice(key),
                     value: Bytes::copy_from_slice(value),
-                    prev: None,
+                    prev: prev.clone(),
                     revision: *rev,
                 });
             }
@@ -245,7 +241,7 @@ fn emit_txn_events(plan: &[OpPlan], buf: &mut Vec<WatchEvent>) {
                         kind: WatchEventKind::Delete,
                         key: Bytes::copy_from_slice(&tomb.key),
                         value: Bytes::new(),
-                        prev: None,
+                        prev: Some(tomb.prev.clone()),
                         revision: tomb.rev,
                     });
                 }
@@ -589,6 +585,15 @@ impl<B: Backend> MvccStore<B> {
         let mut state = self.writer.lock().await;
         let rev = Revision::new(state.next_main, 0);
 
+        // Phase 3 plan §4.6 (ROADMAP.md:863): capture pre-mutation
+        // prev-kv BEFORE `index.put` runs. ONE backend snapshot is
+        // taken per writer call; cost amortises over the read-then-
+        // emit path. `None` if the key was absent or tombstoned.
+        let prev_kv = {
+            let snap_be = self.backend.snapshot()?;
+            self.compute_prev_kv_strict(key, rev, &snap_be)?
+        };
+
         let mut batch = self.backend.begin_batch()?;
         let encoded = encode_key(rev, KeyKind::Put);
         batch.put(KEY_BUCKET_ID, encoded.as_bytes(), value)?;
@@ -638,13 +643,17 @@ impl<B: Backend> MvccStore<B> {
 
         // Phase 3 plan §4.2 (ROADMAP.md:862): synthesize the watch
         // event before snapshot publication so the buffer is ready
-        // to dispatch immediately after `snapshot.store()`. `prev`
-        // is `None` here — populated in ROADMAP.md:863.
+        // to dispatch immediately after `snapshot.store()`.
+        //
+        // INVARIANT X (Phase 3 plan §4.6 / §6, ROADMAP.md:863):
+        // `prev_kv` was resolved above against a `Backend::snapshot`
+        // taken before any index mutation; no second backend or
+        // index lookup runs on the emit path.
         state.emit_buf.push(WatchEvent {
             kind: WatchEventKind::Put,
             key: Bytes::copy_from_slice(key),
             value: Bytes::copy_from_slice(value),
-            prev: None,
+            prev: prev_kv,
             revision: rev,
         });
 
@@ -1009,15 +1018,22 @@ impl<B: Backend> MvccStore<B> {
         // Phase 3 plan §4.2 (ROADMAP.md:862): one Delete event per
         // tombstoned key, in match order, sub-revision matching the
         // on-disk assignment. `value` is empty for Delete; `prev`
-        // is captured on each [`Tombstone`] (this commit) and
-        // wired into the emitted event in commit 3 of the L863
-        // series so bench B2.5 can isolate the capture-only cost.
+        // rides through verbatim from the capture above.
+        //
+        // INVARIANT X (Phase 3 plan §4.6 / §6, ROADMAP.md:863):
+        // every `prev` here was resolved against the single
+        // pre-mutation `Backend::snapshot` taken upstream, before
+        // `index.tombstone` mutated the index. The emit path
+        // performs no second backend or index lookup. Holds because
+        // the snapshot was dropped before the index mutation, and
+        // no path between capture and emit mutates the captured
+        // KeyValues.
         for tomb in &tombstones {
             state.emit_buf.push(WatchEvent {
                 kind: WatchEventKind::Delete,
                 key: Bytes::copy_from_slice(&tomb.key),
                 value: Bytes::new(),
-                prev: None,
+                prev: Some(tomb.prev.clone()),
                 revision: tomb.rev,
             });
         }
@@ -1136,6 +1152,20 @@ impl<B: Backend> MvccStore<B> {
         // contributes nothing). Sub-revisions match the on-disk
         // assignments inside `OpPlan::Put.rev` / the `tombs`
         // pairs, so commit-revision ordering is preserved.
+        //
+        // INVARIANT X (Phase 3 plan §4.6 / §6, ROADMAP.md:863):
+        // every WatchEvent appended here carries the prev-kv that
+        // was captured by `delete_range` / `build_txn_plan` BEFORE
+        // any index mutation ran. The emit path performs no second
+        // backend or index lookup — `prev` is read straight off the
+        // OpPlan / Tombstone. Holds because `apply_txn_in_mem` (the
+        // step that mutates the index and `keys_in_order`) ran
+        // above on this committed plan; the captured prevs were
+        // resolved before that, against the snapshot taken inside
+        // `build_txn_plan`'s single `Backend::snapshot` call (or
+        // the in-flight `TentativeState` for same-branch
+        // overwrites). No call site between capture and emit
+        // mutates the captured KeyValues.
         emit_txn_events(&plan, &mut state.emit_buf);
 
         let next = state.next_main.checked_add(1).ok_or(MvccError::Internal {

--- a/crates/mango-mvcc/src/watchable_store.rs
+++ b/crates/mango-mvcc/src/watchable_store.rs
@@ -282,12 +282,36 @@ impl Watcher {
 /// [`WatchableStore::watch`] is paranoia-belt-suspenders rather than a
 /// realistic guard — the `Internal` arm just makes the failure mode
 /// typed instead of a panic.
+///
+/// # Synced vs unsynced split (Phase 3 plan §4.4 / ROADMAP.md:863)
+///
+/// Watchers fall into one of two disjoint groups:
+///
+/// - `synced` — caught up to `current_revision()`; receive every new
+///   event from the inline writer dispatch path.
+/// - `unsynced` — registered with `start_rev <= current_revision()`
+///   at the time of [`WatchableStore::watch`]; the catch-up driver
+///   (commit 6 of the L863 series) replays history events
+///   `[start_rev, snap_rev]` from the MVCC store before promoting
+///   the watcher to `synced`.
+///
+/// Both groups share the same `Watcher` shape and id space; only
+/// their dispatch / deregister sites differ. A given `WatcherId`
+/// appears in **at most one** map at any time.
 struct Registry {
     next_id: WatcherId,
-    /// Synced watchers: those whose `start_rev > current_revision()` at
-    /// registration. Phase 3 ships only this group; the unsynced
-    /// (catch-up) group lands in ROADMAP.md:863.
+    /// Synced watchers — receive events from the inline writer hot path.
     synced: HashMap<WatcherId, Watcher>,
+    /// Unsynced watchers — under catch-up. Inline dispatch SKIPS them;
+    /// the catch-up driver (ROADMAP.md:863, commit 6 of the L863
+    /// series) is responsible for replaying historical events and
+    /// promoting them to `synced`.
+    ///
+    /// In this commit the map exists but is always empty —
+    /// [`WatchableStore::watch`] still rejects `start_rev <=
+    /// current_revision()` with [`UnsupportedFeature::UnsyncedWatcher`].
+    /// That gate is lifted in commit 6 when the driver lands.
+    unsynced: HashMap<WatcherId, Watcher>,
 }
 
 impl Registry {
@@ -295,7 +319,26 @@ impl Registry {
         Self {
             next_id: 0,
             synced: HashMap::new(),
+            unsynced: HashMap::new(),
         }
+    }
+
+    /// Total live watchers across both groups. Used by
+    /// [`WatchableStore::watcher_count`] so the externally-visible
+    /// count is invariant under group transitions.
+    fn total_len(&self) -> usize {
+        self.synced.len().saturating_add(self.unsynced.len())
+    }
+
+    /// Remove watcher `id` from whichever group holds it. Returns
+    /// the removed [`Watcher`], or `None` if neither group held it.
+    /// The id space is shared and disjoint across groups, so
+    /// at most one removal succeeds.
+    fn remove(&mut self, id: WatcherId) -> Option<Watcher> {
+        if let Some(w) = self.synced.remove(&id) {
+            return Some(w);
+        }
+        self.unsynced.remove(&id)
     }
 }
 
@@ -520,11 +563,13 @@ impl<B: Backend> WatchableStore<B> {
         &self.store
     }
 
-    /// Number of registered watchers. Public (not test-only) so a future
-    /// `mango-server` admin / observability surface can read it.
+    /// Number of registered watchers across both `synced` and
+    /// `unsynced` groups. Invariant under catch-up promotion.
+    /// Public (not test-only) so a future `mango-server` admin /
+    /// observability surface can read it.
     #[must_use]
     pub fn watcher_count(&self) -> usize {
-        self.registry.read().synced.len()
+        self.registry.read().total_len()
     }
 }
 
@@ -610,12 +655,13 @@ impl<B: Backend> Drop for WatchableStore<B> {
     ///   `Arc<WatchableStore>` exists.
     fn drop(&mut self) {
         let mut reg = self.registry.write();
-        let watchers = std::mem::take(&mut reg.synced);
+        let synced = std::mem::take(&mut reg.synced);
+        let unsynced = std::mem::take(&mut reg.unsynced);
         // Drop the lock before consuming permits — the per-watcher
         // permit consumption only touches that watcher's own
         // `disconnect_permit` slot, no cross-locking needed.
         drop(reg);
-        for (_id, w) in watchers {
+        for (_id, w) in synced.into_iter().chain(unsynced.into_iter()) {
             w.consume_disconnect_permit(DisconnectReason::StoreDropped);
             // `w` (and its `Sender`) is dropped at the end of this
             // iteration; the channel closes for the receiver.
@@ -659,7 +705,11 @@ pin_project! {
                 // refactors to a deregister channel if the bench trips
                 // the T4 threshold.
                 let mut w = reg.write();
-                w.synced.remove(this.id);
+                // Watcher may live in either group depending on
+                // catch-up state; the `Registry::remove` helper
+                // tries both. Id space is disjoint across groups
+                // (Phase 3 plan §4.4 / ROADMAP.md:863).
+                let _removed = w.remove(*this.id);
             }
             // mpsc::Receiver::Drop closes the receiver; any in-flight
             // writer try_send on this watcher's tx fails with

--- a/crates/mango-mvcc/src/watchable_store.rs
+++ b/crates/mango-mvcc/src/watchable_store.rs
@@ -101,8 +101,14 @@ pub struct WatchEvent {
     pub key: Bytes,
     /// User value. Empty for [`WatchEventKind::Delete`].
     pub value: Bytes,
-    /// Previous key/value at `revision - 1`, if available. Always
-    /// `None` in this PR; populated in ROADMAP.md:863.
+    /// Previous key/value at `revision - 1`, if available.
+    /// Captured by the writer hot path (single-key `put` /
+    /// `delete_range` and the txn first pass) BEFORE any index
+    /// mutation, against a single `Backend::snapshot` per writer
+    /// call. `None` for `Put` when the key was absent or tombstoned
+    /// at the moment the writer ran; always `Some` for `Delete`
+    /// since tombstones target live keys only. Phase 3 plan §4.6
+    /// (ROADMAP.md:863).
     pub prev: Option<KeyValue>,
     /// Revision at which the event was produced. The dispatch
     /// eligibility filter compares

--- a/crates/mango-mvcc/src/watchable_store.rs
+++ b/crates/mango-mvcc/src/watchable_store.rs
@@ -42,7 +42,7 @@
 
 use std::collections::HashMap;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Arc, Weak};
 use std::task::{Context, Poll};
 
@@ -53,8 +53,9 @@ use parking_lot::{Mutex as PlMutex, RwLock};
 use pin_project_lite::pin_project;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{self, OwnedPermit};
+use tokio::task::AbortHandle;
 
-use crate::error::{MvccError, UnsupportedFeature};
+use crate::error::MvccError;
 use crate::revision::Revision;
 use crate::store::{KeyValue, MvccStore};
 
@@ -164,13 +165,36 @@ pub trait WriteObserver: Send + Sync + 'static {
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 #[allow(
     clippy::exhaustive_enums,
-    reason = "shape committed in Phase 3; future reasons are item 866's call and would be additive — a non_exhaustive marker would forfeit the compile-time exhaustiveness checks the watcher-side match needs to detect a missed reason on update"
+    reason = "shape committed in Phase 3 + ROADMAP.md:863; reasons map 1:1 to terminal disconnect causes the watcher-side match must handle exhaustively. Adding a reason should be a deliberate visible API change."
 )]
 pub enum DisconnectReason {
     /// The per-watcher channel could not accept an event.
     SlowConsumer,
     /// The owning [`WatchableStore`] (and its dispatch path) was dropped.
     StoreDropped,
+    /// Catch-up scan tried to replay events from a revision the
+    /// store has already compacted away. `floor` is the
+    /// post-compaction floor — the watcher cannot recover this range.
+    /// Phase 3 plan §4.5 (ROADMAP.md:863).
+    Compacted {
+        /// Lowest revision still retained on disk.
+        floor: i64,
+    },
+    /// Catch-up driver hit `MAX_CATCHUP_ATTEMPTS` without converging
+    /// (sustained writer outpaced the scan rate). Terminal —
+    /// caller must re-watch with a fresh `start_rev`. Phase 3 plan §4.3.
+    CatchupConvergenceFailed {
+        /// Number of catch-up loop iterations attempted.
+        attempts: u32,
+    },
+    /// Internal error inside the catch-up driver (e.g. backend I/O
+    /// during the scan). Carries a static context string so the
+    /// reason is typed and observable without scraping a side
+    /// channel. Terminal.
+    Internal {
+        /// Short, static description of the failure site.
+        context: &'static str,
+    },
 }
 
 /// Watcher-side error variants. Surfaced as `Stream::Item =
@@ -211,6 +235,20 @@ const EVENT_CAPACITY: usize = 1024;
 
 /// Monotonic id for a registered watcher.
 type WatcherId = u64;
+
+/// Catch-up driver retry cap. After this many trips through
+/// [`catchup_drive_inner`]'s scan loop without converging, the
+/// watcher receives a terminal
+/// [`DisconnectReason::CatchupConvergenceFailed`].
+///
+/// Phase 3 plan §4.3 (ROADMAP.md:863). The cap exists because a
+/// watcher whose scan rate cannot keep up with the writer rate would
+/// otherwise spin forever, holding a registry slot and a backend
+/// snapshot per attempt. 256 attempts is etcd-flavored — sustained
+/// outpacing of a several-thousand-events scan budget per attempt
+/// implies the watcher is structurally unable to catch up; failing
+/// fast lets the caller re-watch with a fresh `start_rev`.
+const MAX_CATCHUP_ATTEMPTS: u32 = 256;
 
 /// Half-open key range `[start, end)`. `end.is_empty()` denotes a
 /// single-key watch (etcd parity — etcd uses `end_key.is_empty()` to
@@ -275,6 +313,117 @@ impl Watcher {
     }
 }
 
+/// Watcher under active catch-up. Held in [`Registry::unsynced`]
+/// while the [`catchup_drive`] task replays historical events from
+/// `start_rev` to the writer-locked snapshot revision; promoted to
+/// the [`Watcher`] form (and moved to `synced`) when caught up.
+///
+/// The id is the [`Registry::unsynced`] `HashMap` key; not duplicated
+/// here (unlike [`Watcher`], where `id` is needed because the
+/// dispatch loop iterates `values()` rather than `iter()`).
+///
+/// Phase 3 plan §4.1 / §4.3 (ROADMAP.md:863).
+struct CatchupWatcher {
+    range: WatcherRange,
+    /// Producer-side clone the catch-up driver uses for
+    /// `tx.send().await`. Constructed via `tx.clone()` at watcher
+    /// build time.
+    tx: mpsc::Sender<Result<WatchEvent, WatchError>>,
+    /// Reserved disconnect slot; same shape and idempotency
+    /// contract as [`Watcher::disconnect_permit`].
+    disconnect_permit: PlMutex<Option<OwnedPermit<Result<WatchEvent, WatchError>>>>,
+    /// Highest `rev.main()` already delivered on this watcher.
+    /// Initialised to `start_rev - 1`. Updated by the catch-up
+    /// driver after each scan iteration succeeds; read by
+    /// [`promote_to_synced`] under `registry.write()` to gate the
+    /// retry-vs-promote decision.
+    ///
+    /// Stored as `Arc<AtomicI64>` (NOT inside the registry RwLock):
+    /// the driver task owns writes; `promote_to_synced` reads it
+    /// via `load(Acquire)`. `AtomicI64` is the right primitive —
+    /// single writer, occasional reader, no need to serialize
+    /// against other watchers' updates.
+    last_delivered: Arc<AtomicI64>,
+    /// `AbortHandle` for the spawned driver task. Drop paths call
+    /// `.abort()` to ensure the driver does not outlive the
+    /// watcher's registration. `.abort()` is idempotent.
+    driver: AbortHandle,
+}
+
+impl CatchupWatcher {
+    /// Same idempotent permit-consume contract as
+    /// [`Watcher::consume_disconnect_permit`].
+    fn consume_disconnect_permit(&self, reason: DisconnectReason) {
+        if let Some(permit) = self.disconnect_permit.lock().take() {
+            let _sender = permit.send(Err(WatchError::Disconnected(reason)));
+        }
+    }
+}
+
+/// Outcome of [`Registry::remove`] — either the watcher was found
+/// in the synced or unsynced group, or it was already gone. The
+/// `Unsynced` arm carries the [`CatchupWatcher`] so the caller can
+/// abort its driver task; the `Synced` arm carries no payload
+/// because nothing group-specific is needed (the `Watcher` is
+/// dropped inside `Registry::remove` along with its `Sender`,
+/// which closes the channel to the consumer).
+enum RegistryRemoval {
+    Synced,
+    Unsynced(CatchupWatcher),
+    None,
+}
+
+/// Catch-up driver exit reason. The driver returns this from its
+/// inner loop (`catchup_drive_inner`); the outer `catchup_drive`
+/// fn uses the variant to decide whether to send a terminal
+/// disconnect via the reserved permit.
+///
+/// `Disconnect(_)` is the only variant that produces a terminal
+/// item on the watcher's stream — the others are silent exits
+/// (the registry entry is already gone or the consumer is gone).
+///
+/// Phase 3 plan §4.3 (ROADMAP.md:863).
+#[derive(Debug)]
+enum DriverExit {
+    /// `tx.send().await` returned `SendError` — the receiver
+    /// (`WatchStream`) was dropped. The `PinnedDrop` already removed
+    /// the registry entry; nothing more to do.
+    ReceiverGone,
+    /// `Weak::upgrade` of the [`WatchableStore`] failed. The store
+    /// dropped while we were running; its `Drop` impl already
+    /// drained both registries and emitted `StoreDropped` to every
+    /// watcher.
+    StoreGone,
+    /// The watcher's registry entry was removed (e.g. `PinnedDrop`
+    /// raced our scan, or the store-drop path drained it). Silent
+    /// exit; whoever removed the entry owns the terminal item.
+    WatcherGone,
+    /// Terminal disconnect — the outer `catchup_drive` consumes
+    /// the disconnect permit with this reason before returning.
+    Disconnect(DisconnectReason),
+}
+
+/// Outcome of `promote_to_synced`. `Done` and `WatcherGone` are
+/// terminal for the driver loop; `Retry` means the writer outpaced
+/// the catch-up scan in the time between releasing the snapshot-pair
+/// mutex and acquiring `registry.write()`, and the driver should
+/// run another scan iteration.
+enum PromoteResult {
+    Done,
+    Retry,
+    WatcherGone,
+}
+
+/// Routing decision made under `registry.write()` in
+/// [`WatchableStore::watch`]: either register as synced (resolved
+/// `start_rev` ready for the inline-dispatch eligibility filter) or
+/// register as unsynced (driver task to be spawned, scan loop to
+/// drive [`start_rev`, `current_revision()`]).
+enum WatchRoute {
+    Synced { resolved_start: i64 },
+    Unsynced { start_rev: i64 },
+}
+
 /// Watcher registry. Behind a [`parking_lot::RwLock`].
 ///
 /// `next_id` is a monotonic `u64`. At ~1B watch registrations/sec the
@@ -291,27 +440,18 @@ impl Watcher {
 ///   event from the inline writer dispatch path.
 /// - `unsynced` — registered with `start_rev <= current_revision()`
 ///   at the time of [`WatchableStore::watch`]; the catch-up driver
-///   (commit 6 of the L863 series) replays history events
+///   (`catchup_drive`) replays history events
 ///   `[start_rev, snap_rev]` from the MVCC store before promoting
-///   the watcher to `synced`.
+///   the watcher to `synced` via [`promote_to_synced`].
 ///
-/// Both groups share the same `Watcher` shape and id space; only
-/// their dispatch / deregister sites differ. A given `WatcherId`
-/// appears in **at most one** map at any time.
+/// A given `WatcherId` appears in **at most one** map at any time.
 struct Registry {
     next_id: WatcherId,
     /// Synced watchers — receive events from the inline writer hot path.
     synced: HashMap<WatcherId, Watcher>,
     /// Unsynced watchers — under catch-up. Inline dispatch SKIPS them;
-    /// the catch-up driver (ROADMAP.md:863, commit 6 of the L863
-    /// series) is responsible for replaying historical events and
-    /// promoting them to `synced`.
-    ///
-    /// In this commit the map exists but is always empty —
-    /// [`WatchableStore::watch`] still rejects `start_rev <=
-    /// current_revision()` with [`UnsupportedFeature::UnsyncedWatcher`].
-    /// That gate is lifted in commit 6 when the driver lands.
-    unsynced: HashMap<WatcherId, Watcher>,
+    /// `catchup_drive` is the sole producer.
+    unsynced: HashMap<WatcherId, CatchupWatcher>,
 }
 
 impl Registry {
@@ -331,14 +471,23 @@ impl Registry {
     }
 
     /// Remove watcher `id` from whichever group holds it. Returns
-    /// the removed [`Watcher`], or `None` if neither group held it.
-    /// The id space is shared and disjoint across groups, so
-    /// at most one removal succeeds.
-    fn remove(&mut self, id: WatcherId) -> Option<Watcher> {
-        if let Some(w) = self.synced.remove(&id) {
-            return Some(w);
+    /// a typed [`RegistryRemoval`] so the caller can dispatch
+    /// group-specific cleanup. The id space is shared and disjoint
+    /// across groups, so at most one removal succeeds.
+    ///
+    /// On `Synced` the removed [`Watcher`] (and its `Sender`) is
+    /// dropped inside this function — the channel closes for the
+    /// consumer immediately. On `Unsynced` the [`CatchupWatcher`] is
+    /// returned so the caller can abort its driver task before
+    /// dropping (and closing the channel).
+    fn remove(&mut self, id: WatcherId) -> RegistryRemoval {
+        if let Some(_w) = self.synced.remove(&id) {
+            return RegistryRemoval::Synced;
         }
-        self.unsynced.remove(&id)
+        if let Some(cw) = self.unsynced.remove(&id) {
+            return RegistryRemoval::Unsynced(cw);
+        }
+        RegistryRemoval::None
     }
 }
 
@@ -448,13 +597,21 @@ impl<B: Backend> WatchableStore<B> {
     ///
     /// - `start_rev == 0` → resolved under the registry write-lock to
     ///   `current_revision() + 1`. The watcher receives every event strictly
-    ///   after the rev observable at registration time. **No race.**
+    ///   after the rev observable at registration time. Registered as
+    ///   **synced**. **No race.**
     /// - `start_rev > 0` and `start_rev > current_revision()` → registered
-    ///   verbatim. `current_revision() + 1` (the explicit synced-from-now
-    ///   case) lands here unambiguously.
-    /// - `start_rev > 0` and `start_rev <= current_revision()` →
-    ///   [`MvccError::Unsupported`]`(`[`UnsupportedFeature::UnsyncedWatcher`]`)`.
-    ///   Item 863 lifts this.
+    ///   verbatim as **synced**. `current_revision() + 1` (the explicit
+    ///   synced-from-now case) lands here unambiguously.
+    /// - `start_rev > 0` and `start_rev > compacted_floor` and
+    ///   `start_rev <= current_revision()` → registered as **unsynced** and
+    ///   a per-watcher catch-up driver task is spawned (Phase 3 plan §4.3 /
+    ///   ROADMAP.md:863). The driver replays history events in
+    ///   `[start_rev, current_revision()]` against an atomic
+    ///   `(mvcc_snap, backend_snap)` pair, then promotes the watcher to
+    ///   synced.
+    /// - `start_rev > 0` and `start_rev <= compacted_floor` →
+    ///   [`MvccError::Compacted`] (the compacted floor is the inclusive
+    ///   boundary — etcd parity).
     /// - `start_rev < 0` → [`MvccError::FutureRevision`] (`< 0` is structurally
     ///   future-of-nothing; etcd rejects the same way).
     ///
@@ -471,8 +628,8 @@ impl<B: Backend> WatchableStore<B> {
     /// # Errors
     ///
     /// - [`MvccError::FutureRevision`] when `start_rev < 0`.
-    /// - [`MvccError::Unsupported`] when `start_rev` is at or below the
-    ///   current revision (catch-up not yet supported).
+    /// - [`MvccError::Compacted`] when `start_rev` is at or below the
+    ///   compaction floor.
     /// - [`MvccError::InvalidRange`] when `range_end` is non-empty and
     ///   strictly less than `range_start`.
     /// - [`MvccError::Internal`] for `current_revision` / watcher-id
@@ -496,22 +653,36 @@ impl<B: Backend> WatchableStore<B> {
 
         // Acquire registry write-lock. The dispatch path takes registry
         // READ-lock under the writer-tokio-mutex; both cannot run
-        // concurrently. Inside this lock:
-        //   - read current_revision exactly once
-        //   - decide synced-eligibility
-        //   - assign id
-        //   - insert watcher
+        // concurrently. Inside this lock we read the published Snapshot
+        // exactly once so `(rev, compacted)` are coherent — see Phase 3
+        // plan §4.4 race proof.
         let mut reg = self.registry.write();
-        let current = self.store.current_revision();
-        let resolved_start = if start_rev == 0 {
-            current.checked_add(1).ok_or(MvccError::Internal {
+        let snap = self.store.current_snapshot();
+        let current = snap.rev;
+        let compacted_floor = snap.compacted;
+
+        // Decide synced vs unsynced.
+        let route: WatchRoute = if start_rev == 0 {
+            let resolved = current.checked_add(1).ok_or(MvccError::Internal {
                 context: "current_revision overflow",
-            })?
+            })?;
+            WatchRoute::Synced {
+                resolved_start: resolved,
+            }
         } else if start_rev > current {
-            start_rev
+            WatchRoute::Synced {
+                resolved_start: start_rev,
+            }
+        } else if start_rev <= compacted_floor {
+            return Err(MvccError::Compacted {
+                requested: start_rev,
+                floor: compacted_floor,
+            });
         } else {
-            return Err(MvccError::Unsupported(UnsupportedFeature::UnsyncedWatcher));
+            // compacted_floor < start_rev <= current — unsynced.
+            WatchRoute::Unsynced { start_rev }
         };
+
         let id = reg.next_id;
         reg.next_id = reg.next_id.checked_add(1).ok_or(MvccError::Internal {
             context: "watcher id overflow",
@@ -533,21 +704,55 @@ impl<B: Backend> WatchableStore<B> {
                     context: "reserve disconnect permit",
                 })?;
 
-        reg.synced.insert(
-            id,
-            Watcher {
-                id,
-                start_rev: resolved_start,
-                range: WatcherRange {
-                    start: range_start,
-                    end: range_end,
-                },
-                tx,
-                disconnect_permit: PlMutex::new(Some(disconnect_permit)),
-                pending_disconnect: AtomicBool::new(false),
-            },
-        );
-        drop(reg);
+        let range = WatcherRange {
+            start: range_start,
+            end: range_end,
+        };
+
+        match route {
+            WatchRoute::Synced { resolved_start } => {
+                reg.synced.insert(
+                    id,
+                    Watcher {
+                        id,
+                        start_rev: resolved_start,
+                        range,
+                        tx,
+                        disconnect_permit: PlMutex::new(Some(disconnect_permit)),
+                        pending_disconnect: AtomicBool::new(false),
+                    },
+                );
+                drop(reg);
+            }
+            WatchRoute::Unsynced { start_rev } => {
+                // Spawn the driver task BEFORE inserting into the
+                // registry — `tokio::spawn` returns a JoinHandle whose
+                // AbortHandle is what we store on the CatchupWatcher.
+                // The driver will quickly take `registry.read()` for
+                // its first iteration; that's safe because we still
+                // hold `registry.write()` here, so the driver's read
+                // queues behind us.
+                //
+                // Initial last_delivered = start_rev - 1 so the first
+                // scan iteration covers [start_rev, snap_rev].
+                let last_delivered = Arc::new(AtomicI64::new(start_rev.saturating_sub(1)));
+                let weak_self = Arc::downgrade(self);
+                let driver_handle = tokio::spawn(catchup_drive(weak_self, id));
+                let driver_abort = driver_handle.abort_handle();
+
+                reg.unsynced.insert(
+                    id,
+                    CatchupWatcher {
+                        range,
+                        tx,
+                        disconnect_permit: PlMutex::new(Some(disconnect_permit)),
+                        last_delivered,
+                        driver: driver_abort,
+                    },
+                );
+                drop(reg);
+            }
+        }
 
         Ok(WatchStream {
             rx,
@@ -632,6 +837,278 @@ impl<B: Backend> WatchableStore<B> {
             }
         }
     }
+
+    // -------- Catch-up driver helpers (Phase 3 plan §4.3 / §4.4) --------
+    //
+    // These are intentionally narrow accessors that take `registry.read()`
+    // (or `registry.write()` for `promote_to_synced`) for the minimum
+    // duration needed and never hold the lock across `.await`. They are
+    // `pub(crate)`-equivalent to the `catchup_drive` free function below
+    // — they live on `impl WatchableStore` only because they need access
+    // to `self.registry` and `self.store`.
+
+    /// Read `last_delivered` for an unsynced watcher via the
+    /// `Arc<AtomicI64>` sidecar. Returns `None` if the watcher
+    /// has been removed from the registry (e.g. `PinnedDrop` ran).
+    fn read_last_delivered(&self, id: WatcherId) -> Option<i64> {
+        let reg = self.registry.read();
+        let cw = reg.unsynced.get(&id)?;
+        Some(cw.last_delivered.load(Ordering::Acquire))
+    }
+
+    /// Update `last_delivered` for an unsynced watcher. Silently
+    /// no-ops if the watcher is gone (the driver is racing a
+    /// drop; the abort will hit shortly).
+    fn write_last_delivered(&self, id: WatcherId, value: i64) {
+        let reg = self.registry.read();
+        if let Some(cw) = reg.unsynced.get(&id) {
+            cw.last_delivered.store(value, Ordering::Release);
+        }
+    }
+
+    /// Clone the unsynced watcher's range under the registry read
+    /// lock. Returns `None` if the watcher is no longer in the
+    /// unsynced group (gone or already promoted).
+    fn unsynced_range(&self, id: WatcherId) -> Option<WatcherRange> {
+        let reg = self.registry.read();
+        reg.unsynced.get(&id).map(|cw| cw.range.clone())
+    }
+
+    /// Clone the unsynced watcher's `Sender` for an `await`-bearing
+    /// `tx.send(...).await` — caller MUST NOT hold the registry
+    /// read lock across the await. Returns `None` if the watcher
+    /// is gone.
+    fn unsynced_tx_clone(
+        &self,
+        id: WatcherId,
+    ) -> Option<mpsc::Sender<Result<WatchEvent, WatchError>>> {
+        let reg = self.registry.read();
+        reg.unsynced.get(&id).map(|cw| cw.tx.clone())
+    }
+
+    /// Idempotent terminal-disconnect for an unsynced watcher.
+    /// Consumes the reserved disconnect permit (if not already
+    /// taken) and removes the registry entry. Caller is the
+    /// catch-up driver's outer wrapper on a `Disconnect(_)` exit.
+    fn consume_unsynced_permit(&self, id: WatcherId, reason: DisconnectReason) {
+        let cw = {
+            let mut reg = self.registry.write();
+            reg.unsynced.remove(&id)
+        };
+        if let Some(cw) = cw {
+            cw.consume_disconnect_permit(reason);
+            // `cw` (and its `Sender`) drops here — channel closes
+            // for the receiver after the terminal Err is consumed.
+        }
+    }
+
+    /// Race-free synced transition for an unsynced watcher.
+    ///
+    /// Phase 3 plan §4.4 (ROADMAP.md:863). Holds `registry.write()`
+    /// for the duration: under that lock, no inline dispatch can
+    /// run (dispatch takes `registry.read()`), and no other writer
+    /// can publish a new snapshot in a way the watcher would miss
+    /// — between `snapshot.store(R)` and `dispatch(...)` the
+    /// writer holds its own `tokio::sync::Mutex` with NO `.await`
+    /// point (Invariant W, see `MvccStore::dispatch_observer`).
+    /// Therefore reading `current_revision()` here observes a
+    /// snapshot whose dispatch (if any) has either fully completed
+    /// already (events already in the channel via the catch-up
+    /// scan, or in transit through the inline path — but the
+    /// inline path skips unsynced entries) or is queued behind us
+    /// on `registry.read()`.
+    fn promote_to_synced(&self, id: WatcherId) -> PromoteResult {
+        let mut reg = self.registry.write();
+        let snap_rev = self.store.current_revision();
+        let Some(cw_ref) = reg.unsynced.get(&id) else {
+            return PromoteResult::WatcherGone;
+        };
+        let last_delivered = cw_ref.last_delivered.load(Ordering::Acquire);
+
+        if last_delivered < snap_rev {
+            return PromoteResult::Retry;
+        }
+
+        // Move the watcher across groups under the same lock
+        // acquisition. We can't unwrap-with-message since clippy
+        // denies expect_used; the Some-check above guarantees the
+        // remove succeeds, but we still surface a typed fall-through
+        // if it somehow doesn't (would mean another path mutated
+        // the registry under our write lock — impossible).
+        let Some(cw) = reg.unsynced.remove(&id) else {
+            return PromoteResult::WatcherGone;
+        };
+        // Synced eligibility filter is `event.rev.main() >=
+        // start_rev`; setting `start_rev = last_delivered + 1`
+        // gives the watcher exactly the events it has not seen
+        // yet. last_delivered = snap_rev means start_rev =
+        // snap_rev + 1, which is the rev the next writer will
+        // allocate.
+        let new_start_rev = last_delivered.saturating_add(1);
+        reg.synced.insert(
+            id,
+            Watcher {
+                id,
+                start_rev: new_start_rev,
+                range: cw.range,
+                tx: cw.tx,
+                disconnect_permit: PlMutex::new(cw.disconnect_permit.lock().take()),
+                pending_disconnect: AtomicBool::new(false),
+            },
+        );
+        // The driver's AbortHandle (`cw.driver`) drops here. That's
+        // fine — the driver task is about to return Ok(()) once
+        // promote returns Done; dropping the handle without aborting
+        // is allowed (tokio: dropping a JoinHandle/AbortHandle just
+        // detaches the task).
+        PromoteResult::Done
+    }
+}
+
+/// Catch-up driver entrypoint. Spawned by [`WatchableStore::watch`]
+/// for each watcher routed onto the unsynced path. Runs the inner
+/// scan/promote loop until convergence, then publishes a terminal
+/// disconnect via the reserved permit on `Disconnect(_)` exits.
+///
+/// Phase 3 plan §4.3 (ROADMAP.md:863).
+async fn catchup_drive<B: Backend>(ws: Weak<WatchableStore<B>>, id: WatcherId) {
+    let outcome = catchup_drive_inner(&ws, id).await;
+    if let Err(DriverExit::Disconnect(reason)) = outcome {
+        if let Some(strong) = ws.upgrade() {
+            strong.consume_unsynced_permit(id, reason);
+        }
+        // If upgrade fails, the WatchableStore is already mid-Drop;
+        // its Drop impl is what's draining the registry and emitting
+        // StoreDropped. The reason we computed here is superseded —
+        // StoreDropped wins.
+    }
+}
+
+/// Catch-up scan/promote loop. See Phase 3 plan §4.3.
+async fn catchup_drive_inner<B: Backend>(
+    ws: &Weak<WatchableStore<B>>,
+    id: WatcherId,
+) -> Result<(), DriverExit> {
+    let mut attempts: u32 = 0;
+    loop {
+        let strong = ws.upgrade().ok_or(DriverExit::StoreGone)?;
+
+        // Atomic snapshot-pair under the writer mutex. The pair
+        // observes the same point in time w.r.t. concurrent
+        // compact/put/delete_range/txn — closes the v2-flagged
+        // mid-scan compaction race (Phase 3 plan §4.5).
+        let (mvcc_snap, snap_be) =
+            strong
+                .store
+                .snapshot_pair_under_writer()
+                .await
+                .map_err(|err| match err {
+                    MvccError::Backend(_) => DriverExit::Disconnect(DisconnectReason::Internal {
+                        context: "snapshot_pair backend error",
+                    }),
+                    _ => DriverExit::Disconnect(DisconnectReason::Internal {
+                        context: "snapshot_pair internal error",
+                    }),
+                })?;
+
+        let last_delivered = strong
+            .read_last_delivered(id)
+            .ok_or(DriverExit::WatcherGone)?;
+        let from_rev = last_delivered.saturating_add(1);
+
+        // Mid-scan compaction guard. The snapshot-pair just taken
+        // includes the published `compacted` floor; if it has moved
+        // past `from_rev` we cannot recover this watcher's range.
+        if mvcc_snap.compacted >= from_rev {
+            return Err(DriverExit::Disconnect(DisconnectReason::Compacted {
+                floor: mvcc_snap.compacted,
+            }));
+        }
+
+        let to_rev = mvcc_snap.rev;
+
+        if from_rev > to_rev {
+            // Caught up. Try the synced transition.
+            // NB: at registration time we required `start_rev <=
+            // current_revision()` (or `start_rev == 0`) to route
+            // unsynced; the resolved `start_rev - 1` initial
+            // last_delivered was therefore `< current_revision()`,
+            // so on the FIRST iteration `from_rev > to_rev` cannot
+            // occur unless the snapshot's `rev` decreased between
+            // registration and the snapshot-pair read (impossible
+            // — current_revision is monotonic). On subsequent
+            // iterations it's the convergence path.
+            match strong.promote_to_synced(id) {
+                PromoteResult::Done => return Ok(()),
+                PromoteResult::Retry => { /* fall through to attempt-cap check */ }
+                PromoteResult::WatcherGone => return Err(DriverExit::WatcherGone),
+            }
+        } else {
+            // Look up the watcher's range under a brief read-lock.
+            // We don't hold the lock across the scan or the awaits
+            // below.
+            let range = strong.unsynced_range(id).ok_or(DriverExit::WatcherGone)?;
+
+            let events = match strong.store.catchup_scan(
+                range.start.as_ref(),
+                range.end.as_ref(),
+                from_rev,
+                to_rev,
+                &mvcc_snap,
+                &snap_be,
+            ) {
+                Ok(events) => events,
+                Err(MvccError::Compacted { floor, .. }) => {
+                    return Err(DriverExit::Disconnect(DisconnectReason::Compacted {
+                        floor,
+                    }));
+                }
+                Err(_other) => {
+                    return Err(DriverExit::Disconnect(DisconnectReason::Internal {
+                        context: "catchup_scan backend or index error",
+                    }));
+                }
+            };
+
+            // Drop the snapshot pair before awaiting on tx.send().
+            // `B::Snapshot` may hold a backend transaction handle
+            // (redb `ReadTransaction`); keeping it alive across an
+            // unbounded await stalls compaction reclamation.
+            drop(snap_be);
+            drop(mvcc_snap);
+
+            for ev in events {
+                let tx = strong
+                    .unsynced_tx_clone(id)
+                    .ok_or(DriverExit::WatcherGone)?;
+                // Backpressure: a slow consumer parks the driver
+                // here. Unsupported as a DoS surface — Phase 6
+                // admission control owns the hard cap on unsynced
+                // count per store.
+                tx.send(Ok(ev))
+                    .await
+                    .map_err(|_| DriverExit::ReceiverGone)?;
+            }
+            // After the batch lands in the channel, advance
+            // last_delivered to `to_rev`. Order matters: only
+            // update *after* every event in [from_rev, to_rev]
+            // has been accepted, so a promote racing the next
+            // iteration sees a sound watermark (no in-flight
+            // events not yet on the channel).
+            strong.write_last_delivered(id, to_rev);
+        }
+
+        // Drop strong ref before next iteration so the WatchableStore
+        // can drop if all user Arcs are released.
+        drop(strong);
+
+        attempts = attempts.saturating_add(1);
+        if attempts >= MAX_CATCHUP_ATTEMPTS {
+            return Err(DriverExit::Disconnect(
+                DisconnectReason::CatchupConvergenceFailed { attempts },
+            ));
+        }
+    }
 }
 
 impl<B: Backend> Drop for WatchableStore<B> {
@@ -661,10 +1138,21 @@ impl<B: Backend> Drop for WatchableStore<B> {
         // permit consumption only touches that watcher's own
         // `disconnect_permit` slot, no cross-locking needed.
         drop(reg);
-        for (_id, w) in synced.into_iter().chain(unsynced.into_iter()) {
+        for (_id, w) in synced {
             w.consume_disconnect_permit(DisconnectReason::StoreDropped);
             // `w` (and its `Sender`) is dropped at the end of this
             // iteration; the channel closes for the receiver.
+        }
+        for (_id, cw) in unsynced {
+            // Abort the catch-up driver task FIRST. The driver may
+            // be parked on `tx.send().await` with a slow consumer;
+            // we don't want it observing the consumed permit and
+            // racing to send a duplicate terminal item. `.abort()`
+            // is idempotent and the spawned task picks it up at the
+            // next yield point (or immediately if not yet started).
+            cw.driver.abort();
+            cw.consume_disconnect_permit(DisconnectReason::StoreDropped);
+            // `cw` (and its `Sender`) drops at end of iteration.
         }
     }
 }
@@ -709,7 +1197,19 @@ pin_project! {
                 // catch-up state; the `Registry::remove` helper
                 // tries both. Id space is disjoint across groups
                 // (Phase 3 plan §4.4 / ROADMAP.md:863).
-                let _removed = w.remove(*this.id);
+                let removed = w.remove(*this.id);
+                // Drop the registry lock BEFORE aborting the driver
+                // task — `AbortHandle::abort` is sync and cheap, but
+                // we don't need the lock held for it.
+                drop(w);
+                if let RegistryRemoval::Unsynced(cw) = removed {
+                    // Stream consumer is gone; the catch-up driver
+                    // would otherwise either (a) park on `tx.send().await`
+                    // until the closed channel surfaces a SendError on
+                    // its next attempt, or (b) burn CPU on the scan
+                    // loop. Abort terminates it deterministically.
+                    cw.driver.abort();
+                }
             }
             // mpsc::Receiver::Drop closes the receiver; any in-flight
             // writer try_send on this watcher's tx fails with
@@ -766,7 +1266,7 @@ mod tests {
         DisconnectReason, WatchError, WatchEvent, WatchEventKind, WatchableStore, WatcherRange,
         WriteObserver,
     };
-    use crate::error::{MvccError, UnsupportedFeature};
+    use crate::error::MvccError;
     use crate::revision::Revision;
     use crate::store::MvccStore;
     use bytes::Bytes;
@@ -949,23 +1449,41 @@ mod tests {
         assert!(!r.covers(b"\xff"));
     }
 
-    /// Phase 3 plan §11 test #7. `start_rev > 0 && start_rev <= current_revision()`
-    /// returns Unsupported(UnsyncedWatcher).
+    /// L863 unit test #C0. `start_rev > 0 && start_rev <= current_revision()`
+    /// is now accepted: the watcher is registered into the unsynced
+    /// group and a catch-up driver is spawned. We assert the
+    /// registration outcome only — the dispatched events are
+    /// asserted in the integration tests in `tests/watch_catchup.rs`.
     #[tokio::test(flavor = "current_thread")]
-    async fn start_rev_below_current_returns_unsupported() {
+    async fn start_rev_below_current_registers_unsynced_watcher() {
         let store = open();
         store.put(b"k", b"v").await.expect("put");
         assert_eq!(store.current_revision(), 1);
         let ws = WatchableStore::new(store).expect("new");
+        let _stream = ws
+            .watch(Bytes::from_static(b"k"), Bytes::new(), 1)
+            .expect("unsynced watcher accepted");
+        // total_len is 1 across synced + unsynced; the watcher may
+        // already have been promoted to synced if the driver woke
+        // before the assertion, so don't probe individual groups.
+        assert_eq!(ws.watcher_count(), 1);
+    }
+
+    /// L863 unit test #C0b. `MvccError::Compacted` is still returned
+    /// when `start_rev <= compacted_floor` — the catch-up path is
+    /// only available against revisions still on disk.
+    #[tokio::test(flavor = "current_thread")]
+    async fn start_rev_below_compacted_floor_returns_compacted() {
+        let store = open();
+        // Create a few revisions then compact past them.
+        store.put(b"k", b"v1").await.expect("put");
+        store.put(b"k", b"v2").await.expect("put");
+        store.put(b"k", b"v3").await.expect("put");
+        store.compact(2).await.expect("compact");
+        let ws = WatchableStore::new(store).expect("new");
         let err = ws
             .watch(Bytes::from_static(b"k"), Bytes::new(), 1)
-            .expect_err("catch-up rejected");
-        assert!(
-            matches!(
-                err,
-                MvccError::Unsupported(UnsupportedFeature::UnsyncedWatcher)
-            ),
-            "got {err:?}"
-        );
+            .expect_err("rejected as compacted");
+        assert!(matches!(err, MvccError::Compacted { .. }), "got {err:?}");
     }
 }

--- a/crates/mango-mvcc/tests/watch_basic.rs
+++ b/crates/mango-mvcc/tests/watch_basic.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use mango_mvcc::store::range::RangeRequest;
 use mango_mvcc::store::MvccStore;
-use mango_mvcc::{DisconnectReason, MvccError, WatchError, WatchEventKind, WatchableStore};
+use mango_mvcc::{DisconnectReason, WatchError, WatchEventKind, WatchableStore};
 use mango_storage::{Backend, BackendConfig, InMemBackend};
 use tokio::time::timeout;
 
@@ -378,19 +378,28 @@ async fn range_query_after_event_delivery_is_consistent() {
     assert_eq!(res.kvs[0].mod_revision.main(), 1);
 }
 
-/// Phase 3 plan §11 test #7 redux at integration level — the unit
-/// test exercises the same path but goes through the public API
-/// surface here for completeness.
+/// L863 integration smoke. `start_rev <= current_revision()` is now
+/// accepted: the watcher is registered into the unsynced group and
+/// the catch-up driver delivers the prior write before any new
+/// events. The full catch-up matrix lives in `tests/watch_catchup.rs`;
+/// this test stays in `watch_basic` as a quick regression guard.
 #[tokio::test(flavor = "current_thread")]
-async fn start_rev_below_current_returns_unsupported_integration() {
+async fn start_rev_below_current_registers_unsynced_integration() {
     let store = open();
     store.put(b"a", b"v").await.expect("seed");
     let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
     // current_revision() is 1; start_rev = 1 satisfies `<= current`.
-    let err = ws
+    let mut s = ws
         .watch(Bytes::from_static(b"a"), Bytes::new(), 1)
-        .expect_err("rejected");
-    assert!(matches!(err, MvccError::Unsupported(_)), "got {err:?}");
+        .expect("unsynced watcher accepted");
+    let ev = timeout(Duration::from_millis(500), s.recv())
+        .await
+        .expect("catch-up event delivered before timeout")
+        .expect("channel open")
+        .expect("Ok event");
+    assert_eq!(ev.kind, WatchEventKind::Put);
+    assert_eq!(ev.key, Bytes::from_static(b"a"));
+    assert_eq!(ev.revision.main(), 1);
 }
 
 /// Phase 3 plan §11 test #12 (`slow_consumer_disconnect_emits_signal`).

--- a/crates/mango-mvcc/tests/watch_catchup.rs
+++ b/crates/mango-mvcc/tests/watch_catchup.rs
@@ -1,0 +1,568 @@
+//! Integration tests for the unsynced-watcher catch-up path
+//! (ROADMAP.md:863, plan v3 §11.C1-C14).
+//!
+//! These tests cross the writer hot path → registry dispatch → catch-up
+//! driver → channel boundary, the same surface as `watch_basic.rs`,
+//! but exercise watchers registered with `start_rev <=
+//! current_revision()` — the path that was previously rejected with
+//! `MvccError::Unsupported(UnsyncedWatcher)`.
+//!
+//! Under `--cfg madsim` this file is excluded — `tokio::spawn`
+//! cooperates with the simulator differently than production tokio,
+//! and the deterministic-watch story is Phase 5's concern.
+
+#![cfg(not(madsim))]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::missing_panics_doc,
+    clippy::missing_errors_doc,
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_wrap,
+    clippy::items_after_statements,
+    clippy::match_wild_err_arm,
+    clippy::explicit_iter_loop,
+    clippy::doc_markdown,
+    clippy::needless_continue,
+    clippy::uninlined_format_args,
+    missing_docs,
+    reason = "test code: panics are the assertion mechanism, arithmetic is bounded by loop counters, casts are bounded by literal SEED/N constants"
+)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use mango_mvcc::store::MvccStore;
+use mango_mvcc::{DisconnectReason, MvccError, WatchError, WatchEventKind, WatchableStore};
+use mango_storage::{Backend, BackendConfig, InMemBackend};
+use tokio::time::{sleep, timeout};
+
+const RECV_TIMEOUT: Duration = Duration::from_millis(2_000);
+
+fn open() -> Arc<MvccStore<InMemBackend>> {
+    let backend = InMemBackend::open(BackendConfig::new("/unused".into(), false))
+        .expect("inmem open never fails");
+    Arc::new(MvccStore::open(backend).expect("fresh open"))
+}
+
+fn full_range() -> (Bytes, Bytes) {
+    (Bytes::new(), Bytes::from_static(&[0xff_u8]))
+}
+
+/// C1. Pre-seed N puts; watch from `start_rev = 1` should deliver all
+/// N historical events (via catch-up) then a fresh write delivered
+/// inline through the synced path.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn catchup_delivers_all_historical_events_then_synced() {
+    let store = open();
+    for i in 0..5 {
+        let key = format!("k{i}");
+        store.put(key.as_bytes(), b"v").await.expect("seed put");
+    }
+    assert_eq!(store.current_revision(), 5);
+
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let (start, end) = full_range();
+    let mut s = ws.watch(start, end, 1).expect("unsynced watch accepted");
+
+    let mut received: Vec<i64> = Vec::with_capacity(6);
+    for _ in 0..5 {
+        let ev = timeout(RECV_TIMEOUT, s.recv())
+            .await
+            .expect("catch-up event")
+            .expect("channel open")
+            .expect("Ok event");
+        assert_eq!(ev.kind, WatchEventKind::Put);
+        received.push(ev.revision.main());
+    }
+    assert_eq!(received, vec![1, 2, 3, 4, 5]);
+
+    // Catch-up complete. A new put should land via the synced path.
+    let new_rev = store.put(b"k99", b"v").await.expect("post-catchup put");
+    assert_eq!(new_rev.main(), 6);
+
+    let ev = timeout(RECV_TIMEOUT, s.recv())
+        .await
+        .expect("synced event")
+        .expect("channel open")
+        .expect("Ok event");
+    assert_eq!(ev.revision.main(), 6);
+    assert_eq!(ev.kind, WatchEventKind::Put);
+    assert_eq!(ev.key, Bytes::from_static(b"k99"));
+}
+
+/// C2. `start_rev` strictly below the compacted floor: hard reject
+/// at `watch()` time with `MvccError::Compacted`.
+#[tokio::test(flavor = "current_thread")]
+async fn catchup_below_compacted_floor_returns_compacted() {
+    let store = open();
+    for _ in 0..5 {
+        store.put(b"k", b"v").await.expect("seed put");
+    }
+    store.compact(5).await.expect("compact to 5");
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let (start, end) = full_range();
+    let err = ws.watch(start, end, 3).expect_err("rejected");
+    assert!(
+        matches!(
+            err,
+            MvccError::Compacted {
+                requested: 3,
+                floor: 5
+            }
+        ),
+        "got {err:?}"
+    );
+}
+
+/// C3. `start_rev == compacted_floor`: also rejected — the floor is
+/// the inclusive lower bound, so the lowest LIVE revision is
+/// `floor + 1`. Etcd parity. (`MUST_VERIFY` flagged in plan §11.)
+#[tokio::test(flavor = "current_thread")]
+async fn catchup_at_compacted_floor_returns_compacted() {
+    let store = open();
+    for _ in 0..5 {
+        store.put(b"k", b"v").await.expect("seed put");
+    }
+    store.compact(5).await.expect("compact to 5");
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let (start, end) = full_range();
+    let err = ws.watch(start, end, 5).expect_err("rejected at floor");
+    assert!(matches!(err, MvccError::Compacted { .. }), "got {err:?}");
+}
+
+/// C4. Concurrent writes during catch-up: the watcher should receive
+/// every event in `[start_rev, final_rev]` exactly once, in
+/// monotonic order. Pre-seed K events, watch from rev 1, then drive
+/// K more events concurrently.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn catchup_with_concurrent_writes_no_miss_no_dup() {
+    let store = open();
+    const SEED: usize = 50;
+    const CONCURRENT: usize = 50;
+    for i in 0..SEED {
+        let v = format!("v{i}");
+        store.put(b"k", v.as_bytes()).await.expect("seed put");
+    }
+    assert_eq!(store.current_revision(), SEED as i64);
+
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let mut s = ws
+        .watch(Bytes::from_static(b"k"), Bytes::new(), 1)
+        .expect("unsynced watch");
+
+    // Spawn writer that drives more events while the catch-up scan runs.
+    let writer = {
+        let store = Arc::clone(&store);
+        tokio::spawn(async move {
+            for i in 0..CONCURRENT {
+                let v = format!("vc{i}");
+                store.put(b"k", v.as_bytes()).await.expect("concurrent put");
+                // Yield to let the catch-up scan interleave.
+                tokio::task::yield_now().await;
+            }
+        })
+    };
+
+    let total = SEED + CONCURRENT;
+    let mut received: Vec<i64> = Vec::with_capacity(total);
+    for _ in 0..total {
+        let ev = timeout(RECV_TIMEOUT, s.recv())
+            .await
+            .expect("event before timeout")
+            .expect("channel open")
+            .expect("Ok event");
+        received.push(ev.revision.main());
+    }
+    writer.await.expect("writer task");
+
+    // Monotonic & exact coverage [1, total].
+    let expected: Vec<i64> = (1..=total as i64).collect();
+    assert_eq!(received, expected, "no miss, no dup, monotonic");
+}
+
+/// C5. A slow consumer that doesn't drain the channel parks the
+/// catch-up driver via `tx.send().await` backpressure. The watcher
+/// remains registered (no disconnect, no convergence failure) for
+/// the full sleep window.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn catchup_with_slow_consumer_backpressures_driver() {
+    let store = open();
+    // Need more events than channel capacity (1024) to force the
+    // driver to actually block on send.
+    const N: usize = 1_500;
+    for i in 0..N {
+        let v = format!("v{i}");
+        store.put(b"k", v.as_bytes()).await.expect("seed put");
+    }
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let mut s = ws
+        .watch(Bytes::from_static(b"k"), Bytes::new(), 1)
+        .expect("unsynced watch");
+
+    // Read just 100 events, then sleep — the channel fills, driver parks.
+    for _ in 0..100 {
+        let _ev = timeout(RECV_TIMEOUT, s.recv())
+            .await
+            .expect("event")
+            .expect("channel open")
+            .expect("Ok event");
+    }
+    sleep(Duration::from_millis(200)).await;
+    // Watcher still registered (driver is parked, NOT disconnected).
+    assert_eq!(ws.watcher_count(), 1);
+
+    // Drain the rest — total must be exactly N.
+    let mut more = 100_usize;
+    while more < N {
+        let _ev = timeout(RECV_TIMEOUT, s.recv())
+            .await
+            .expect("event")
+            .expect("channel open")
+            .expect("Ok event");
+        more += 1;
+    }
+    assert_eq!(more, N);
+}
+
+/// C6. Dropping the `WatchStream` during catch-up aborts the driver
+/// task and removes the registry entry within a small bounded window.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropping_watch_stream_during_catchup_aborts_driver() {
+    let store = open();
+    const N: usize = 1_500;
+    for i in 0..N {
+        let v = format!("v{i}");
+        store.put(b"k", v.as_bytes()).await.expect("seed put");
+    }
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let mut s = ws
+        .watch(Bytes::from_static(b"k"), Bytes::new(), 1)
+        .expect("unsynced watch");
+    // Read a few events to confirm the driver is running.
+    for _ in 0..10 {
+        let _ev = timeout(RECV_TIMEOUT, s.recv())
+            .await
+            .expect("event")
+            .expect("channel open")
+            .expect("Ok event");
+    }
+    drop(s);
+    // PinnedDrop runs synchronously; it removes the registry entry
+    // and aborts the driver. Allow a brief async window for the
+    // driver task to actually be aborted by the runtime.
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(500);
+    while tokio::time::Instant::now() < deadline {
+        if ws.watcher_count() == 0 {
+            return;
+        }
+        sleep(Duration::from_millis(5)).await;
+    }
+    panic!(
+        "watcher_count never reached 0 after stream drop: {}",
+        ws.watcher_count()
+    );
+}
+
+/// C7. Dropping the `WatchableStore` while a catch-up driver is
+/// running emits a terminal `Err(Disconnected(StoreDropped))` to the
+/// surviving stream, then closes the channel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropping_watchable_store_during_catchup_emits_storedropped() {
+    let store = open();
+    const N: usize = 1_500;
+    for i in 0..N {
+        let v = format!("v{i}");
+        store.put(b"k", v.as_bytes()).await.expect("seed put");
+    }
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let mut s = ws
+        .watch(Bytes::from_static(b"k"), Bytes::new(), 1)
+        .expect("unsynced watch");
+    for _ in 0..10 {
+        let _ev = timeout(RECV_TIMEOUT, s.recv())
+            .await
+            .expect("event")
+            .expect("channel open")
+            .expect("Ok event");
+    }
+    drop(ws);
+
+    // Drain pending events; eventually receive the terminal disconnect.
+    let mut saw_terminal = false;
+    let drain_deadline = tokio::time::Instant::now() + Duration::from_millis(2_000);
+    while tokio::time::Instant::now() < drain_deadline {
+        match timeout(Duration::from_millis(500), s.recv()).await {
+            Ok(Some(Ok(_ev))) => continue,
+            Ok(Some(Err(WatchError::Disconnected(DisconnectReason::StoreDropped)))) => {
+                saw_terminal = true;
+                break;
+            }
+            Ok(Some(Err(other))) => {
+                panic!("unexpected disconnect reason: {other:?}");
+            }
+            Ok(None) => {
+                // Channel closed without terminal. The drop path
+                // emits StoreDropped *before* the Sender drops, so
+                // None first means a regression. Fail explicitly.
+                panic!("channel closed before terminal disconnect arrived");
+            }
+            Err(_) => panic!("timeout draining stream after store drop"),
+        }
+    }
+    assert!(saw_terminal, "did not observe StoreDropped terminal");
+}
+
+/// C8. Delete during catch-up: the catch-up scan should emit the
+/// historical Put for rev 1 and then the synced path should emit the
+/// Delete for rev 2 (with `prev_kv` populated).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_during_catchup_emits_delete_event_in_order() {
+    let store = open();
+    store.put(b"k", b"v").await.expect("seed put");
+    assert_eq!(store.current_revision(), 1);
+
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let mut s = ws
+        .watch(Bytes::from_static(b"k"), Bytes::new(), 1)
+        .expect("unsynced watch");
+
+    let _ = store.delete_range(b"k", b"").await.expect("delete_range");
+
+    let ev1 = timeout(RECV_TIMEOUT, s.recv())
+        .await
+        .expect("event 1")
+        .expect("channel open")
+        .expect("Ok");
+    assert_eq!(ev1.kind, WatchEventKind::Put);
+    assert_eq!(ev1.revision.main(), 1);
+    assert_eq!(ev1.value, Bytes::from_static(b"v"));
+
+    let ev2 = timeout(RECV_TIMEOUT, s.recv())
+        .await
+        .expect("event 2")
+        .expect("channel open")
+        .expect("Ok");
+    assert_eq!(ev2.kind, WatchEventKind::Delete);
+    assert_eq!(ev2.revision.main(), 2);
+    let prev = ev2.prev.as_ref().expect("prev_kv populated");
+    assert_eq!(prev.value, Bytes::from_static(b"v"));
+}
+
+/// C9. `watcher_count` reflects the union of synced + unsynced.
+/// 5 unsynced + 3 synced → 8; after promotion still 8.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unsynced_watcher_count_separate_from_synced() {
+    let store = open();
+    for _ in 0..3 {
+        store.put(b"k", b"v").await.expect("seed");
+    }
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+
+    let mut streams = Vec::new();
+    // 3 synced (start_rev = 0 → resolved to current+1).
+    for _ in 0..3 {
+        streams.push(
+            ws.watch(Bytes::from_static(b"k"), Bytes::new(), 0)
+                .expect("synced watch"),
+        );
+    }
+    // 5 unsynced (start_rev = 1 ≤ current = 3).
+    for _ in 0..5 {
+        streams.push(
+            ws.watch(Bytes::from_static(b"k"), Bytes::new(), 1)
+                .expect("unsynced watch"),
+        );
+    }
+    assert_eq!(ws.watcher_count(), 8);
+
+    // Drain catch-up events on the 5 unsynced streams; promotion
+    // should not change watcher_count.
+    for s in streams.iter_mut().skip(3) {
+        for _ in 0..3 {
+            let _ev = timeout(RECV_TIMEOUT, s.recv())
+                .await
+                .expect("event")
+                .expect("channel open")
+                .expect("Ok");
+        }
+    }
+    // Wait briefly for the promotion to land for all 5.
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(500);
+    while tokio::time::Instant::now() < deadline {
+        if ws.watcher_count() == 8 {
+            // count never changes — but verify a synced send still
+            // reaches all watchers, including those just promoted.
+            break;
+        }
+        sleep(Duration::from_millis(5)).await;
+    }
+    assert_eq!(ws.watcher_count(), 8);
+}
+
+/// C10. Independent unsynced watchers each receive a full copy of
+/// the historical event range.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_unsynced_watchers_independent() {
+    let store = open();
+    const N: usize = 50;
+    for i in 0..N {
+        let v = format!("v{i}");
+        store.put(b"k", v.as_bytes()).await.expect("seed");
+    }
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let mut streams = (0..5)
+        .map(|_| {
+            ws.watch(Bytes::from_static(b"k"), Bytes::new(), 1)
+                .expect("unsynced watch")
+        })
+        .collect::<Vec<_>>();
+
+    for s in streams.iter_mut() {
+        let mut received: Vec<i64> = Vec::with_capacity(N);
+        for _ in 0..N {
+            let ev = timeout(RECV_TIMEOUT, s.recv())
+                .await
+                .expect("event")
+                .expect("channel open")
+                .expect("Ok");
+            received.push(ev.revision.main());
+        }
+        let expected: Vec<i64> = (1..=N as i64).collect();
+        assert_eq!(received, expected);
+    }
+}
+
+/// C11. Catch-up event ordering across a multi-key DeleteRange. The
+/// scan must replay events in `(rev.main, rev.sub)` order across the
+/// per-key history streams.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn catchup_event_ordering_across_multi_key_delete_range() {
+    let store = open();
+    store.put(b"k1", b"v1").await.expect("p1");
+    store.put(b"k2", b"v2").await.expect("p2");
+    store.put(b"k3", b"v3").await.expect("p3");
+    let (deleted, del_rev) = store
+        .delete_range(b"k1", b"k4")
+        .await
+        .expect("delete_range");
+    assert_eq!(deleted, 3);
+    assert_eq!(del_rev.main(), 4);
+
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let mut s = ws
+        .watch(Bytes::new(), Bytes::from_static(&[0xff_u8]), 1)
+        .expect("unsynced watch");
+
+    let mut events = Vec::new();
+    for _ in 0..6 {
+        let ev = timeout(RECV_TIMEOUT, s.recv())
+            .await
+            .expect("event")
+            .expect("channel open")
+            .expect("Ok");
+        events.push(ev);
+    }
+
+    // First three are puts at revs (1,0), (2,0), (3,0).
+    assert_eq!(events[0].kind, WatchEventKind::Put);
+    assert_eq!(events[0].revision.main(), 1);
+    assert_eq!(events[0].key, Bytes::from_static(b"k1"));
+    assert_eq!(events[1].revision.main(), 2);
+    assert_eq!(events[1].key, Bytes::from_static(b"k2"));
+    assert_eq!(events[2].revision.main(), 3);
+    assert_eq!(events[2].key, Bytes::from_static(b"k3"));
+
+    // Last three are deletes at rev 4 with subs 0,1,2 (one per
+    // matched key, key-order).
+    assert_eq!(events[3].kind, WatchEventKind::Delete);
+    assert_eq!(events[3].revision.main(), 4);
+    assert_eq!(events[4].revision.main(), 4);
+    assert_eq!(events[5].revision.main(), 4);
+    let mut subs: Vec<i64> = events[3..6].iter().map(|e| e.revision.sub()).collect();
+    subs.sort_unstable();
+    assert_eq!(subs, vec![0, 1, 2]);
+
+    // Each delete carries prev_kv with the value seeded above.
+    for ev in &events[3..6] {
+        assert!(ev.prev.is_some(), "delete prev_kv populated: {ev:?}");
+    }
+}
+
+/// C12. Compaction concurrent with catch-up: the watcher must end up
+/// in one of two valid terminal states — either it received the full
+/// pre-compaction event range and converged to synced, or the
+/// catch-up scan observed `compacted >= from_rev` and emitted a
+/// terminal `Disconnected(Compacted)`. The atomic snapshot-pair
+/// (§4.5) rules out a third outcome (partial events + silent close).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn catchup_compaction_during_scan_either_completes_or_compacts() {
+    let store = open();
+    const N: usize = 200;
+    for i in 0..N {
+        let v = format!("v{i}");
+        store.put(b"k", v.as_bytes()).await.expect("seed");
+    }
+    let ws = WatchableStore::new(Arc::clone(&store)).expect("new");
+    let mut s = ws
+        .watch(Bytes::from_static(b"k"), Bytes::new(), 50)
+        .expect("unsynced watch");
+
+    // Concurrent compaction. The two outcomes are both valid:
+    //  1. Catch-up wins → events 50..=N delivered, no terminal.
+    //  2. Compaction wins → at most some events, then terminal
+    //     `Disconnected(Compacted { floor: 100 })`.
+    let store_h = Arc::clone(&store);
+    let compactor = tokio::spawn(async move {
+        // Brief delay so the catch-up driver actually starts before
+        // we compact.
+        sleep(Duration::from_millis(5)).await;
+        store_h.compact(100).await.expect("compact");
+    });
+
+    let mut event_count = 0_usize;
+    let mut last_rev: i64 = 49;
+    let mut terminal: Option<DisconnectReason> = None;
+    let drain_deadline = tokio::time::Instant::now() + Duration::from_millis(3_000);
+    loop {
+        if tokio::time::Instant::now() >= drain_deadline {
+            break;
+        }
+        match timeout(Duration::from_millis(500), s.recv()).await {
+            Ok(Some(Ok(ev))) => {
+                event_count += 1;
+                assert!(ev.revision.main() > last_rev, "monotonic: {:?}", ev);
+                last_rev = ev.revision.main();
+            }
+            Ok(Some(Err(WatchError::Disconnected(reason)))) => {
+                terminal = Some(reason);
+                break;
+            }
+            Ok(Some(Err(other))) => panic!("unexpected error: {other:?}"),
+            Ok(None) => break,
+            Err(_) => {
+                // Timeout with no events: assume catch-up converged
+                // and the watcher is now synced (no further events
+                // expected, no terminal).
+                break;
+            }
+        }
+    }
+    compactor.await.expect("compactor task");
+
+    match terminal {
+        // Outcome 1: terminal compacted disconnect.
+        Some(DisconnectReason::Compacted { floor }) => {
+            assert_eq!(floor, 100, "floor matches compaction target");
+        }
+        // Outcome 2: full delivery, no terminal.
+        None => {
+            assert_eq!(event_count, N - 49, "delivered events 50..=N");
+            assert_eq!(last_rev, N as i64);
+        }
+        Some(other) => panic!("unexpected terminal disconnect: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Lifts the `MvccError::Unsupported(UnsyncedWatcher)` rejection in `WatchableStore::watch(...)` so a watcher can register with `start_rev <= current_revision()` and receive the historical event range before catching up to the synced dispatch path. Closes ROADMAP.md:863.

- **Registry split**: `synced` and `unsynced` `HashMap`s. The synced dispatch path is unchanged; unsynced watchers run a per-watcher catch-up driver.
- **Catch-up driver**: a Tokio task per unsynced watcher acquires `MvccStore::snapshot_pair_under_writer` (atomic mvcc + backend snapshot), walks per-key history via `catchup_scan`, sends events via `tx.send().await` (real backpressure), then either promotes (`promote_to_synced`) or retries. Bounded by `MAX_CATCHUP_ATTEMPTS = 256`.
- **Race-free promotion**: `promote_to_synced` runs under `registry.write()` and relies on Invariant W (writer publishes `snapshot.store(R)` and dispatches events under the writer-mutex with no `.await` between them) — closes the catch-up race spelled out in plan §4.4.
- **Atomic snapshot pair**: `MvccStore::snapshot_pair_under_writer` takes the writer-mutex once and returns `(Snapshot, B::Snapshot)`. The mid-scan compaction race from plan v2 (where `current_revision` and `backend.snapshot()` could observe different points) is no longer reachable.
- **`prev_kv` on the writer hot path**: every `WatchEvent` (`Put` / `Delete` / `Txn`) now carries `prev` captured pre-mutation under the writer-lock — required for catch-up parity (etcd's `mvccpb.WatchResponse.prev_kv`) and verified by the new test C8.

### Removed (API break)

`MvccError::Unsupported` and `UnsupportedFeature::UnsyncedWatcher` are deleted. The variant only existed to reject this path. `MvccError` is `#[non_exhaustive]` so external `_` arms keep compiling. `CHANGELOG.md` updated.

### Commit-by-commit

| #   | Subject                                                                                     |
| --- | ------------------------------------------------------------------------------------------- |
| 1   | `feat(mvcc): KeyHistory::events_in_range, ShardedKeyIndex::events_in_range + get_strict_lt` |
| 2   | `refactor(mvcc): capture prev_kv state before index mutation in delete_range and txn`       |
| 3   | `feat(mvcc): emit prev_kv on every WatchEvent (single-op put/delete + txn)`                 |
| 4   | `feat(mvcc): add MvccStore::snapshot_pair_under_writer (atomic snapshot pair for catch-up)` |
| 5   | `refactor(mvcc): split Registry into synced + unsynced HashMaps`                            |
| 6   | `feat(mvcc): catch-up driver + synced transition for unsynced watchers`                     |
| 7   | `test(mvcc): catch-up integration + race tests for unsynced watchers`                       |

### Deferred (follow-up issues will track)

- **C13** `catchup_convergence_failure_after_max_attempts_disconnects` — needs `MAX_CATCHUP_ATTEMPTS_TEST_OVERRIDE` env hook.
- **C14** `catchup_race_proptest` — needs proptest infra for this crate.
- **Bench harness** — no criterion in the workspace yet; bench gating is plan §1 item 8 (DEFER if criterion not wired).

## Test plan

- [x] `cargo nextest run -p mango-mvcc --no-fail-fast` — 240 tests pass (228 base + 12 new in `tests/watch_catchup.rs`).
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Race tests C4 / C12 exercise the snapshot-pair guarantee under concurrent writers and concurrent compaction; the watcher always reaches one of two valid terminal states (full delivery → synced, or `Disconnected(Compacted)`), never a partial-events silent close.
- [x] Drop tests C6 / C7 verify the driver `AbortHandle` runs through `WatchStream::PinnedDrop` and `WatchableStore::Drop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Watch operations now support historical playback when starting from past revisions, automatically delivering missed events before continuing with live updates.

* **Improvements**
  * Watch events now populate previous key/value data for all operation types, enabling better event context tracking.
  * Enhanced handling of compacted revisions with explicit error messaging.

* **Removals**
  * Removed `UnsupportedFeature` and related unsupported error variant from public API—the previously unsupported catch-up watch path is now fully implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->